### PR TITLE
Add check for libsodium for linux examples.

### DIFF
--- a/configure
+++ b/configure
@@ -4317,6 +4317,45 @@ _ACEOF
 
 fi
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lsodium" >&5
+$as_echo_n "checking for main in -lsodium... " >&6; }
+if ${ac_cv_lib_sodium_main+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lsodium  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_sodium_main=yes
+else
+  ac_cv_lib_sodium_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_sodium_main" >&5
+$as_echo "$ac_cv_lib_sodium_main" >&6; }
+if test "x$ac_cv_lib_sodium_main" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBSODIUM 1
+_ACEOF
+
+  LIBS="-lsodium $LIBS"
+
+fi
+
 
 # Checks for header files.
 

--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,7 @@ AC_CHECK_LIB([pthread], [main])
 AC_CHECK_LIB([rt], [main])
 AC_CHECK_LIB([wsock32], [main])
 AC_CHECK_LIB([zmq], [main])
+AC_CHECK_LIB([sodium], [main])
 
 # Checks for header files.
 AC_FUNC_ALLOCA

--- a/test/examples/1-BasicDataProduct/Makefile.in
+++ b/test/examples/1-BasicDataProduct/Makefile.in
@@ -63,7 +63,11 @@ ifneq (,$(findstring MINGW32_NT,$(SYSTEM)))
 	OS_EXE_EXT=.exe
 windows: all;
 else ifneq (,$(findstring Linux,$(SYSTEM)))
+ifneq (,$(findstring lsodium,$(LIBS)))
+	OS_SPECIFIC_LIBS = -lzmq -lsodium -Wl,-Bdynamic -lrt -lpthread
+else
 	OS_SPECIFIC_LIBS = -lzmq -Wl,-Bdynamic -lrt -lpthread
+endif
 	OS_EXE_EXT=
 linux: all;
 else

--- a/test/examples/10-Archiving/Makefile.in
+++ b/test/examples/10-Archiving/Makefile.in
@@ -67,7 +67,11 @@ ifneq (,$(findstring MINGW32_NT,$(SYSTEM)))
 	OS_EXE_EXT=.exe
 windows: all;
 else ifneq (,$(findstring Linux,$(SYSTEM)))
+ifneq (,$(findstring lsodium,$(LIBS)))
+	OS_SPECIFIC_LIBS = -lzmq -lsodium -Wl,-Bdynamic -lrt -lpthread
+else
 	OS_SPECIFIC_LIBS = -lzmq -Wl,-Bdynamic -lrt -lpthread
+endif
 	OS_EXE_EXT=
 linux: all;
 else

--- a/test/examples/13-Relay/Makefile.in
+++ b/test/examples/13-Relay/Makefile.in
@@ -67,7 +67,11 @@ ifneq (,$(findstring MINGW32_NT,$(SYSTEM)))
 	OS_EXE_EXT=.exe
 windows: all;
 else ifneq (,$(findstring Linux,$(SYSTEM)))
+ifneq (,$(findstring lsodium,$(LIBS)))
+	OS_SPECIFIC_LIBS = -lzmq -lsodium -Wl,-Bdynamic -lrt -lpthread
+else
 	OS_SPECIFIC_LIBS = -lzmq -Wl,-Bdynamic -lrt -lpthread
+endif
 	OS_EXE_EXT=
 linux: all;
 else

--- a/test/examples/2-ProtobufDataProduct/Makefile.in
+++ b/test/examples/2-ProtobufDataProduct/Makefile.in
@@ -67,7 +67,11 @@ ifneq (,$(findstring MINGW32_NT,$(SYSTEM)))
 	OS_EXE_EXT=.exe
 windows: all;
 else ifneq (,$(findstring Linux,$(SYSTEM)))
+ifneq (,$(findstring lsodium,$(LIBS)))
+	OS_SPECIFIC_LIBS = -lzmq -lsodium -Wl,-Bdynamic -lrt -lpthread
+else
 	OS_SPECIFIC_LIBS = -lzmq -Wl,-Bdynamic -lrt -lpthread
