### PR TITLE
Make TR1 calls explicit to not confuse compiler.

### DIFF
--- a/src/api/cpp/GravityHeartbeat.cpp
+++ b/src/api/cpp/GravityHeartbeat.cpp
@@ -36,7 +36,6 @@ namespace gravity
 {
 
 using namespace std;
-using namespace std::tr1;
 
 std::list<ExpectedMessageQueueElement> Heartbeat::queueElements; //This is so we can reuse these guys.
 std::priority_queue<ExpectedMessageQueueElement*, vector<ExpectedMessageQueueElement*>, EMQComparator> Heartbeat::messageTimes;
@@ -46,7 +45,7 @@ Semaphore Heartbeat::lock;
 std::set<std::string> Heartbeat::filledHeartbeats;
 
 
-void Heartbeat::subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts)
+void Heartbeat::subscriptionFilled(const std::vector< tr1::shared_ptr<GravityDataProduct> >& dataProducts)
 {
 	lock.Lock();
 	for(size_t i = 0; i < dataProducts.size(); i++)

--- a/src/api/cpp/GravityNode.cpp
+++ b/src/api/cpp/GravityNode.cpp
@@ -155,7 +155,6 @@ void* Heartbeat(void* thread_context);
 
 
 using namespace std;
-using namespace std::tr1;
 
 GravityNode::GravityNodeDomainListener::GravityNodeDomainListener(void* context)
 {
@@ -968,6 +967,9 @@ GravityReturnCode GravityNode::sendRequestToServiceProvider(string url, const Gr
 													response.getDataProductID().c_str(), timeout_in_milliseconds);
     void* socket = zmq_socket(context, ZMQ_REQ); // Socket to connect to service provider
 	zmq_connect(socket, url.c_str());
+	int linger = 0;
+    zmq_setsockopt(socket, ZMQ_LINGER, &linger, sizeof(linger));
+
 
 	// Send message to service provider
 	sendGravityDataProduct(socket, request, ZMQ_DONTWAIT);
@@ -1721,6 +1723,7 @@ GravityReturnCode GravityNode::request(string connectionURL, string serviceID, c
 	sendStringMessage(requestManagerSWL.socket, serviceID, ZMQ_SNDMORE);
 	sendStringMessage(requestManagerSWL.socket, connectionURL, ZMQ_SNDMORE);
 	sendStringMessage(requestManagerSWL.socket, requestID, ZMQ_SNDMORE);
+	sendIntMessage(requestManagerSWL.socket, timeout_milliseconds, ZMQ_SNDMORE);
 
 	zmq_msg_t msg;
 	zmq_msg_init_size(&msg, dataProduct.getSize());
@@ -1740,7 +1743,7 @@ GravityReturnCode GravityNode::request(string connectionURL, string serviceID, c
 }
 
 //Synchronous Request
-shared_ptr<GravityDataProduct> GravityNode::request(string serviceID, const GravityDataProduct& request, 
+tr1::shared_ptr<GravityDataProduct> GravityNode::request(string serviceID, const GravityDataProduct& request, 
 													int timeout_milliseconds, string domain)
 {
 	//set Component ID
@@ -1764,17 +1767,17 @@ shared_ptr<GravityDataProduct> GravityNode::request(string serviceID, const Grav
 		{
 			Log::warning("Unable to find service %s: %s", serviceID.c_str(), getCodeString(ret).c_str());
 		}
-		return shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
+		return tr1::shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
 	}
 
 	uint64_t t1 = gravity::getCurrentTime();
-	shared_ptr<GravityDataProduct> response(new GravityDataProduct(serviceID));
+	tr1::shared_ptr<GravityDataProduct> response(new GravityDataProduct(serviceID));
 	Log::trace("Sending request to service provider @ %s", connectionURL.c_str());
 	ret = sendRequestToServiceProvider(connectionURL, request, *response, timeout_milliseconds);
 	if(ret != GravityReturnCodes::SUCCESS)
 	{
 		Log::warning("service request returned error: %s", getCodeString(ret).c_str());
-		return shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
+		return tr1::shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
 	}
 
 	if (response->isFutureResponse())
@@ -1793,7 +1796,7 @@ shared_ptr<GravityDataProduct> GravityNode::request(string serviceID, const Grav
 		if(ret != GravityReturnCodes::SUCCESS)
 		{
 			Log::warning("service request returned error: %s", getCodeString(ret).c_str());
-			return shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
+			return tr1::shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
 		}
 		Log::trace("Received future response's response");
 	}
@@ -2196,7 +2199,7 @@ string GravityNode::getDomain()
     return myDomain;
 }
 
-shared_ptr<FutureResponse> GravityNode::createFutureResponse()
+tr1::shared_ptr<FutureResponse> GravityNode::createFutureResponse()
 {
 	// Send request to create future response
     requestManagerRepSWL.lock.Lock();
@@ -2218,12 +2221,12 @@ shared_ptr<FutureResponse> GravityNode::createFutureResponse()
 	if (url.empty())
 	{
 		Log::critical("Could not find available port for FutureResponse");
-		return shared_ptr<FutureResponse>((FutureResponse*)NULL);
+		return tr1::shared_ptr<FutureResponse>((FutureResponse*)NULL);
 	}
 
 	requestManagerRepSWL.lock.Unlock();
 
-	shared_ptr<FutureResponse> futureResponse(new FutureResponse(url));
+	tr1::shared_ptr<FutureResponse> futureResponse(new FutureResponse(url));
 	return futureResponse;
 }
 

--- a/src/api/cpp/GravityPublishManager.cpp
+++ b/src/api/cpp/GravityPublishManager.cpp
@@ -35,9 +35,8 @@ namespace gravity
 {
 
 using namespace std;
-using namespace std::tr1;
 
-bool sortCacheValues (const shared_ptr<CacheValue> &i, const shared_ptr<CacheValue> &j)
+bool sortCacheValues (const tr1::shared_ptr<CacheValue> &i, const tr1::shared_ptr<CacheValue> &j)
 {
     return i->timestamp < j->timestamp;
 }
@@ -238,20 +237,20 @@ void GravityPublishManager::start()
 
 				if (newsub)
 				{					
-				    shared_ptr<PublishDetails> pd = publishMapBySocket[pollItems[i].socket];
+				    tr1::shared_ptr<PublishDetails> pd = publishMapBySocket[pollItems[i].socket];
 				    // can't log here because the network logging uses this code - any logs here will result in an
 				    // infinite loop, or a deadlock.
 				    // This message can be useful though, so leaving it in, but commented out.
 //				    Log::debug("got a new subscriber for %s, resending %d values", pd->dataProductID.c_str(), pd->lastCachedValues.size());
 
-				    list<shared_ptr<CacheValue> > values;
-				    for (map<string,shared_ptr<CacheValue> >::iterator iter = pd->lastCachedValues.begin(); iter != pd->lastCachedValues.end(); iter++)
+				    list<tr1::shared_ptr<CacheValue> > values;
+				    for (map<string,tr1::shared_ptr<CacheValue> >::iterator iter = pd->lastCachedValues.begin(); iter != pd->lastCachedValues.end(); iter++)
 				        values.push_back(iter->second);
 
 					
 				    // we shouldn't be doing this often, so just sort these when we need it.
                     values.sort(sortCacheValues);
-				    for (list<shared_ptr<CacheValue> >::iterator iter = values.begin(); iter != values.end(); iter++)
+				    for (list<tr1::shared_ptr<CacheValue> >::iterator iter = values.begin(); iter != values.end(); iter++)
 					{
 						//we have a new subscriber and are going to send it the last cached data product value. 
 						char* bytes = (*iter)->value;
@@ -274,11 +273,11 @@ void GravityPublishManager::start()
 	}
 
 	// Clean up any pub sockets
-	for (map<void*,shared_ptr<PublishDetails> >::iterator iter = publishMapBySocket.begin(); iter != publishMapBySocket.end(); iter++)
+	for (map<void*,tr1::shared_ptr<PublishDetails> >::iterator iter = publishMapBySocket.begin(); iter != publishMapBySocket.end(); iter++)
 	{
-		shared_ptr<PublishDetails> pubDetails = publishMapBySocket[iter->second->socket];
+		tr1::shared_ptr<PublishDetails> pubDetails = publishMapBySocket[iter->second->socket];
 		zmq_close(pubDetails->pollItem.socket);
-        for (map<string,shared_ptr<CacheValue> >::iterator valIter = pubDetails->lastCachedValues.begin(); valIter != pubDetails->lastCachedValues.end(); valIter++)
+        for (map<string,tr1::shared_ptr<CacheValue> >::iterator valIter = pubDetails->lastCachedValues.begin(); valIter != pubDetails->lastCachedValues.end(); valIter++)
             delete [] valIter->second->value;
         pubDetails->lastCachedValues.clear();
 	}
@@ -381,7 +380,7 @@ void GravityPublishManager::registerDataProduct()
 	pollItems.push_back(pollItem);
 
     // Track dataProductID->socket mapping
-    shared_ptr<PublishDetails> publishDetails = shared_ptr<PublishDetails>(new PublishDetails);
+    tr1::shared_ptr<PublishDetails> publishDetails = tr1::shared_ptr<PublishDetails>(new PublishDetails);
     publishDetails->url = connectionURL;
     publishDetails->dataProductID = dataProductID;
     publishDetails->socket = pubSocket;
@@ -406,7 +405,7 @@ void GravityPublishManager::unregisterDataProduct()
 	// If data product ID exists, clean up and remove socket. Otherwise, likely a duplicate unregister request
 	if (publishMapByID.count(dataProductID))
 	{
-		shared_ptr<PublishDetails> publishDetails = publishMapByID[dataProductID];
+		tr1::shared_ptr<PublishDetails> publishDetails = publishMapByID[dataProductID];
 		void* socket = publishDetails->pollItem.socket;
 		publishMapBySocket.erase(socket);
 		publishMapByID.erase(dataProductID);
@@ -414,7 +413,7 @@ void GravityPublishManager::unregisterDataProduct()
 		zmq_close(socket);
 
 		// delete any cached values.
-        for (map<string,shared_ptr<CacheValue> >::iterator iter = publishDetails->lastCachedValues.begin(); iter != publishDetails->lastCachedValues.end(); iter++)
+        for (map<string,tr1::shared_ptr<CacheValue> >::iterator iter = publishDetails->lastCachedValues.begin(); iter != publishDetails->lastCachedValues.end(); iter++)
 		    delete [] iter->second->value;
         publishDetails->lastCachedValues.clear();
 
@@ -461,7 +460,7 @@ void GravityPublishManager::publish(void* requestSocket)
     zmq_msg_close(&msg);
 
 	
-    shared_ptr<PublishDetails> publishDetails = publishMapByID[dataProductId];
+    tr1::shared_ptr<PublishDetails> publishDetails = publishMapByID[dataProductId];
     if (!publishDetails)
     {
         Log::critical("Unable to process publish for unknown data product %s", dataProductId.c_str());
@@ -476,7 +475,7 @@ void GravityPublishManager::publish(void* requestSocket)
 	if(publishDetails->cacheLastValue){
 		Log::trace("Cache last data product value for %s", dataProductId.c_str());
 		// ... save new data for late subscribers
-		shared_ptr<CacheValue> val = shared_ptr<CacheValue>(new CacheValue);
+		tr1::shared_ptr<CacheValue> val = tr1::shared_ptr<CacheValue>(new CacheValue);
 		val->filterText = filterText;
 		val->value = bytes;
 		val->size = gdbSize;

--- a/src/api/cpp/GravityServiceManager.cpp
+++ b/src/api/cpp/GravityServiceManager.cpp
@@ -31,7 +31,6 @@
 namespace gravity {
 
 using namespace std;
-using namespace std::tr1;
 
 GravityServiceManager::GravityServiceManager(void* context)
 {
@@ -152,9 +151,9 @@ void GravityServiceManager::start()
 				// Clean up message
 				zmq_msg_close(&message);
 
-				shared_ptr<ServiceDetails> serviceDetails = serviceMapBySocket[pollItems[i].socket];
+				tr1::shared_ptr<ServiceDetails> serviceDetails = serviceMapBySocket[pollItems[i].socket];
 				Log::trace("Sending request to provider for serviceID = '%s'", serviceDetails->serviceID.c_str());
-				shared_ptr<GravityDataProduct> response = serviceDetails->server->request(serviceDetails->serviceID, dataProduct);
+				tr1::shared_ptr<GravityDataProduct> response = serviceDetails->server->request(serviceDetails->serviceID, dataProduct);
 
 				response->setComponentId(componentID);
 				response->setDomain(domain);
@@ -165,7 +164,7 @@ void GravityServiceManager::start()
 	}
 
 	// Clean up all our open sockets
-	for (map<void*,shared_ptr<ServiceDetails> >::iterator iter = serviceMapBySocket.begin(); iter != serviceMapBySocket.end(); iter++)
+	for (map<void*,tr1::shared_ptr<ServiceDetails> >::iterator iter = serviceMapBySocket.begin(); iter != serviceMapBySocket.end(); iter++)
 	{
 		void* socket = iter->first;
 		zmq_close(socket);
@@ -217,7 +216,7 @@ void GravityServiceManager::addService()
 	memcpy(&server, zmq_msg_data(&msg), zmq_msg_size(&msg));
 	zmq_msg_close(&msg);
 
-	shared_ptr<ServiceDetails> serviceDetails;
+	tr1::shared_ptr<ServiceDetails> serviceDetails;
 
 	// Create the response socket
 	void* serverSocket = zmq_socket(context, ZMQ_REP);
@@ -280,7 +279,7 @@ void GravityServiceManager::removeService()
 	// If service ID exists, clean up and remove socket. Otherwise, likely a duplicate unregister request
 	if (serviceMapByServiceID.count(serviceID))
 	{
-		shared_ptr<ServiceDetails> serviceDetails = serviceMapByServiceID[serviceID];
+		tr1::shared_ptr<ServiceDetails> serviceDetails = serviceMapByServiceID[serviceID];
 		void* socket = serviceDetails->pollItem.socket;
 		serviceMapBySocket.erase(socket);
 		serviceMapByServiceID.erase(serviceID);

--- a/src/api/cpp/GravitySubscriptionManager.cpp
+++ b/src/api/cpp/GravitySubscriptionManager.cpp
@@ -36,9 +36,8 @@ namespace gravity
 {
 
 using namespace std;
-using namespace std::tr1;
 
-bool sortCacheValues (const shared_ptr<GravityDataProduct> &i, const shared_ptr<GravityDataProduct> &j)
+bool sortCacheValues (const tr1::shared_ptr<GravityDataProduct> &i, const tr1::shared_ptr<GravityDataProduct> &j)
 {
     return i->getGravityTimestamp() < j->getGravityTimestamp();
 }
@@ -250,17 +249,17 @@ void GravitySubscriptionManager::start()
 			    if (subscriptionSocketMap.count(pollItems[index].socket) > 0)
 			    {
                     // Deliver to subscriber(s)
-                    shared_ptr<SubscriptionDetails> subDetails = subscriptionSocketMap[pollItems[index].socket];
+                    tr1::shared_ptr<SubscriptionDetails> subDetails = subscriptionSocketMap[pollItems[index].socket];
 
-                    vector< shared_ptr<GravityDataProduct> > dataProducts;
+                    vector< tr1::shared_ptr<GravityDataProduct> > dataProducts;
                     while (true)
                     {
                         string filterText;
-                        shared_ptr<GravityDataProduct> dataProduct;
+                        tr1::shared_ptr<GravityDataProduct> dataProduct;
                         if (readSubscription(pollItems[index].socket, filterText, dataProduct) < 0)
                             break;
 						
-                        shared_ptr<GravityDataProduct> lastCachedValue = lastCachedValueMap[pollItems[index].socket];
+                        tr1::shared_ptr<GravityDataProduct> lastCachedValue = lastCachedValueMap[pollItems[index].socket];
 
                         // if it's been relayed, it will come in on a different socket than the original.  Look at all cached values
                         // to try to filter out duplicates.
@@ -269,7 +268,7 @@ void GravitySubscriptionManager::start()
                         bool cachedRelay = false;
                         if (!lastCachedValue && dataProduct->isRelayedDataproduct())
                         {
-                            for (map<void*, shared_ptr<GravityDataProduct> >::const_iterator mapIter = lastCachedValueMap.begin();
+                            for (map<void*, tr1::shared_ptr<GravityDataProduct> >::const_iterator mapIter = lastCachedValueMap.begin();
                                     mapIter != lastCachedValueMap.end(); mapIter++)
                             {
                                 if (mapIter->second &&
@@ -321,7 +320,7 @@ void GravitySubscriptionManager::start()
 							(*iter)->subscriptionFilled(dataProducts);
 						}
 						uint64_t currTime = getCurrentTime()/1000;
-						for (set<shared_ptr<TimeoutMonitor> >::iterator iter = subDetails->monitors.begin(); iter != subDetails->monitors.end(); iter++)
+						for (set<tr1::shared_ptr<TimeoutMonitor> >::iterator iter = subDetails->monitors.begin(); iter != subDetails->monitors.end(); iter++)
 						{						
 							(*iter)->lastReceived = (int64_t) currTime;
 							(*iter)->endTime = currTime + (*iter)->timeout;
@@ -335,7 +334,7 @@ void GravitySubscriptionManager::start()
                 }
 			    else // it's a publisher update list from the SD
 			    {
-                    shared_ptr<GravityDataProduct> dataProduct;
+                    tr1::shared_ptr<GravityDataProduct> dataProduct;
                     string dataProductID;
                     readSubscription(pollItems[index].socket, dataProductID, dataProduct);
                     if (dataProductID.empty())
@@ -361,7 +360,7 @@ void GravitySubscriptionManager::start()
 
                     if (subscriptionMap.count(key) != 0)
                     {
-                        for (map<string, shared_ptr<SubscriptionDetails> >::iterator iter = subscriptionMap[key].begin();
+                        for (map<string, tr1::shared_ptr<SubscriptionDetails> >::iterator iter = subscriptionMap[key].begin();
                              iter != subscriptionMap[key].end();
                              iter++)
                         {
@@ -442,7 +441,7 @@ void GravitySubscriptionManager::start()
 	}
 
 	// Clean up all our open sockets
-	for (map<void*,shared_ptr<SubscriptionDetails> >::iterator iter = subscriptionSocketMap.begin(); iter != subscriptionSocketMap.end(); iter++)
+	for (map<void*,tr1::shared_ptr<SubscriptionDetails> >::iterator iter = subscriptionSocketMap.begin(); iter != subscriptionSocketMap.end(); iter++)
 	{
 		zmq_close(iter->first);
 	}
@@ -473,7 +472,7 @@ void GravitySubscriptionManager::ready()
 	zmq_close(initSocket);
 }
 
-int GravitySubscriptionManager::readSubscription(void *socket, string &filterText, shared_ptr<GravityDataProduct> &dataProduct)
+int GravitySubscriptionManager::readSubscription(void *socket, string &filterText, tr1::shared_ptr<GravityDataProduct> &dataProduct)
 {
     // Messages
     zmq_msg_t filter, message;
@@ -499,7 +498,7 @@ int GravitySubscriptionManager::readSubscription(void *socket, string &filterTex
     zmq_msg_init(&message);
     zmq_recvmsg(socket, &message, 0);
     // Create new GravityDataProduct from the incoming message
-    dataProduct = shared_ptr<GravityDataProduct>(new GravityDataProduct(zmq_msg_data(&message), zmq_msg_size(&message)));
+    dataProduct = tr1::shared_ptr<GravityDataProduct>(new GravityDataProduct(zmq_msg_data(&message), zmq_msg_size(&message)));
     // Clean up message
     zmq_msg_close(&message);
 
@@ -598,7 +597,7 @@ void GravitySubscriptionManager::addSubscription()
 	if (subscriptionMap.count(key) == 0)
 	{
 		Log::trace("subscriptionMap.count == 0");
-	    map<string, shared_ptr<SubscriptionDetails> > filterMap;
+	    map<string, tr1::shared_ptr<SubscriptionDetails> > filterMap;
 	    subscriptionMap[key] = filterMap;
 	    if (publisherUpdateUrl.size() > 0)
 	    {
@@ -609,7 +608,7 @@ void GravitySubscriptionManager::addSubscription()
 	    }
 	}
 
-	shared_ptr<SubscriptionDetails> subDetails;
+	tr1::shared_ptr<SubscriptionDetails> subDetails;
 	
 	
 	
@@ -659,7 +658,7 @@ void GravitySubscriptionManager::addSubscription()
 	if(subDetails->subscribers.empty() && !subDetails->monitors.empty())
 	{
 		uint64_t currTime = getCurrentTime()/1000;
-		for(set<shared_ptr<TimeoutMonitor> >::iterator monitorIter = subDetails->monitors.begin(); monitorIter != subDetails->monitors.end(); monitorIter++)
+		for(set<tr1::shared_ptr<TimeoutMonitor> >::iterator monitorIter = subDetails->monitors.begin(); monitorIter != subDetails->monitors.end(); monitorIter++)
 		{
 			(*monitorIter)->endTime = currTime + (*monitorIter)->timeout;
 		}
@@ -676,7 +675,7 @@ void GravitySubscriptionManager::addSubscription()
 		if(receiveLastCachedValue)
 		{
 			Log::trace("Sending cached value to subscriber");
-			vector<shared_ptr<GravityDataProduct> > dataProducts;
+			vector<tr1::shared_ptr<GravityDataProduct> > dataProducts;
 			for (map<string, zmq_pollitem_t>::iterator iter = subDetails->pollItemMap.begin(); iter != subDetails->pollItemMap.end(); iter++)
 			{
 				if (lastCachedValueMap[iter->second.socket])
@@ -728,7 +727,7 @@ void GravitySubscriptionManager::removeSubscription()
 	if (subscriptionMap.count(key) > 0 && subscriptionMap[key].count(filter) > 0)
 	{
 		// Get subscription details
-		shared_ptr<SubscriptionDetails> subDetails = subscriptionMap[key][filter];
+		tr1::shared_ptr<SubscriptionDetails> subDetails = subscriptionMap[key][filter];
 
 		// Find & remove subscriber from our list of subscribers for this data product
 		set<GravitySubscriber*>::iterator iter = subDetails->subscribers.begin();
@@ -806,7 +805,7 @@ void GravitySubscriptionManager::setTimeoutMonitor()
 	
 	DomainDataKey key(domain, dataProductID);
 		
-	shared_ptr<SubscriptionDetails> subDetails;
+	tr1::shared_ptr<SubscriptionDetails> subDetails;
 	if (subscriptionMap[key].count(filter) > 0)
 	{
 		// Already have a details for this
@@ -818,14 +817,14 @@ void GravitySubscriptionManager::setTimeoutMonitor()
 		subDetails->dataProductID = dataProductID;
 		subDetails->domain = domain;
 		subDetails->filter = filter;
-		map<string, shared_ptr<SubscriptionDetails> > filterMap;
+		map<string, tr1::shared_ptr<SubscriptionDetails> > filterMap;
 	    subscriptionMap[key] = filterMap;
 		subscriptionMap[key][filter] = subDetails;
 	}
 		
 	uint64_t currTime = getCurrentTime()/1000;
 
-	for(std::set<shared_ptr<TimeoutMonitor> >::iterator iter = subDetails->monitors.begin();iter != subDetails->monitors.end();iter++)
+	for(std::set<tr1::shared_ptr<TimeoutMonitor> >::iterator iter = subDetails->monitors.begin();iter != subDetails->monitors.end();iter++)
 	{
 		// if a reference to this monitor already exists
 		if((*iter)->monitor == monitor)
@@ -838,7 +837,7 @@ void GravitySubscriptionManager::setTimeoutMonitor()
 	}
 
 	// create and add new monitor
-	shared_ptr<TimeoutMonitor> tm;
+	tr1::shared_ptr<TimeoutMonitor> tm;
 	tm.reset(new TimeoutMonitor());
 
 	tm->monitor = monitor;
@@ -871,10 +870,10 @@ void GravitySubscriptionManager::clearTimeoutMonitor()
 		
 	if (subscriptionMap.count(key) > 0 && subscriptionMap[key].count(filter) > 0)
 	{
-		shared_ptr<SubscriptionDetails> subDetails = subscriptionMap[key][filter];
+		tr1::shared_ptr<SubscriptionDetails> subDetails = subscriptionMap[key][filter];
 
 		// Find & remove all matching monitors
-		set<shared_ptr<TimeoutMonitor> >::iterator iter = subDetails->monitors.begin();
+		set<tr1::shared_ptr<TimeoutMonitor> >::iterator iter = subDetails->monitors.begin();
 		while (iter != subDetails->monitors.end())
 		{
 			if ((*iter)->monitor == monitor)
@@ -910,15 +909,15 @@ void GravitySubscriptionManager::calculateTimeout()
 	int minTime = -1;
 	currTimeoutMonitor.reset();
 	currMonitorDetails.reset();
-	map<DomainDataKey, map<std::string, shared_ptr<SubscriptionDetails> > >::iterator dpIter = subscriptionMap.begin();
+	map<DomainDataKey, map<std::string, tr1::shared_ptr<SubscriptionDetails> > >::iterator dpIter = subscriptionMap.begin();
 	//go through all domain-dataproduct keys
 	while (dpIter != subscriptionMap.end())
 	{
-		map<string, shared_ptr<SubscriptionDetails> >::iterator filterIter = dpIter->second.begin();
+		map<string, tr1::shared_ptr<SubscriptionDetails> >::iterator filterIter = dpIter->second.begin();
 		while(filterIter != dpIter->second.end())
 		{
-			shared_ptr<SubscriptionDetails> subDetails = filterIter->second;
-			for(set<shared_ptr<TimeoutMonitor> >::iterator monitorIter = subDetails->monitors.begin(); monitorIter != subDetails->monitors.end(); monitorIter++)
+			tr1::shared_ptr<SubscriptionDetails> subDetails = filterIter->second;
+			for(set<tr1::shared_ptr<TimeoutMonitor> >::iterator monitorIter = subDetails->monitors.begin(); monitorIter != subDetails->monitors.end(); monitorIter++)
 			{
 				// check if this is an active subscription with a valid timeout
 				if(subDetails->subscribers.size() > 0 && (*monitorIter)->timeout>=0)
@@ -962,13 +961,13 @@ void GravitySubscriptionManager::calculateTimeout()
 }
 
 
-void GravitySubscriptionManager::collectMetrics(vector<shared_ptr<GravityDataProduct> > dataProducts)
+void GravitySubscriptionManager::collectMetrics(vector<tr1::shared_ptr<GravityDataProduct> > dataProducts)
 {
     // Iterate over all the data products
-    vector<shared_ptr<GravityDataProduct> >::iterator gdpIter;
+    vector<tr1::shared_ptr<GravityDataProduct> >::iterator gdpIter;
     for (gdpIter = dataProducts.begin(); gdpIter != dataProducts.end(); gdpIter++)
     {
-        shared_ptr<GravityDataProduct> gdp = *gdpIter;
+        tr1::shared_ptr<GravityDataProduct> gdp = *gdpIter;
         metricsData.incrementMessageCount(gdp->getDataProductID(), 1);
         metricsData.incrementByteCount(gdp->getDataProductID(), gdp->getSize());
     }

--- a/src/components/cpp/Archiver/FileArchiver.cpp
+++ b/src/components/cpp/Archiver/FileArchiver.cpp
@@ -26,7 +26,6 @@
 #include "protobuf/FileArchiverControlResponsePB.pb.h"
 
 using namespace std;
-using namespace std::tr1;
 
 int main(int argc, const char* argv[])
 {
@@ -105,13 +104,13 @@ vector<string> FileArchiver::split(string s)
 	return tokens;
 }
 
-void FileArchiver::subscriptionFilled(const vector<shared_ptr<GravityDataProduct> >& dataProducts)
+void FileArchiver::subscriptionFilled(const vector<tr1::shared_ptr<GravityDataProduct> >& dataProducts)
 {
     if (!suspend)
     {
         for (unsigned int i = 0; i < dataProducts.size(); i++)
         {
-            shared_ptr<GravityDataProduct> dataProduct = dataProducts.at(i);
+            tr1::shared_ptr<GravityDataProduct> dataProduct = dataProducts.at(i);
 
             // Write the size of the data product
             int size = dataProduct->getSize();
@@ -128,7 +127,7 @@ void FileArchiver::subscriptionFilled(const vector<shared_ptr<GravityDataProduct
     }
 }
 
-shared_ptr<GravityDataProduct> FileArchiver::request(const std::string serviceID, const GravityDataProduct& dataProduct)
+tr1::shared_ptr<GravityDataProduct> FileArchiver::request(const std::string serviceID, const GravityDataProduct& dataProduct)
 {
     Log::debug("Received service request of type '%s'", serviceID.c_str());
     FileArchiverControlResponsePB faResponse;
@@ -150,7 +149,7 @@ shared_ptr<GravityDataProduct> FileArchiver::request(const std::string serviceID
         }
     }
 
-    shared_ptr<GravityDataProduct> gdpResponse = shared_ptr<GravityDataProduct>(new GravityDataProduct("FileArchiverControlResponse"));
+    tr1::shared_ptr<GravityDataProduct> gdpResponse = tr1::shared_ptr<GravityDataProduct>(new GravityDataProduct("FileArchiverControlResponse"));
     gdpResponse->setData(faResponse);
     return gdpResponse;
 }

--- a/src/components/cpp/ConfigServer/ConfigServer.cpp
+++ b/src/components/cpp/ConfigServer/ConfigServer.cpp
@@ -27,7 +27,6 @@
 
 using namespace gravity;
 using namespace std;
-using namespace std::tr1;
 
 struct ConfigEntry
 {
@@ -46,11 +45,11 @@ class ConfigServer : public GravityServiceProvider
 {
 public:
 	ConfigServer() {}
-    virtual shared_ptr<GravityDataProduct> request(const std::string serviceID, const GravityDataProduct& dataProduct);
+    virtual tr1::shared_ptr<GravityDataProduct> request(const std::string serviceID, const GravityDataProduct& dataProduct);
     ~ConfigServer() {};
 };
 
-shared_ptr<GravityDataProduct> ConfigServer::request(const std::string serviceID, const GravityDataProduct& dataProduct)
+tr1::shared_ptr<GravityDataProduct> ConfigServer::request(const std::string serviceID, const GravityDataProduct& dataProduct)
 {
 	ConfigRequestPB cfpb;
 	dataProduct.populateMessage(cfpb);
@@ -83,7 +82,7 @@ shared_ptr<GravityDataProduct> ConfigServer::request(const std::string serviceID
     if(!key_value_map.size())
 	{
 		cout << "Critical Error: Could not open config file: config_file.ini" << endl;
-		return shared_ptr<GravityDataProduct>();
+		return tr1::shared_ptr<GravityDataProduct>();
 	}
 
 	//Populate Response Message and Send it
@@ -97,7 +96,7 @@ shared_ptr<GravityDataProduct> ConfigServer::request(const std::string serviceID
 		message.add_value(i->second);
 	}
 
-	shared_ptr<GravityDataProduct> response(new GravityDataProduct("ConfigResponsePB"));
+	tr1::shared_ptr<GravityDataProduct> response(new GravityDataProduct("ConfigResponsePB"));
 	response->setData(message);
 
 	return response; //Returning the message will send it.

--- a/src/components/cpp/LogRecorder/GravityLogRecorder.cpp
+++ b/src/components/cpp/LogRecorder/GravityLogRecorder.cpp
@@ -28,7 +28,6 @@
 #include <algorithm>
 
 using namespace std;
-using namespace std::tr1;
 
 namespace gravity {
 
@@ -81,13 +80,13 @@ void LogRecorder::start()
 }
 
 
-void LogRecorder::subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts)
+void LogRecorder::subscriptionFilled(const std::vector< tr1::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-    //shared_ptr<GravityDataProduct> gdp = *dataProducts.begin();
-    //for_each(dataProducts.begin(), dataProducts.end(), [ this ] (shared_ptr<GravityDataProduct> dataProduct) { //Lambda function
-    for(vector<shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin(); i != dataProducts.end(); i++)
+    //tr1::shared_ptr<GravityDataProduct> gdp = *dataProducts.begin();
+    //for_each(dataProducts.begin(), dataProducts.end(), [ this ] (tr1::shared_ptr<GravityDataProduct> dataProduct) { //Lambda function
+    for(vector<tr1::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin(); i != dataProducts.end(); i++)
     {
-        shared_ptr<GravityDataProduct> dataProduct = *i;
+        tr1::shared_ptr<GravityDataProduct> dataProduct = *i;
         num_logs++;
 
         GravityLogMessagePB message;

--- a/src/components/cpp/Playback/FileReader.cpp
+++ b/src/components/cpp/Playback/FileReader.cpp
@@ -26,7 +26,6 @@
 #endif
 
 using namespace std;
-using namespace std::tr1;
 
 namespace gravity {
 
@@ -105,7 +104,7 @@ int FileReader::readNextDataProduct()
         	}
 
         	// Convert to GravityDataProduct
-		shared_ptr<GravityDataProduct> gdp = shared_ptr<GravityDataProduct>(new GravityDataProduct(buffer.data(), size));
+		tr1::shared_ptr<GravityDataProduct> gdp = tr1::shared_ptr<GravityDataProduct>(new GravityDataProduct(buffer.data(), size));
 		//gdp->parseFromArray(buffer, size);
 
 		// Make sure this is a data product we care about
@@ -149,18 +148,18 @@ bool FileReader::hasData()
 	return ret;
 }
 
-shared_ptr<GravityDataProduct> FileReader::popGravityDataProduct()
+tr1::shared_ptr<GravityDataProduct> FileReader::popGravityDataProduct()
 {
 	pthread_mutex_lock(&mutex);
-	shared_ptr<GravityDataProduct> gdp = dataProducts[0];
+	tr1::shared_ptr<GravityDataProduct> gdp = dataProducts[0];
 	dataProducts.erase(dataProducts.begin());
 	pthread_mutex_unlock(&mutex);
 	return gdp;
 }
 
-shared_ptr<GravityDataProduct> FileReader::getNextDataProduct()
+tr1::shared_ptr<GravityDataProduct> FileReader::getNextDataProduct()
 {
-	shared_ptr<GravityDataProduct> gdp;
+	tr1::shared_ptr<GravityDataProduct> gdp;
 	if (!hasData() && !readNextDataProduct())
 	{
 	}

--- a/src/components/cpp/Playback/FileReplay.cpp
+++ b/src/components/cpp/Playback/FileReplay.cpp
@@ -28,7 +28,6 @@
 #endif
 
 using namespace std;
-using namespace std::tr1;
 
 int main(int argc, const char* argv[])
 {
@@ -70,7 +69,7 @@ FileReplay::~FileReplay() {}
 
 void FileReplay::processArchive()
 {
-    shared_ptr<GravityDataProduct> gdp = fileReader.getNextDataProduct();
+    tr1::shared_ptr<GravityDataProduct> gdp = fileReader.getNextDataProduct();
     while (gdp)
     {
         // Ensure that we've registered this data product

--- a/src/components/cpp/Relay/Relay.cpp
+++ b/src/components/cpp/Relay/Relay.cpp
@@ -56,7 +56,6 @@ void handler(int sig)
 
 using namespace gravity;
 using namespace std;
-using namespace std::tr1;
 
 class Relay : public GravitySubscriber
 {
@@ -68,7 +67,7 @@ public:
     virtual ~Relay() {};
 
     int run();
-    void subscriptionFilled(const std::vector< std::tr1::shared_ptr<GravityDataProduct> >& dataProducts);
+    void subscriptionFilled(const std::vector< tr1::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 int Relay::run()
@@ -138,11 +137,11 @@ int Relay::run()
  * Not much happens here, it just passes along the GDP's that it receives.  The main work is done in the ServiceDirectory
  * where it recognizes subscribers that are collocated with the Relay and just provides data from there.
  */
-void Relay::subscriptionFilled(const std::vector< std::tr1::shared_ptr<GravityDataProduct> >& dataProducts)
+void Relay::subscriptionFilled(const std::vector< tr1::shared_ptr<GravityDataProduct> >& dataProducts)
 {
     for (unsigned int i = 0; i < dataProducts.size(); i++)
     {
-        shared_ptr<GravityDataProduct> dataProduct = dataProducts.at(i);
+        tr1::shared_ptr<GravityDataProduct> dataProduct = dataProducts.at(i);
         Log::debug("Republishing %s", dataProduct->getDataProductID().c_str());
         dataProduct->setIsRelayedDataproduct(true);
         gravityNode.publish(*dataProduct);

--- a/src/components/cpp/ServiceDirectory/ServiceDirectory.cpp
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectory.cpp
@@ -54,7 +54,6 @@
 #define DIRECTORY_SERVICE "DirectoryService"
 
 using namespace std;
-using namespace std::tr1;
 
 struct RegistrationData
 {
@@ -355,7 +354,7 @@ void ServiceDirectory::start()
              * on a separate thread provided by the GravityNode.
              */
             lock.Lock();
-            shared_ptr<GravityDataProduct> response = request(req);
+            tr1::shared_ptr<GravityDataProduct> response = request(req);
             if (!registeredPublishersProcessed && registeredPublishersReady)
             {
                 GravityDataProduct update(REGISTERED_PUBLISHERS);
@@ -419,9 +418,9 @@ void ServiceDirectory::start()
     }
 }
 
-shared_ptr<GravityDataProduct> ServiceDirectory::request(const GravityDataProduct& dataProduct)
+tr1::shared_ptr<GravityDataProduct> ServiceDirectory::request(const GravityDataProduct& dataProduct)
 {
-	shared_ptr<GravityDataProduct> gdpResponse = shared_ptr<GravityDataProduct>(new GravityDataProduct("DataProductRegistrationResponse"));
+	tr1::shared_ptr<GravityDataProduct> gdpResponse = tr1::shared_ptr<GravityDataProduct>(new GravityDataProduct("DataProductRegistrationResponse"));
     string requestType = dataProduct.getDataProductID();
 
     ///////////////////////////////////
@@ -458,10 +457,10 @@ shared_ptr<GravityDataProduct> ServiceDirectory::request(const GravityDataProduc
  * Because the lock in this method blocks the main SD loop above, we can't issue any GravityNode calls
  * here that require SD support (e.g. register, etc).
  */
-shared_ptr<GravityDataProduct> ServiceDirectory::request(const std::string serviceID, const GravityDataProduct& request)
+tr1::shared_ptr<GravityDataProduct> ServiceDirectory::request(const std::string serviceID, const GravityDataProduct& request)
 {
     Log::debug("Received service request of type '%s'", serviceID.c_str());
-	shared_ptr<GravityDataProduct> gdpResponse = shared_ptr<GravityDataProduct>(new GravityDataProduct("DirectoryServiceResponse"));
+	tr1::shared_ptr<GravityDataProduct> gdpResponse = tr1::shared_ptr<GravityDataProduct>(new GravityDataProduct("DirectoryServiceResponse"));
    
     if (serviceID == DIRECTORY_SERVICE)
     {

--- a/src/components/cpp/ServiceDirectory/ServiceDirectorySynchronizer.cpp
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectorySynchronizer.cpp
@@ -34,7 +34,6 @@
 #include <iostream>
 
 using namespace std;
-using namespace std::tr1;
 
 namespace gravity
 {
@@ -111,7 +110,7 @@ void ServiceDirectorySynchronizer::start()
 				if (syncMap.find(domain) == syncMap.end())
 				{					
 					// Create details
-					shared_ptr<SyncDomainDetails> details(new SyncDomainDetails());					
+					tr1::shared_ptr<SyncDomainDetails> details(new SyncDomainDetails());					
 					details->domain = domain;
 					details->ipAddress = domainIP;
 					details->pollItemIndex = pollItems.size();
@@ -164,7 +163,7 @@ void ServiceDirectorySynchronizer::start()
 				{
 					// A domain is no longer available and needs to be removed. Get 
 					// details from map
-					shared_ptr<SyncDomainDetails> details = syncMap[domain];
+					tr1::shared_ptr<SyncDomainDetails> details = syncMap[domain];
 
 					// Remove our subscription listener from pollItems vector
 					// (i.e. no longer care to receive updates)
@@ -250,7 +249,7 @@ void ServiceDirectorySynchronizer::start()
                             Log::message("Received DataProductRegistrationResponse response from ServiceDirectory for domain: '%s'", domain.c_str());
 
                             // Get the details for the domain that is providing an update
-                            shared_ptr<SyncDomainDetails> details = syncMap[domain];
+                            tr1::shared_ptr<SyncDomainDetails> details = syncMap[domain];
 
                             // Clean up the request socket (to be replaced with a SUB socket)
                             zmq_close(details->socket);
@@ -279,7 +278,7 @@ void ServiceDirectorySynchronizer::start()
 
 						Log::message("Received update from ServiceDirectory for domain: '%s'", domain.c_str());
 
-						shared_ptr<SyncDomainDetails> details = syncMap[domain];
+						tr1::shared_ptr<SyncDomainDetails> details = syncMap[domain];
 						details->providerMap.Clear();
 						response.populateMessage(details->providerMap);					
 						if (!details->initialized)
@@ -350,7 +349,7 @@ void ServiceDirectorySynchronizer::start()
 		if (!pendingResponse && !registrationUpdates.empty())
 		{
 			// Pop the next update to send from the queue
-			shared_ptr<GravityDataProduct> gdp = registrationUpdates.front();
+			tr1::shared_ptr<GravityDataProduct> gdp = registrationUpdates.front();
 			registrationUpdates.pop();
 
 			// Send data product
@@ -381,7 +380,7 @@ void ServiceDirectorySynchronizer::createRegistrationRequest(string productID, s
 	registerRequest.set_domain(domain);
 	registerRequest.set_timestamp(timestamp);
 
-	shared_ptr<GravityDataProduct> gdp(new GravityDataProduct("RegistrationRequest"));
+	tr1::shared_ptr<GravityDataProduct> gdp(new GravityDataProduct("RegistrationRequest"));
 	gdp->setData(registerRequest);
 	registrationUpdates.push(gdp);
 }
@@ -398,7 +397,7 @@ void ServiceDirectorySynchronizer::createUnregistrationRequest(string productID,
 	unregisterRequest.set_type(rtype);	
 	unregisterRequest.set_domain(domain);
 
-	shared_ptr<GravityDataProduct> gdp(new GravityDataProduct("UnregistrationRequest"));							
+	tr1::shared_ptr<GravityDataProduct> gdp(new GravityDataProduct("UnregistrationRequest"));							
 	gdp->setData(unregisterRequest);
 	registrationUpdates.push(gdp);
 }

--- a/test/examples/1-BasicDataProduct/BasicDataProductSubscriber.cpp
+++ b/test/examples/1-BasicDataProduct/BasicDataProductSubscriber.cpp
@@ -22,13 +22,13 @@
 #include <Utility.h>
 
 using namespace gravity;
-using namespace std::tr1;
+using namespace std;
 
 //Declare a class for receiving Published messages.
 class SimpleGravitySubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts);
+	virtual void subscriptionFilled(const std::vector<tr1::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 int main()
@@ -61,9 +61,9 @@ int main()
 	gn.unsubscribe("HelloWorldDataProduct", hwSubscriber);
 }
 
-void SimpleGravitySubscriber::subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravitySubscriber::subscriptionFilled(const std::vector<tr1::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+	for(std::vector<tr1::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
 			i != dataProducts.end(); i++)
 	{
 		//Get a raw message

--- a/test/examples/10-Archiving/ArchiveTest.cpp
+++ b/test/examples/10-Archiving/ArchiveTest.cpp
@@ -28,7 +28,7 @@ int main()
 {
 	using namespace gravity;
     using namespace std;
-    using namespace std::tr1;
+    
 
 	GravityNode gn;
 	//Initialize gravity, giving this node a componentID.

--- a/test/examples/10-Archiving/ReplayTest.cpp
+++ b/test/examples/10-Archiving/ReplayTest.cpp
@@ -26,13 +26,13 @@
 
 using namespace gravity;
 using namespace std;
-using namespace std::tr1;
+
 
 //Declare class for receiving Published messages.
 class SimpleGravityCounterSubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts);
+	virtual void subscriptionFilled(const std::vector<tr1::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 int main()
@@ -64,9 +64,9 @@ int main()
 	gn.unsubscribe("BasicCounterDataProduct", counterSubscriber);
 }
 
-void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector<tr1::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+	for(std::vector<tr1::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
 			i != dataProducts.end(); i++)
 	{
 		//Get the protobuf object from the message

--- a/test/examples/13-Relay/ProtobufDataProductPublisher.cpp
+++ b/test/examples/13-Relay/ProtobufDataProductPublisher.cpp
@@ -27,7 +27,7 @@ int main()
 {
 	using namespace gravity;
 	using namespace std;
-	using namespace std::tr1;
+	
 
 	GravityNode gn;
 	//Initialize gravity, giving this node a componentID.

--- a/test/examples/13-Relay/ProtobufDataProductSubscriber.cpp
+++ b/test/examples/13-Relay/ProtobufDataProductSubscriber.cpp
@@ -26,13 +26,13 @@
 
 using namespace gravity;
 using namespace std;
-using namespace std::tr1;
+
 
 //Declare class for receiving Published messages.
 class SimpleGravityCounterSubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts);
+	virtual void subscriptionFilled(const std::vector<tr1::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 int main()
@@ -54,9 +54,9 @@ int main()
 	gn.unsubscribe("BasicCounterDataProduct", counterSubscriber);
 }
 
-void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector<tr1::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+	for(std::vector<tr1::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
 			i != dataProducts.end(); i++)
 	{
 		//Get the protobuf object from the message

--- a/test/examples/2-ProtobufDataProduct/ProtobufDataProductPublisher.cpp
+++ b/test/examples/2-ProtobufDataProduct/ProtobufDataProductPublisher.cpp
@@ -27,7 +27,7 @@ int main()
 {
 	using namespace gravity;
 	using namespace std;
-	using namespace std::tr1;
+	
 
 	GravityNode gn;
 	//Initialize gravity, giving this node a componentID.

--- a/test/examples/2-ProtobufDataProduct/ProtobufDataProductSubscriber.cpp
+++ b/test/examples/2-ProtobufDataProduct/ProtobufDataProductSubscriber.cpp
@@ -26,13 +26,12 @@
 
 using namespace gravity;
 using namespace std;
-using namespace std::tr1;
 
 //Declare class for receiving Published messages.
 class SimpleGravityCounterSubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts);
+	virtual void subscriptionFilled(const std::vector< tr1::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 int main()
@@ -54,9 +53,9 @@ int main()
 	gn.unsubscribe("BasicCounterDataProduct", counterSubscriber);
 }
 
-void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector< tr1::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+	for(std::vector< tr1::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
 			i != dataProducts.end(); i++)
 	{
 		//Get the protobuf object from the message

--- a/test/examples/3-MultipleDataProduct/MultipleDataProductSubscriber.cpp
+++ b/test/examples/3-MultipleDataProduct/MultipleDataProductSubscriber.cpp
@@ -25,13 +25,12 @@
 
 using namespace gravity;
 using namespace std;
-using namespace std::tr1;
 
 //Declare a class for receiving Published messages.
 class SimpleGravitySubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts);
+	virtual void subscriptionFilled(const std::vector< tr1::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 //Declare another class for receiving Published messages.
@@ -39,7 +38,7 @@ class SimpleGravityCounterSubscriber : public GravitySubscriber
 {
 public:
 	SimpleGravityCounterSubscriber();
-	virtual void subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts);
+	virtual void subscriptionFilled(const std::vector< tr1::shared_ptr<GravityDataProduct> >& dataProducts);
 private:
 	int countTotals; //Declare a variable to keep track of the sum of all counts received.
 };
@@ -54,7 +53,7 @@ SimpleGravityCounterSubscriber::SimpleGravityCounterSubscriber()
 class SimpleGravityHelloWorldSubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts);
+	virtual void subscriptionFilled(const std::vector< tr1::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 
@@ -82,9 +81,9 @@ int main()
 	gn.waitForExit();
 }
 
-void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector< tr1::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+	for(std::vector< tr1::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
 			i != dataProducts.end(); i++)
 	{
 		//Get the protobuf object from the message
@@ -98,9 +97,9 @@ void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector< share
 	}
 }
 
-void SimpleGravityHelloWorldSubscriber::subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravityHelloWorldSubscriber::subscriptionFilled(const std::vector< tr1::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+	for(std::vector< tr1::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
 			i != dataProducts.end(); i++)
 	{
 		//Get a raw message
@@ -116,9 +115,9 @@ void SimpleGravityHelloWorldSubscriber::subscriptionFilled(const std::vector< sh
 	}
 }
 
-void SimpleGravitySubscriber::subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravitySubscriber::subscriptionFilled(const std::vector< tr1::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+	for(std::vector< tr1::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
 			i != dataProducts.end(); i++)
 	{
 		//Process Message

--- a/test/examples/4-BasicService/BasicServiceProvider.cpp
+++ b/test/examples/4-BasicService/BasicServiceProvider.cpp
@@ -25,21 +25,20 @@
 
 using namespace gravity;
 using namespace std;
-using namespace std::tr1;
 
 class MultiplicationServiceProvider : public GravityServiceProvider
 {
 public:
-	virtual shared_ptr<GravityDataProduct> request(const std::string serviceID, const GravityDataProduct& dataProduct);
+	virtual tr1::shared_ptr<GravityDataProduct> request(const std::string serviceID, const GravityDataProduct& dataProduct);
 };
 
 
-shared_ptr<GravityDataProduct> MultiplicationServiceProvider::request(const std::string serviceID, const GravityDataProduct& dataProduct)
+tr1::shared_ptr<GravityDataProduct> MultiplicationServiceProvider::request(const std::string serviceID, const GravityDataProduct& dataProduct)
 {
 	//Just to be safe.  In theory this can never happen unless this class is registered with more than one serviceID types.
 	if(dataProduct.getDataProductID() != "Multiplication") {
 		Log::critical("Request is not for multiplication!");
-		return shared_ptr<GravityDataProduct>(new GravityDataProduct("BadRequest"));
+		return tr1::shared_ptr<GravityDataProduct>(new GravityDataProduct("BadRequest"));
 	}
 
 	//Get the parameters for this request.
@@ -55,7 +54,7 @@ shared_ptr<GravityDataProduct> MultiplicationServiceProvider::request(const std:
 	MultiplicationResultPB resultPB;
 	resultPB.set_result(result);
 
-	shared_ptr<GravityDataProduct> resultDP(new GravityDataProduct("MultiplicationResult"));
+	tr1::shared_ptr<GravityDataProduct> resultDP(new GravityDataProduct("MultiplicationResult"));
 	resultDP->setData(resultPB);
 
 	return resultDP;

--- a/test/examples/4-BasicService/BasicServiceRequestor.cpp
+++ b/test/examples/4-BasicService/BasicServiceRequestor.cpp
@@ -25,7 +25,6 @@
 
 using namespace gravity;
 using namespace std;
-using namespace std::tr1;
 
 bool gotAsyncMessage = false;
 
@@ -94,7 +93,7 @@ int main()
 	multRequest2.setData(params2);
 
 	//Make a Synchronous request for multiplication
-	shared_ptr<GravityDataProduct> multSync = gn.request("Multiplication", //Service Name
+	tr1::shared_ptr<GravityDataProduct> multSync = gn.request("Multiplication", //Service Name
 														multRequest2, //Request
 														1000); //Timeout in milliseconds
 	if(multSync == NULL)

--- a/test/examples/5-MiscFunctionality/MiscComponent2.cpp
+++ b/test/examples/5-MiscFunctionality/MiscComponent2.cpp
@@ -23,7 +23,7 @@
 
 using namespace gravity;
 using namespace std;
-using namespace std::tr1;
+
 
 class MiscHBListener : public GravityHeartbeatListener
 {
@@ -48,12 +48,12 @@ void MiscHBListener::ReceivedHeartbeat(std::string dataProductID, int64_t& inter
 class MiscGravitySubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts);
+	virtual void subscriptionFilled(const std::vector<tr1::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
-void MiscGravitySubscriber::subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts)
+void MiscGravitySubscriber::subscriptionFilled(const std::vector<tr1::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+	for(std::vector<tr1::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
 			i != dataProducts.end(); i++)
 	{
 		//Get a raw message

--- a/test/examples/9-Domains/ProtobufDataProductSubscriber.cpp
+++ b/test/examples/9-Domains/ProtobufDataProductSubscriber.cpp
@@ -26,13 +26,13 @@
 
 using namespace gravity;
 using namespace std;
-using namespace std::tr1;
+
 
 //Declare class for receiving Published messages.
 class SimpleGravityCounterSubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts);
+	virtual void subscriptionFilled(const std::vector<tr1::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 int main()
@@ -64,9 +64,9 @@ int main()
 	gn.unsubscribe("BasicCounterDataProduct", counterSubscriber);
 }
 
-void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector< shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector<tr1::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+	for(std::vector<tr1::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
 			i != dataProducts.end(); i++)
 	{
 		//Get the protobuf object from the message


### PR DESCRIPTION
I think this fixes issue #29 by making all TR1 calls explicit, and removing all instances of 'using namespace tr1'.