### PR TITLE
Missing header

### DIFF
--- a/configDeps.bat
+++ b/configDeps.bat
@@ -160,7 +160,7 @@ pushd %PROTOBUF_HOME%\java
 copy /y %PROTOBUF_HOME%\protoc.exe ..\src
 call mvn package
 popd
-copy /y %PROTOBUF_HOME%\java\target\protobuf-java-*.jar %GRAVITY_DEPS%\protobuf-java.jar
+copy /y /b %PROTOBUF_HOME%\java\target\protobuf-java-*.jar %GRAVITY_DEPS%\protobuf-java.jar
 
 echo ===== Copy to Debug configuration =====
 echo.

--- a/configDeps.bat
+++ b/configDeps.bat
@@ -160,7 +160,7 @@ pushd %PROTOBUF_HOME%\java
 copy /y %PROTOBUF_HOME%\protoc.exe ..\src
 call mvn package
 popd
-copy /y %PROTOBUF_HOME%\java\target\protobuf-java-2.5.0.jar %GRAVITY_DEPS%\protobuf-java.jar
+copy /y %PROTOBUF_HOME%\java\target\protobuf-java-*.jar %GRAVITY_DEPS%\protobuf-java.jar
 
 echo ===== Copy to Debug configuration =====
 echo.

--- a/src/components/cpp/ServiceDirectory/ServiceDirectoryUDPReceiver.cpp
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectoryUDPReceiver.cpp
@@ -26,6 +26,7 @@
 #include "ServiceDirectoryUDPReceiver.h"
 #include "GravityLogger.h"
 #include "CommUtil.h"
+#include <cstdlib>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Fix a missing header and update configDeps.bat to allow for later versions of the protobuf library.