### PR TITLE
Add setReceiveTimestamp to matlab and java GravityDataProduct

### DIFF
--- a/src/api/MATLAB/GravityDataProduct.m
+++ b/src/api/MATLAB/GravityDataProduct.m
@@ -82,6 +82,10 @@ classdef GravityDataProduct < handle
 		
 		function setComponentID(this, componentID)
 			this.gravityDataProduct.setComponentID(componentID);
-	    end
+        end
+        
+        function setReceivedTimestamp(this, receivedTimestamp)
+			this.gravityDataProduct.setReceivedTimestamp(receivedTimestamp);
+        end        
     end
 end

--- a/src/api/java/src/java/com/aphysci/gravity/GravityDataProduct.java
+++ b/src/api/java/src/java/com/aphysci/gravity/GravityDataProduct.java
@@ -82,7 +82,6 @@ public class GravityDataProduct {
      * Method to set the timestamp associated with receipt of data product
      * @param ts timestamp (epoch microseconds) for this GravityDataProduct's receipt timestamp
      */
-  
     public void setReceivedTimestamp(long ts) {
 		gdp.setReceivedTimestamp(ts);		
     }
@@ -258,7 +257,8 @@ public class GravityDataProduct {
 	{
 		return gdp.getFutureResponse();
 	}
-		/**
+
+	/**
 	 * Method to get the boolean indication of whether this is a cached data product.
 	 * Unless specified otherwise, publishers cache the last data product sent to 
 	 * send to new subscribers. This flag indicates whether the DP is new or if it was 

--- a/src/api/java/src/java/com/aphysci/gravity/GravityDataProduct.java
+++ b/src/api/java/src/java/com/aphysci/gravity/GravityDataProduct.java
@@ -77,6 +77,15 @@ public class GravityDataProduct {
 		}
     	return receivedTimestamp;
     }
+    
+    /**
+     * Method to set the timestamp associated with receipt of data product
+     * @param ts timestamp (epoch microseconds) for this GravityDataProduct's receipt timestamp
+     */
+  
+    public void setReceivedTimestamp(long ts) {
+		gdp.setReceivedTimestamp(ts);		
+    }
 
     /**
      * Method to set the timestamp for this GravityDataProduct


### PR DESCRIPTION
To be consistent with the C++ api, added a setReceiveTimestamp method to both GravityDataProduct.m and GravityDataProduct.java.