### PR TITLE
Fixed improper deallocation of arrays (Issue #60)

### DIFF
--- a/src/api/cpp/FutureResponse.cpp
+++ b/src/api/cpp/FutureResponse.cpp
@@ -51,7 +51,7 @@ void FutureResponse::setResponse(const GravityDataProduct& response)
 	char* data = new char[size];
 	response.serializeToArray(data);
 	setData(data, size);
-	delete data;
+	delete [] data;
 }
 
 } /* namespace gravity */

--- a/src/api/cpp/GravityNode.cpp
+++ b/src/api/cpp/GravityNode.cpp
@@ -2245,7 +2245,7 @@ GravityReturnCode GravityNode::sendFutureResponse(const FutureResponse& futureRe
 	response.setComponentId(componentID);
 	response.setDomain(myDomain);
 	sendGravityDataProduct(requestManagerRepSWL.socket, response, ZMQ_DONTWAIT);
-	delete bytes;
+	delete [] bytes;
 
 	// Get results back from GravityRequestManager
 	int ret = readIntMessage(requestManagerRepSWL.socket);


### PR DESCRIPTION
Fixed improper deallocation of arrays that were using delete rather than delete[]. Issue #60.