### PR TITLE
Fix #180 - failure to load libraries closes MATLAB

### DIFF
--- a/src/api/java/src/swig/gravity.i
+++ b/src/api/java/src/swig/gravity.i
@@ -44,23 +44,17 @@
     try {
         System.loadLibrary("zmq");
     } catch (UnsatisfiedLinkError unused) {
-	    try {
-	        System.loadLibrary("libzmq");
-	    } catch (UnsatisfiedLinkError e) {
-	      System.err.println("Native code library failed to load. Tried both zmq and libzmq.\n" + e);
-	      System.exit(1);
-	    }
+        System.loadLibrary("libzmq");
+        // Unhandled exceptions will bubble up, so that MATLAB (e.g.) can catch them
+        // If exiting is the desired behavior, the using application can catch and exit
     }
 
     try {
         System.loadLibrary("gravity_wrap");
     } catch (UnsatisfiedLinkError unused) {
-	    try {
-	        System.loadLibrary("libgravity_wrap");
-	    } catch (UnsatisfiedLinkError e) {
-	      System.err.println("Native code library failed to load. Tried both gravity_wrap and libgravity_wrap.\n" + e);
-	      System.exit(1);
-	    }
+        System.loadLibrary("libgravity_wrap");
+        // Unhandled exceptions will bubble up, so that MATLAB (e.g.) can catch them
+        // If exiting is the desired behavior, the using application can catch and exit
     }
   }
 %}


### PR DESCRIPTION
I have neither compiled nor tested this, as I am not a user of the MATLAB/Java bindings.  Making the fix for Brendan Nichols - I think it is trivial enough it's probably OK to inspect and merge, but others may feel differently.

Closes #180.