### PR TITLE
Fix #97, but with no changes to autoconf/configure.

### DIFF
--- a/src/api/cpp/Utility.cpp
+++ b/src/api/cpp/Utility.cpp
@@ -92,6 +92,16 @@ GRAVITY_API std::string& trim(
   return trim_left_inplace( trim_right_inplace( s, delimiters ), delimiters );
 }
 
+GRAVITY_API void replaceAll(std::string& target, const std::string& oldValue, const std::string& newValue)
+{
+    auto pos = target.find(oldValue);
+    while(pos != std::string::npos) {
+      target.replace(pos, oldValue.size(), newValue);
+      pos = target.find(oldValue);
+    }
+}
+
+
 // OS
 GRAVITY_API bool IsValidFilename(const std::string filename)
 {

--- a/src/api/cpp/Utility.h
+++ b/src/api/cpp/Utility.h
@@ -56,6 +56,14 @@ GRAVITY_API double StringToDouble(std::string str, int default_value); ///< Retu
  * \return also return a reference to the modified string
  */
 GRAVITY_API std::string& trim(std::string& s, const std::string& delimiters = " \f\n\r\t\v" );
+
+/**
+ * Replace substrings in a string.
+ * \param target string that will be modified
+ * \param oldValue source substring to search for in target
+ * \param newValue replacement substring
+ */
+GRAVITY_API void replaceAll(std::string& target, const std::string& oldValue, const std::string& newValue);
 /** @} */ //String conversion and helper functions
 
 GRAVITY_API bool IsValidFilename(const std::string filename); ///< Return if filename is valid, which is OS dependent

--- a/src/components/cpp/ServiceDirectory/ServiceDirectory.cpp
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectory.cpp
@@ -42,7 +42,6 @@
 //#include "protobuf/ServiceDirectoryBroadcastSetup.pb.h"
 
 #include <zmq.h>
-#include <boost/algorithm/string.hpp>
 
 #include <stdlib.h>
 #include <string>
@@ -178,12 +177,12 @@ void ServiceDirectory::start()
 		return;
 	}
 	
-    registeredPublishersReady = registeredPublishersProcessed = false;
-    gn.init("ServiceDirectory");
+  registeredPublishersReady = registeredPublishersProcessed = false;
+  gn.init("ServiceDirectory");
 
-    std::string sdURL = gn.getStringParam("ServiceDirectoryUrl", "tcp://*:5555");
-    boost::replace_all(sdURL, "localhost", "127.0.0.1");
-    Log::message("running with SD connection string: %s", sdURL.c_str());
+  std::string sdURL = gn.getStringParam("ServiceDirectoryUrl", "tcp://*:5555");
+  replaceAll(sdURL, "localhost", "127.0.0.1");
+  Log::message("running with SD connection string: %s", sdURL.c_str());
 
 	bool broadcastEnabled = gn.getBoolParam("BroadcastEnabled",false);
 


### PR DESCRIPTION
This change replaces boost/algorithm/string/ with a std::string equivalent.  Requires compiling with -`std=c++11`

    CPPFLAGS="-std=c++11" ./configure <standard configure  switches>