### PR TITLE
Issue 15

### DIFF
--- a/src/api/python/src/swig/gravity.i
+++ b/src/api/python/src/swig/gravity.i
@@ -17,6 +17,7 @@
  */
 
 %include "std_string.i" // for std::string typemaps
+%include "stdint.i" // for std::string typemaps
 
 %module(directors="1", naturalvar="1") gravity
 

--- a/test/examples/11-PythonPubSub/Gravity.ini
+++ b/test/examples/11-PythonPubSub/Gravity.ini
@@ -1,0 +1,6 @@
+[general]
+ServiceDirectoryURL="tcp://localhost:5555"
+NoConfigServer=true
+LocalLogLevel=DEBUG
+ConsoleLogLevel=DEBUG
+

--- a/test/examples/12-PythonBasicService/Gravity.ini
+++ b/test/examples/12-PythonBasicService/Gravity.ini
@@ -1,0 +1,6 @@
+[general]
+ServiceDirectoryURL="tcp://localhost:5555"
+NoConfigServer=true
+LocalLogLevel=DEBUG
+ConsoleLogLevel=DEBUG
+


### PR DESCRIPTION
The latest version of swig changed that way they handle special int-related types (e.g. int64_t).  The default behavior is to create a pointer to wrap the object, which is never deleted.  Including the stdint.i file fixes this. This works for older versions of swig as well.