### PR TITLE
fix for unsynced clocks on clients

### DIFF
--- a/src/components/cpp/Playback/FileReplay.cpp
+++ b/src/components/cpp/Playback/FileReplay.cpp
@@ -82,7 +82,11 @@ void FileReplay::processArchive()
         }
 
         // Wait the appropriate amount of time and then publish this data product
-        uint64_t timestamp = gdp->getGravityTimestamp();
+        uint64_t timestamp = gdp->getReceivedTimestamp();
+        if (timestamp == 0)
+        {
+            timestamp = gdp->getGravityTimestamp();
+        }
         if (firstPublishTime == 0)
         {
             // This is the first one


### PR DESCRIPTION
Running 2 VMs with clocks off by over a minute, archived data is now replayed based on receive time not "data" time.