### PR TITLE
Don't print invalid characters on a yyparse error

### DIFF
--- a/src/keyvalue_parser/keyvalue.l
+++ b/src/keyvalue_parser/keyvalue.l
@@ -38,7 +38,7 @@ const char *g_section_name;
 extern char *g_current_section;
 
 extern int yyparse(void* pbuckets);
-extern void yyerror(const char *s);
+extern void yyerror(void *p, const char *s);
 extern int yydebug;
 
 
@@ -100,4 +100,4 @@ int keyvalue_parse_params(const char* param_fn, const char * const section_list[
 \[[ ]*[A-Za-z0-9\_\.\@\/;]+[ ]*\]                       { yylval = yytext; return(SECTION); }
 $[A-Za-z0-9\_\.\@;]+                                    { yylval = yytext+1; return(VAR); }
 [ \t]+                                                  { }
-.                                                       { printf("%s ", yytext ); yyerror("invalid character"); return(ERROR);}
+.                                                       { printf("%s ", yytext ); yyerror(NULL, "invalid character"); return(ERROR);}


### PR DESCRIPTION
When testing an unterminated quoted string it caught the error but it printed two error messages, one with garbage characters.  I believe if those characters didn't happen to lead to a terminator it would crash as seen in #160 