### PR TITLE
Issue 143 (Consider updating Log API for Python and Java)

### DIFF
--- a/src/api/java/cpp_makefile.in
+++ b/src/api/java/cpp_makefile.in
@@ -101,9 +101,11 @@ endif
 
 all: $(LIB_NAME).$(LIB_EXT)
 
+src/cpp/gravity_wrap.$(OBJ_EXT): CFLAGS+=-fno-strict-aliasing
+
 %.$(OBJ_EXT): %.cpp
 	@echo $(CC) $<
-	$(warning COMPILE_FLAG is $(COMPILE_FLAG))
+	$(warning CFLAGS = $(CFLAGS))
 	@$(CC) $(COMPILE_FLAG) $(OS_SPECIFIC_FLAGS) $(CFLAGS) $(COUTPUT_FLAG)$@ $<
 
 $(LIB_NAME).$(LIB_EXT): $(CPP_OBJ)

--- a/src/api/java/src/swig/gravity.i
+++ b/src/api/java/src/swig/gravity.i
@@ -189,7 +189,9 @@ INOUT_TYPEMAP(int64_t, jlong, long, Long, "[Ljava/lang/Long;", jlongArray);
 %typemap(javadirectorin) int64_t "$jniinput"
 %typemap(javadirectorout) int64_t "$javacall"
 //%typemap(directorout) int64_t {}
-%typemap(directorin,descriptor="J") int64_t {}
+%typemap(directorin,descriptor="J") int64_t { 
+  $input = $1;
+}
 %typemap(javaout) int64_t {
     return $jnicall;
   }

--- a/src/api/java/src/swig/gravity.i
+++ b/src/api/java/src/swig/gravity.i
@@ -180,6 +180,8 @@ INOUT_TYPEMAP(int64_t, jlong, long, Long, "[Ljava/lang/Long;", jlongArray);
 {
     INOUT = ((int64_t *) jenv->GetLongArrayElements(jINOUT, 0))[0];
     (jenv)->DeleteLocalRef(jINOUT);
+    
+    $result = (int64_t)$input;
 }
 
 %typemap(jtype) int64_t "long";

--- a/src/api/java/src/swig/gravitynode.i
+++ b/src/api/java/src/swig/gravitynode.i
@@ -16,7 +16,6 @@
  **
  */
 
-
 %typemap(javaimports) gravity::GravityNode %{
 import com.aphysci.gravity.GravityDataProduct;
 import com.aphysci.gravity.FutureResponse;
@@ -56,6 +55,7 @@ namespace gravity {
 	   virtual std::shared_ptr<gravity::GravityDataProduct> request(const std::string serviceID, char *BYTE, int byteLength);
 	};
 
+    // return type changed to int64_t on these to pick up typemap for deallocation of the int64_t ref value (INOUT)
 	class CPPGravityHeartbeatListener
 	{
 	public:

--- a/src/api/java/src/swig/logger.i
+++ b/src/api/java/src/swig/logger.i
@@ -69,7 +69,8 @@ public:
  * in the log message that may be interpretted as a format character.
  */
 %typemap(in) (const char* format, const char* message) {
-    $1 = "%s";
+    $1 = (char *) malloc(4*sizeof(char *));
+    sprintf($1, "%%s");
     $2 = (char *)jenv->GetStringUTFChars($input, 0);
     if (!$2) return ;
 }
@@ -77,6 +78,7 @@ public:
 %typemap(jstype) (const char* format, const char* message) "String"
 %typemap(javain) (const char* format, const char* message) "$javainput"
 %typemap(freearg) (const char* format, const char* message) {
+    free((char *) $1);
     if ($2) jenv->ReleaseStringUTFChars($input, (const char *)$2);
 }
     static void fatal(const char* format, const char* message);

--- a/src/api/java/src/swig/logger.i
+++ b/src/api/java/src/swig/logger.i
@@ -63,12 +63,28 @@ public:
 
     static void CloseLoggers();
 
-    static void fatal(const char* message, ...);
-    static void critical(const char* message, ...);
-    static void warning(const char* message, ...);
-    static void message(const char* message, ...);
-    static void debug(const char* message, ...);
-    static void trace(const char* message, ...);
+/**
+ * For all of the log methods, only take a single string, but provide that string to the C++
+ * call as the second arg with "%s" as the format string.  This prevents issues with any text 
+ * in the log message that may be interpretted as a format character.
+ */
+%typemap(in) (const char* format, const char* message) {
+    $1 = "%s";
+    $2 = (char *)jenv->GetStringUTFChars($input, 0);
+    if (!$2) return ;
+}
+%typemap(jtype) (const char* format, const char* message) "String"
+%typemap(jstype) (const char* format, const char* message) "String"
+%typemap(javain) (const char* format, const char* message) "$javainput"
+%typemap(freearg) (const char* format, const char* message) {
+    if ($2) jenv->ReleaseStringUTFChars($input, (const char *)$2);
+}
+    static void fatal(const char* format, const char* message);
+    static void critical(const char* format, const char* message);
+    static void warning(const char* format, const char* message);
+    static void message(const char* format, const char* message);
+    static void debug(const char* format, const char* message);
+    static void trace(const char* format, const char* message);
 
 };
 

--- a/src/api/python/src/swig/gravitylogger.i
+++ b/src/api/python/src/swig/gravitylogger.i
@@ -55,12 +55,29 @@ namespace gravity{
 	
 	    static void CloseLoggers();
 	
-	    static void fatal(const char* message, ...);
-	    static void critical(const char* message, ...);
-	    static void warning(const char* message, ...);
-	    static void message(const char* message, ...);
-	    static void debug(const char* message, ...);
-	    static void trace(const char* message, ...);
-	
+%typemap(in) (const char* format, const char* message) 
+  (int res, char *buf = 0, int alloc = 0)
+{ 
+  $1 = (char *) malloc(4*sizeof(char *));
+  sprintf($1, "%%s");
+  res = SWIG_AsCharPtrAndSize($input, &buf, NULL, &alloc);
+  if (!SWIG_IsOK(res)) {
+    %argument_fail(res,"$type",$symname, $argnum);
+  }
+  $2 = %reinterpret_cast(buf, $2_ltype); 
+}
+
+%typemap(freearg) (const char* format, const char* message)
+{
+  free((char *) $1);
+  if (alloc$argnum == SWIG_NEWOBJ) delete[] buf$argnum;
+}
+
+        static void fatal(const char* format, const char* message);
+        static void critical(const char* format, const char* message);
+        static void warning(const char* format, const char* message);
+        static void message(const char* format, const char* message);
+        static void debug(const char* format, const char* message);
+        static void trace(const char* format, const char* message);
 	};
 };


### PR DESCRIPTION
Update the Java and Python logging interfaces to only accept a single string argument to all log calls (i.e. debug, message, warning, etc).  These previously accepted multiple arguments, but did not actually use any arguments after the first, so even though this is technically an API change, this does not effect backwards compatibility.   

This means you can now have log statements like:
> Log.warning("an int spec: %d");

and it will log the string correctly (without trying to substitute):

> [04/27/20 10:36:45.250944 JavaProtobufDataProductPublisher-WARNING] an int spec: %d

I also made a few changes to clean up the warnings that were generated when compiling the auto-generated gravity_wrap.cpp for the Java build with gcc.  

Fixes #143. 