### PR TITLE
Allow for empty ini file strings to be added to the keyvalue map

### DIFF
--- a/src/api/cpp/GravityConfigParser.cpp
+++ b/src/api/cpp/GravityConfigParser.cpp
@@ -52,11 +52,8 @@ void GravityConfigParser::ParseConfigFile(const char* config_filename)
 			i != keys.end(); i++)
 	{
 		std::string value = parser.GetString(*i);
-		if(value != "")
-        {
-            std::string key_lower = StringCopyToLowerCase(*i);
-			key_value_map[key_lower] = value;
-        }
+        std::string key_lower = StringCopyToLowerCase(*i);
+	    key_value_map[key_lower] = value;
 	}
 	return;
 }


### PR DESCRIPTION
Fix for #153 