### PR TITLE
Fix dodgy #includes

### DIFF
--- a/src/api/cpp/GravityNode.cpp
+++ b/src/api/cpp/GravityNode.cpp
@@ -36,7 +36,7 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 #include <netdb.h>
 #endif
 #include <sstream>

--- a/src/api/cpp/Utility.cpp
+++ b/src/api/cpp/Utility.cpp
@@ -35,7 +35,7 @@ struct timespec
 #endif
 #else
 #include <stdint.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 #endif
 
 namespace gravity {

--- a/src/components/cpp/Playback/FileReader.cpp
+++ b/src/components/cpp/Playback/FileReader.cpp
@@ -23,7 +23,7 @@
 #include <iostream>
 #include <mutex>
 #ifndef WIN32
-#include <sys/unistd.h>
+#include <unistd.h>
 #endif
 
 using namespace std;

--- a/src/components/cpp/Playback/FileReplay.cpp
+++ b/src/components/cpp/Playback/FileReplay.cpp
@@ -25,7 +25,7 @@
 #include <string>
 #include <thread>
 #ifndef WIN32
-#include <sys/unistd.h>
+#include <unistd.h>
 #endif
 
 using namespace std;

--- a/src/components/cpp/ServiceDirectory/ServiceDirectoryUDPBroadcaster.h
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectoryUDPBroadcaster.h
@@ -33,6 +33,7 @@
 #include <WinBase.h>
 #include <Windows.h>
 #else
+#include <sys/types.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <unistd.h>


### PR DESCRIPTION
Found these issues while cross-compiling

Missing sys/types.h in one file

should be <unistd.h> not <sys/unistd.h>