### PR TITLE
Fixes #173. Fixes #174. Fixes #175.

### DIFF
--- a/src/api/cpp/GravityNode.cpp
+++ b/src/api/cpp/GravityNode.cpp
@@ -1642,15 +1642,15 @@ GravityReturnCode GravityNode::publish(const GravityDataProduct& dataProduct, st
 			dataProduct.setTimestamp(timestamp);
 		}
 
-		// Set registration time
-		dataProduct.setRegistrationTime(dataRegistrationTimeMap[dataProductID]);
-
 		//set Component ID
 		dataProduct.setComponentId(componentID);
 
 		//set Domain
 		dataProduct.setDomain(myDomain);
 	}
+
+    // Set registration time
+    dataProduct.setRegistrationTime(dataRegistrationTimeMap[dataProductID]);
 
 	// Send subscription details
     publishManagerPublishSWL.lock.Lock();
@@ -2337,7 +2337,7 @@ GravityReturnCode GravityNode::unregisterHeartbeatListener(string componentID, s
 
 GravityReturnCode GravityNode::registerRelay(string dataProductID, const GravitySubscriber& subscriber, bool localOnly, GravityTransportType transportType)
 {
-	return registerRelay(dataProductID, subscriber, localOnly, transportType, defaultCacheLastSentDataprodut);
+	return registerRelay(dataProductID, subscriber, localOnly, transportType, false);
 }
 
 GravityReturnCode GravityNode::registerRelay(string dataProductID, const GravitySubscriber& subscriber, bool localOnly, GravityTransportType transportType, bool cacheLastValue)
@@ -2346,10 +2346,14 @@ GravityReturnCode GravityNode::registerRelay(string dataProductID, const Gravity
     {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
+    if (cacheLastValue)
+    {
+        Log::warning("Using a Relay with cacheLastValue=true is atypical and may result in duplicate messages received by subscribers during the relay start/stop transition");
+    }
 	GravityReturnCode ret = registerDataProductInternal(dataProductID, transportType, cacheLastValue, true, localOnly);
 	if (ret != GravityReturnCodes::SUCCESS)
 		return ret;
-	return subscribe(dataProductID, subscriber);
+	return subscribe(dataProductID, subscriber, "", "", false);
 }
 
 GravityReturnCode GravityNode::unregisterRelay(std::string dataProductID, const GravitySubscriber& subscriber)

--- a/src/api/cpp/GravityNode.h
+++ b/src/api/cpp/GravityNode.h
@@ -491,7 +491,8 @@ public:
      * \param subscriber object that implements the GravitySubscriber interface and will be notified of data availability
      * \param localOnly specifies whether the registered relay will provide data to their own host only, or components on any host looking for this dataProductID
      * \param transportType transport type (e.g. 'tcp', 'ipc')
-     * \param cacheLastValue flag used to signify whether or not GravityNode will cache the last sent value for a published dataproduct
+     * \param cacheLastValue flag used to signify whether or not GravityNode will cache the last sent value for a published dataproduct. Note that using a Relay
+     *                       with cachedLastValue=true is atypical and may result in duplicate messages received by subscribers during the relay start/stop transition
      * \return success flag
      */
     GRAVITY_API GravityReturnCode registerRelay(std::string dataProductID, const GravitySubscriber& subscriber, bool localOnly, GravityTransportType transportType, bool cacheLastValue);

--- a/src/api/cpp/Utility.cpp
+++ b/src/api/cpp/Utility.cpp
@@ -228,6 +228,8 @@ GRAVITY_API uint64_t getCurrentTime()
 
 GRAVITY_API unsigned int sleep(int milliseconds)
 {
+	// If sleep time < 0, set it to 0
+	milliseconds = std::max(0, milliseconds);
 #ifdef WIN32
 	Sleep(milliseconds);
 	return 0;

--- a/src/components/cpp/ServiceDirectory/ServiceDirectory.cpp
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectory.cpp
@@ -74,8 +74,8 @@ static void* registration(void* regData)
     gravity::GravityNode* gn = ((RegistrationData*)regData)->node;
     gravity::GravityServiceProvider* provider = ((RegistrationData*)regData)->provider;
 
-    // Register data product for reporting changes to registered publishers
-    gn->registerDataProduct(REGISTERED_PUBLISHERS, gravity::GravityTransportTypes::TCP);
+    // Register data product for reporting changes to registered publishers (always cache this one)
+    gn->registerDataProduct(REGISTERED_PUBLISHERS, gravity::GravityTransportTypes::TCP, true);
 
     // Register the data product for domain broadcast details
 	gn->registerDataProduct("ServiceDirectory_DomainDetails", gravity::GravityTransportTypes::TCP);


### PR DESCRIPTION
Always cache ServiceDirectory's registered publisher message. Negative sleep duration treated as 0. Properly track publisher socket for Gravity relay components. Fixes #173. Fixes #174. Fixes #175.