### PR TITLE
Fix to support Oneof field in protobuf 2.6.1

### DIFF
--- a/src/api/MATLAB/MATLABProtobufGenerator.java
+++ b/src/api/MATLAB/MATLABProtobufGenerator.java
@@ -32,7 +32,8 @@ public class MATLABProtobufGenerator
 															   "getInitializationErrorString", "getClass", "clear", "clearField", "hasField",
 															   "clone", "build", "buildPartial", "mergeFrom", "isInitialized", "mergeTest", 
 															   "mergeUnknownFields", "findInitializationErrors", "mergeDelimitedFrom",
-															   "wait", "equals", "toString", "hashCode", "notify", "notifyAll");
+															   "wait", "equals", "toString", "hashCode", "notify", "notifyAll",
+															   "getOneofFieldDescriptor", "clearOneof", "hasOneof");
 	
 	private static final String numListToArrayFcn = "com.aphysci.gravity.matlab.MATLABGravitySubscriber.convertNumberListToDoubleArray";
 	private static final String numArrayToListFcn = "com.aphysci.gravity.matlab.MATLABGravitySubscriber.convertNumberArrayToNumberList";


### PR DESCRIPTION
Modified MATLABProtobufGenerator to ignore some of the methods specific to Oneof that are not required by the MATLAB interface.