### PR TITLE
Issue 97

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ lib/**
 VERSION.txt
 config.h
 config.status
+tags
+.tags
+

--- a/src/api/cpp/GravityNode.cpp
+++ b/src/api/cpp/GravityNode.cpp
@@ -27,7 +27,6 @@
 #include <iostream>
 #include <pthread.h>
 #include <assert.h>
-#include <boost/assign.hpp>
 #ifdef WIN32
 #include <winsock2.h>
 #include <WinBase.h>
@@ -2441,19 +2440,20 @@ std::string GravityNode::getComponentID()
 }
 
 static std::map<GravityReturnCode,std::string> code_strings =
-  boost::assign::map_list_of
-    (GravityReturnCodes::SUCCESS, "SUCCESS")
-    (GravityReturnCodes::FAILURE, "FAILURE")
-    (GravityReturnCodes::NO_SERVICE_DIRECTORY, "NO_SERVICE_DIRECTORY")
-    (GravityReturnCodes::REQUEST_TIMEOUT, "REQUEST_TIMEOUT")
-    (GravityReturnCodes::DUPLICATE, "DUPLICATE")
-    (GravityReturnCodes::REGISTRATION_CONFLICT, "REGISTRATION_CONFLICT")
-    (GravityReturnCodes::NOT_REGISTERED, "NOT_REGISTERED")
-    (GravityReturnCodes::NO_SUCH_SERVICE, "NO_SUCH_SERVICE")
-    (GravityReturnCodes::LINK_ERROR, "LINK_ERROR")
-    (GravityReturnCodes::INTERRUPTED, "INTERRUPTED")
-    (GravityReturnCodes::NO_SERVICE_PROVIDER, "NO_SERVICE_PROVIDER")
-    (GravityReturnCodes::NO_PORTS_AVAILABLE, "NO_PORTS_AVAILABLE");
+  {
+    {GravityReturnCodes::SUCCESS, "SUCCESS"},
+    {GravityReturnCodes::FAILURE, "FAILURE"},
+    {GravityReturnCodes::NO_SERVICE_DIRECTORY, "NO_SERVICE_DIRECTORY"},
+    {GravityReturnCodes::REQUEST_TIMEOUT, "REQUEST_TIMEOUT"},
+    {GravityReturnCodes::DUPLICATE, "DUPLICATE"},
+    {GravityReturnCodes::REGISTRATION_CONFLICT, "REGISTRATION_CONFLICT"},
+    {GravityReturnCodes::NOT_REGISTERED, "NOT_REGISTERED"},
+    {GravityReturnCodes::NO_SUCH_SERVICE, "NO_SUCH_SERVICE"},
+    {GravityReturnCodes::LINK_ERROR, "LINK_ERROR"},
+    {GravityReturnCodes::INTERRUPTED, "INTERRUPTED"},
+    {GravityReturnCodes::NO_SERVICE_PROVIDER, "NO_SERVICE_PROVIDER"},
+    {GravityReturnCodes::NO_PORTS_AVAILABLE, "NO_PORTS_AVAILABLE"}
+  };
 
 string GravityNode::getCodeString(GravityReturnCode code) {
     std::string s;

--- a/src/api/cpp/Utility.cpp
+++ b/src/api/cpp/Utility.cpp
@@ -222,4 +222,14 @@ GRAVITY_API unsigned int sleep(int milliseconds)
 #endif
 }
 
+GRAVITY_API void replaceAll(std::string& target, const std::string& oldValue, const std::string& newValue)
+{
+  auto pos = target.find(oldValue);
+  while(pos != std::string::npos) {
+    target.replace(pos, oldValue.size(), newValue);
+    pos = target.find(oldValue);
+  }
+}
+
+
 }

--- a/src/api/cpp/Utility.h
+++ b/src/api/cpp/Utility.h
@@ -18,6 +18,7 @@
 
 #ifndef GRAVITY_UTILITY_H__
 #define GRAVITY_UTILITY_H__
+#include <cstdint>
 #include <string>
 
 #ifdef _WIN32
@@ -33,8 +34,6 @@
 #else
 #define GRAVITY_API
 #endif
-
-#include <stdint.h>
 
 namespace gravity {
 
@@ -52,6 +51,7 @@ GRAVITY_API uint64_t getCurrentTime();  ///< Utility method to get the current s
 GRAVITY_API unsigned int sleep(int milliseconds);
 GRAVITY_API std::string& trim(std::string& s, const std::string& delimiters = " \f\n\r\t\v" );
 
+GRAVITY_API void replaceAll(std::string& target, const std::string& oldValue, const std::string& newValue);
 
 }
 

--- a/src/components/cpp/ServiceDirectory/ServiceDirectory.cpp
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectory.cpp
@@ -29,6 +29,7 @@
 #include "ServiceDirectorySynchronizer.h"
 #include "GravityLogger.h"
 #include "CommUtil.h"
+#include "Utility.h"
 
 #include "protobuf/ServiceDirectoryMapPB.pb.h"
 #include "protobuf/ServiceDirectoryRegistrationPB.pb.h"
@@ -42,7 +43,6 @@
 //#include "protobuf/ServiceDirectoryBroadcastSetup.pb.h"
 
 #include <zmq.h>
-#include <boost/algorithm/string.hpp>
 
 #include <stdlib.h>
 #include <string>
@@ -182,7 +182,7 @@ void ServiceDirectory::start()
     gn.init("ServiceDirectory");
 
     std::string sdURL = gn.getStringParam("ServiceDirectoryUrl", "tcp://*:5555");
-    boost::replace_all(sdURL, "localhost", "127.0.0.1");
+    replaceAll(sdURL, "localhost", "127.0.0.1");
     Log::message("running with SD connection string: %s", sdURL.c_str());
 
 	bool broadcastEnabled = gn.getBoolParam("BroadcastEnabled",false);


### PR DESCRIPTION
Fixes #97, but doesn't change any autoconf scripts.
To compile, use:

    CPPFLAGS="-std=c++11" ./configure (normal gravity switches)

I took a crack at making configure.ac able to enforce C++11, to no avail.

I'm working on a set of cmake files for gravity instead.  See issue #46 