+endif
 	OS_EXE_EXT=
 linux: all;
 else

--- a/test/examples/3-MultipleDataProduct/Makefile.in
+++ b/test/examples/3-MultipleDataProduct/Makefile.in
@@ -66,7 +66,11 @@ ifneq (,$(findstring MINGW32_NT,$(SYSTEM)))
 	OS_EXE_EXT=.exe
 windows: all;
 else ifneq (,$(findstring Linux,$(SYSTEM)))
+ifneq (,$(findstring lsodium,$(LIBS)))
+	OS_SPECIFIC_LIBS = -lzmq -lsodium -Wl,-Bdynamic -lrt -lpthread
+else
 	OS_SPECIFIC_LIBS = -lzmq -Wl,-Bdynamic -lrt -lpthread
+endif
 	OS_EXE_EXT=
 linux: all;
 else

--- a/test/examples/4-BasicService/Makefile.in
+++ b/test/examples/4-BasicService/Makefile.in
@@ -65,7 +65,11 @@ ifneq (,$(findstring MINGW32_NT,$(SYSTEM)))
 	OS_EXE_EXT=.exe
 windows: all;
 else ifneq (,$(findstring Linux,$(SYSTEM)))
+ifneq (,$(findstring lsodium,$(LIBS)))
+	OS_SPECIFIC_LIBS = -lzmq -lsodium -Wl,-Bdynamic -lrt -lpthread
+else
 	OS_SPECIFIC_LIBS = -lzmq -Wl,-Bdynamic -lrt -lpthread
+endif
 	OS_EXE_EXT=
 linux: all;
 else

--- a/test/examples/5-MiscFunctionality/Makefile.in
+++ b/test/examples/5-MiscFunctionality/Makefile.in
@@ -60,7 +60,11 @@ ifneq (,$(findstring MINGW32_NT,$(SYSTEM)))
 	BUILD_VARIANT_DIRECTIVE=-DWIN32
 windows: all;
 else ifneq (,$(findstring Linux,$(SYSTEM)))
+ifneq (,$(findstring lsodium,$(LIBS)))
+	OS_SPECIFIC_LIBS = -lzmq -lsodium -Wl,-Bdynamic -lrt -lpthread
+else
 	OS_SPECIFIC_LIBS = -lzmq -Wl,-Bdynamic -lrt -lpthread
+endif
 	OS_EXE_EXT=
 linux: all;
 else

--- a/test/examples/8-ConfigFile/Makefile.in
+++ b/test/examples/8-ConfigFile/Makefile.in
@@ -61,7 +61,11 @@ ifneq (,$(findstring MINGW32_NT,$(SYSTEM)))
 	OS_EXE_EXT=.exe
 windows: all;
 else ifneq (,$(findstring Linux,$(SYSTEM)))
+ifneq (,$(findstring lsodium,$(LIBS)))
+	OS_SPECIFIC_LIBS = -lzmq -lsodium -Wl,-Bdynamic -lrt -lpthread
+else
 	OS_SPECIFIC_LIBS = -lzmq -Wl,-Bdynamic -lrt -lpthread
+endif
 	OS_EXE_EXT=
 linux: all;
 else

--- a/test/examples/9-Domains/Makefile.in
+++ b/test/examples/9-Domains/Makefile.in
@@ -67,7 +67,11 @@ ifneq (,$(findstring MINGW32_NT,$(SYSTEM)))
 	OS_EXE_EXT=.exe
 windows: all;
 else ifneq (,$(findstring Linux,$(SYSTEM)))
+ifneq (,$(findstring lsodium,$(LIBS)))
+	OS_SPECIFIC_LIBS = -lzmq -lsodium -Wl,-Bdynamic -lrt -lpthread
+else
 	OS_SPECIFIC_LIBS = -lzmq -Wl,-Bdynamic -lrt -lpthread
+endif
 	OS_EXE_EXT=
 linux: all;
 else


### PR DESCRIPTION
If libsodium is present, links test examples
against it so that they compile on Ubuntu 16.04
using distributed libraries.

Closes aphysci/gravity#20