### PR TITLE
Adding ServiceDirectoryMapPB to Python bindings.

### DIFF
--- a/src/api/python/Makefile.in
+++ b/src/api/python/Makefile.in
@@ -47,7 +47,7 @@ PYTHONSRC_DIR=src/python/gravity
 #Protobuf sources (.proto)
 PROTO_DIR=../protobufs
 
-PROTO_SRC=$(PROTO_DIR)/GravityDataProductPB.proto $(PROTO_DIR)/GravityMetricsDataPB.proto $(PROTO_DIR)/FileArchiverControlRequestPB.proto $(PROTO_DIR)/FileArchiverControlResponsePB.proto
+PROTO_SRC=$(PROTO_DIR)/GravityDataProductPB.proto $(PROTO_DIR)/GravityMetricsDataPB.proto $(PROTO_DIR)/FileArchiverControlRequestPB.proto $(PROTO_DIR)/FileArchiverControlResponsePB.proto $(PROTO_DIR)/ServiceDirectoryMapPB.proto
 PROTO_PYTHON=$(patsubst $(PROTO_DIR)/%PB.proto,$(PYTHONSRC_DIR)/%Container.py,$(PROTO_SRC))
 
 


### PR DESCRIPTION
Please add this .proto to the Gravity python bindings - it provides a useful way to monitor what publications exist.

Is there a reason that all the core protobufs aren't built for the python bindings?  If not, probably worth just adding the whole lot.