### PR TITLE
Reformat C++ sources with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,207 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Allman
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: NextLine
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
+PPIndentWidth:   -1
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  false
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    Never
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/src/api/DotNet/gravity_plugin/src/gravity_wrapper.cpp
+++ b/src/api/DotNet/gravity_plugin/src/gravity_wrapper.cpp
@@ -7,7 +7,6 @@
 #include <Utility.h>
 #include "gravitywrapper_export.h"
 
-
 #ifdef __cplusplus
 extern "C"
 {
@@ -27,8 +26,10 @@ extern "C"
         };
 
         typedef void (*gravityinterop_subscriptionFilled_cb)(gravityinterop_dataproduct**, int);
-        typedef void (*gravityinterop_requestFilled_cb)(const char* serviceId, const char* requestId, gravityinterop_dataproduct* dp);
-        typedef gravityinterop_dataproduct* (*gravityinterop_servicerequest_cb)(const char* serviceId, gravityinterop_dataproduct* dp);
+        typedef void (*gravityinterop_requestFilled_cb)(const char* serviceId, const char* requestId,
+                                                        gravityinterop_dataproduct* dp);
+        typedef gravityinterop_dataproduct* (*gravityinterop_servicerequest_cb)(const char* serviceId,
+                                                                                gravityinterop_dataproduct* dp);
         typedef void (*gravityinterop_OnDebug_cb)(const char* message, int size);
         gravityinterop_OnDebug_cb g_gi_onDebugCb;
         std::mutex g_onDebugCbMutex;
@@ -61,17 +62,19 @@ extern "C"
         class SimpleGravityServiceProvider : public gravity::GravityServiceProvider
         {
         public:
-            SimpleGravityServiceProvider(gravityinterop_servicerequest_cb onRequest) : m_onRequest(onRequest)
-            {}
+            SimpleGravityServiceProvider(gravityinterop_servicerequest_cb onRequest) : m_onRequest(onRequest) {}
 
-            virtual std::shared_ptr<gravity::GravityDataProduct> request(const std::string serviceID, const gravity::GravityDataProduct& dataProduct)
+            virtual std::shared_ptr<gravity::GravityDataProduct> request(const std::string serviceID,
+                                                                         const gravity::GravityDataProduct& dataProduct)
             {
                 LogDebug("request", "Gravity request");
 
                 std::lock_guard<std::mutex> lck(m_onRequestMutex);
                 if (m_onRequest != nullptr)
                 {
-                    auto gi_dp = m_onRequest(serviceID.c_str(), new gravityinterop_dataproduct{ std::make_shared<gravity::GravityDataProduct>(dataProduct) });
+                    auto gi_dp = m_onRequest(
+                        serviceID.c_str(),
+                        new gravityinterop_dataproduct{std::make_shared<gravity::GravityDataProduct>(dataProduct)});
                     return gi_dp->dp;
                 }
                 return nullptr;
@@ -91,19 +94,18 @@ extern "C"
         class SimpleGravityRequestor : public gravity::GravityRequestor
         {
         public:
-            SimpleGravityRequestor(gravityinterop_requestFilled_cb cb) : m_onFilled(cb)
-            {
-                    
-            }
+            SimpleGravityRequestor(gravityinterop_requestFilled_cb cb) : m_onFilled(cb) {}
 
-            virtual void requestFilled(std::string serviceId, std::string requestId, const gravity::GravityDataProduct& gdp)
+            virtual void requestFilled(std::string serviceId, std::string requestId,
+                                       const gravity::GravityDataProduct& gdp)
             {
                 LogDebug("requestFilled", "Responded");
 
                 std::lock_guard<std::mutex> lck(m_onFilledcbMutex);
                 if (m_onFilled != nullptr)
                 {
-                    m_onFilled(serviceId.c_str(), requestId.c_str(), new gravityinterop_dataproduct{ std::make_shared<gravity::GravityDataProduct>(gdp) });
+                    m_onFilled(serviceId.c_str(), requestId.c_str(),
+                               new gravityinterop_dataproduct{std::make_shared<gravity::GravityDataProduct>(gdp)});
                 }
             }
 
@@ -121,11 +123,10 @@ extern "C"
         class SimpleGravitySubscriber : public gravity::GravitySubscriber
         {
         public:
-            SimpleGravitySubscriber(gravityinterop_subscriptionFilled_cb onFilled) : m_onFilled(onFilled)
-            {
-            }
+            SimpleGravitySubscriber(gravityinterop_subscriptionFilled_cb onFilled) : m_onFilled(onFilled) {}
 
-            virtual void subscriptionFilled(const std::vector< std::shared_ptr<gravity::GravityDataProduct> >& dataProducts)
+            virtual void subscriptionFilled(
+                const std::vector<std::shared_ptr<gravity::GravityDataProduct> >& dataProducts)
             {
                 std::ostringstream oss;
                 oss << "count: " << dataProducts.size();
@@ -135,9 +136,11 @@ extern "C"
                 std::lock_guard<std::mutex> lck(m_onFilledcbMutex);
                 if (m_onFilled != nullptr)
                 {
-                    for (std::vector< std::shared_ptr<gravity::GravityDataProduct> >::const_iterator i = dataProducts.begin(); i != dataProducts.end(); i++)
+                    for (std::vector<std::shared_ptr<gravity::GravityDataProduct> >::const_iterator i =
+                             dataProducts.begin();
+                         i != dataProducts.end(); i++)
                     {
-                        gi_dps.push_back(new gravityinterop_dataproduct{ *i });
+                        gi_dps.push_back(new gravityinterop_dataproduct{*i});
                     }
                     m_onFilled(&gi_dps[0], gi_dps.size());
                 }
@@ -148,11 +151,10 @@ extern "C"
                 std::lock_guard<std::mutex> lck(m_onFilledcbMutex);
                 m_onFilled = onFilled;
             }
-       
+
         protected:
             gravityinterop_subscriptionFilled_cb m_onFilled;
             std::mutex m_onFilledcbMutex;
-
         };
 
         struct gravityinterop_subscriber
@@ -177,15 +179,14 @@ extern "C"
             auto cwd = std::filesystem::current_path();
             LogDebug("GravityInit", cwd.string().c_str());
 
-            return new gravityinterop_node{ node };
+            return new gravityinterop_node{node};
         }
 
-        GRAVITYWRAPPER_EXPORT void gravity_delete_node(gravityinterop_node* gi_node)
-        {
-            delete gi_node;
-        }
+        GRAVITYWRAPPER_EXPORT void gravity_delete_node(gravityinterop_node* gi_node) { delete gi_node; }
 
-        GRAVITYWRAPPER_EXPORT void gravity_register_serviceprovider(gravityinterop_node* gi_node, const char* serviceId, gravity::GravityTransportType type, gravityinterop_serviceprovider* sp)
+        GRAVITYWRAPPER_EXPORT void gravity_register_serviceprovider(gravityinterop_node* gi_node, const char* serviceId,
+                                                                    gravity::GravityTransportType type,
+                                                                    gravityinterop_serviceprovider* sp)
         {
             gi_node->node->registerService(serviceId, type, *sp->provider);
         }
@@ -193,36 +194,40 @@ extern "C"
         GRAVITYWRAPPER_EXPORT gravityinterop_requestor* gravity_create_requestor()
         {
             auto requestor = std::make_shared<SimpleGravityRequestor>(nullptr);
-            return new gravityinterop_requestor{ requestor };
+            return new gravityinterop_requestor{requestor};
         }
 
-        GRAVITYWRAPPER_EXPORT void gravity_set_requestor_callback(gravityinterop_requestor* gi_requestor, gravityinterop_requestFilled_cb cb)
+        GRAVITYWRAPPER_EXPORT void gravity_set_requestor_callback(gravityinterop_requestor* gi_requestor,
+                                                                  gravityinterop_requestFilled_cb cb)
         {
             gi_requestor->requestor->setRequestorCallback(cb);
         }
 
-        GRAVITYWRAPPER_EXPORT void gravity_delete_requestor(gravityinterop_requestor* gi_req)
-        {
-            delete gi_req;
-        }
+        GRAVITYWRAPPER_EXPORT void gravity_delete_requestor(gravityinterop_requestor* gi_req) { delete gi_req; }
 
-        GRAVITYWRAPPER_EXPORT int gravity_request_async(gravityinterop_node* gi_node, const char* servName, gravityinterop_dataproduct* gi_request_dp, gravityinterop_requestor* gi_requestor, const char* requestId)
+        GRAVITYWRAPPER_EXPORT int gravity_request_async(gravityinterop_node* gi_node, const char* servName,
+                                                        gravityinterop_dataproduct* gi_request_dp,
+                                                        gravityinterop_requestor* gi_requestor, const char* requestId)
         {
             return gi_node->node->request(servName, *gi_request_dp->dp, *gi_requestor->requestor, requestId);
         }
 
-        GRAVITYWRAPPER_EXPORT gravityinterop_dataproduct* gravity_request(gravityinterop_node* gi_node, const char* servName, gravityinterop_dataproduct* gi_request_dp, int timeoutMs)
+        GRAVITYWRAPPER_EXPORT gravityinterop_dataproduct* gravity_request(gravityinterop_node* gi_node,
+                                                                          const char* servName,
+                                                                          gravityinterop_dataproduct* gi_request_dp,
+                                                                          int timeoutMs)
         {
-            return new gravityinterop_dataproduct{ gi_node->node->request(servName, *gi_request_dp->dp, timeoutMs) };
+            return new gravityinterop_dataproduct{gi_node->node->request(servName, *gi_request_dp->dp, timeoutMs)};
         }
 
         GRAVITYWRAPPER_EXPORT gravityinterop_serviceprovider* gravity_create_serviceprovider()
         {
             auto provider = std::make_shared<SimpleGravityServiceProvider>(nullptr);
-            return new gravityinterop_serviceprovider{ provider };
+            return new gravityinterop_serviceprovider{provider};
         }
 
-        GRAVITYWRAPPER_EXPORT void gravity_set_serviceprovider_callback(gravityinterop_serviceprovider* gi_sp, gravityinterop_servicerequest_cb cb)
+        GRAVITYWRAPPER_EXPORT void gravity_set_serviceprovider_callback(gravityinterop_serviceprovider* gi_sp,
+                                                                        gravityinterop_servicerequest_cb cb)
         {
             gi_sp->provider->setProviderCallback(cb);
         }
@@ -235,13 +240,10 @@ extern "C"
         GRAVITYWRAPPER_EXPORT gravityinterop_dataproduct* gravity_create_dataproduct(const char* dpId)
         {
             auto dp = std::make_shared<gravity::GravityDataProduct>(dpId);
-            return new gravityinterop_dataproduct{ dp };
+            return new gravityinterop_dataproduct{dp};
         }
 
-        GRAVITYWRAPPER_EXPORT void gravity_delete_dataproduct(gravityinterop_dataproduct* gi_dp)
-        {
-            delete gi_dp;
-        }
+        GRAVITYWRAPPER_EXPORT void gravity_delete_dataproduct(gravityinterop_dataproduct* gi_dp) { delete gi_dp; }
 
         GRAVITYWRAPPER_EXPORT int gravity_getsize_dataproduct(gravityinterop_dataproduct* gi_dp)
         {
@@ -261,15 +263,13 @@ extern "C"
         GRAVITYWRAPPER_EXPORT gravityinterop_subscriber* gravity_create_subscriber()
         {
             auto sub = std::make_shared<SimpleGravitySubscriber>(nullptr);
-            return new gravityinterop_subscriber{ sub };
+            return new gravityinterop_subscriber{sub};
         }
 
-        GRAVITYWRAPPER_EXPORT void gravity_delete_subscriber(gravityinterop_subscriber* gi_sub)
-        {
-            delete gi_sub;
-        }
+        GRAVITYWRAPPER_EXPORT void gravity_delete_subscriber(gravityinterop_subscriber* gi_sub) { delete gi_sub; }
 
-        GRAVITYWRAPPER_EXPORT void gravity_set_subscriber_callback(gravityinterop_subscriber* gi_sub, gravityinterop_subscriptionFilled_cb on_filled)
+        GRAVITYWRAPPER_EXPORT void gravity_set_subscriber_callback(gravityinterop_subscriber* gi_sub,
+                                                                   gravityinterop_subscriptionFilled_cb on_filled)
         {
             gi_sub->subscriber->setSubscriberCallback(on_filled);
         }
@@ -282,7 +282,8 @@ extern "C"
             LogDebug("gravity_node_publish", oss.str().c_str());
         }
 
-        GRAVITYWRAPPER_EXPORT void gravity_node_subscribe(const char* dpId, gravityinterop_node* gi_node, gravityinterop_subscriber* gi_sub)
+        GRAVITYWRAPPER_EXPORT void gravity_node_subscribe(const char* dpId, gravityinterop_node* gi_node,
+                                                          gravityinterop_subscriber* gi_sub)
         {
             gi_node->node->subscribe(std::string(dpId), *gi_sub->subscriber);
             std::ostringstream oss;
@@ -296,12 +297,13 @@ extern "C"
             g_gi_onDebugCb = onDebug;
         }
 
-        GRAVITYWRAPPER_EXPORT void gravity_register_dataproduct(gravityinterop_node* gi_node, const char* dpId, gravity::GravityTransportType type)
+        GRAVITYWRAPPER_EXPORT void gravity_register_dataproduct(gravityinterop_node* gi_node, const char* dpId,
+                                                                gravity::GravityTransportType type)
         {
             gi_node->node->registerDataProduct(dpId, type);
         }
-    }
+    }  // namespace GravityWrapper
 
 #ifdef __cplusplus
-    } //extern "C"
+}  //extern "C"
 #endif

--- a/src/api/cpp/CommUtil.h
+++ b/src/api/cpp/CommUtil.h
@@ -41,26 +41,26 @@
 #define MIN_PORT 24000
 #define MAX_PORT 24999
 
-#define DEFAULT_BROADCAST_RATE_SEC  10
-#define	DEFAULT_BROADCAST_PORT   8276
-#define DEFAULT_BROADCAST_TIMEOUT_SEC 10 
+#define DEFAULT_BROADCAST_RATE_SEC 10
+#define DEFAULT_BROADCAST_PORT 8276
+#define DEFAULT_BROADCAST_TIMEOUT_SEC 10
 #define MAXRECVSTRING 255
 
 namespace gravity
 {
-    namespace constants 
-    {
-        // ServiceDirectory Reserved Data Products
-        const std::string REGISTERED_PUBLISHERS_DPID = "RegisteredPublishers";
-        const std::string DOMAIN_DETAILS_DPID = "ServiceDirectory_DomainDetails";
-        const std::string DOMAIN_UPDATE_DPID = "ServiceDirectory_DomainUpdate";
-        const std::string DIRECTORY_SERVICE_DPID = "DirectoryService";
+namespace constants
+{
+    // ServiceDirectory Reserved Data Products
+    const std::string REGISTERED_PUBLISHERS_DPID = "RegisteredPublishers";
+    const std::string DOMAIN_DETAILS_DPID = "ServiceDirectory_DomainDetails";
+    const std::string DOMAIN_UPDATE_DPID = "ServiceDirectory_DomainUpdate";
+    const std::string DIRECTORY_SERVICE_DPID = "DirectoryService";
 
-        // GravityNode Reserved Data Products
-        const std::string METRICS_DATA_DPID = "GravityMetricsData";
-	const std::string GRAVITY_SETTINGS_DPID = "GRAVITY_SETTINGS";
-	const std::string GRAVITY_LOGGER_DPID = "GRAVITY_LOGGER";
-    }
+    // GravityNode Reserved Data Products
+    const std::string METRICS_DATA_DPID = "GravityMetricsData";
+    const std::string GRAVITY_SETTINGS_DPID = "GRAVITY_SETTINGS";
+    const std::string GRAVITY_LOGGER_DPID = "GRAVITY_LOGGER";
+}  // namespace constants
 
 /**
  * @name ZMQ Socket functions 
@@ -78,7 +78,7 @@ namespace gravity
  * \note flag 0 is not defined in zmq.h. From the unit tests it seems that this will block until it receives a message. If messages are sent with the ZMQ_SNDMORE flag, zmq will hold off on actually sending the messages until it has the final message with the ZMQ_DONTWAIT flag. Until then this will be a blocking call.
  * \return message
  */
-GRAVITY_API std::string readStringMessage(void *socket);
+GRAVITY_API std::string readStringMessage(void* socket);
 
 /**
  * \copybrief readStringMessage(void*)
@@ -87,7 +87,7 @@ GRAVITY_API std::string readStringMessage(void *socket);
  * \n <a href="http://api.zeromq.org/3-0:zmq-recvmsg">source</a>
  * \copydetails readStringMessage(void*)
  */
-GRAVITY_API std::string readStringMessage(void *socket, int flags);
+GRAVITY_API std::string readStringMessage(void* socket, int flags);
 
 /**
  * Send a message through a zmq socket
@@ -96,28 +96,33 @@ GRAVITY_API std::string readStringMessage(void *socket, int flags);
  * \n ZMQ_SNDMORE (set to 2 in zmq.h) "Specifies that the message being sent is a multi-part message, and that further message data parts are to follow." 
  * \n <a href="http://api.zeromq.org/3-0:zmq-sendmsg">source</a>
  */
-GRAVITY_API void sendStringMessage(void* socket, std::string str, int flags); 
-GRAVITY_API int readIntMessage(void *socket); ///< \copydoc readStringMessage(void*)
-GRAVITY_API void sendIntMessage(void* socket, int val, int flags); ///< \copydoc sendStringMessage(void*,std::string,int)
-GRAVITY_API uint64_t readUint64Message(void* socket); ///< \copydoc readStringMessage(void*)
-GRAVITY_API void sendUint64Message(void* socket, uint64_t val, int flags); ///< \copydoc sendStringMessage(void*,std::string,int)
-GRAVITY_API uint32_t readUint32Message(void* socket);///< \copydoc readStringMessage(void*)
-GRAVITY_API void sendUint32Message(void* socket, uint32_t val, int flags); ///< \copydoc sendStringMessage(void*,std::string,int)
+GRAVITY_API void sendStringMessage(void* socket, std::string str, int flags);
+GRAVITY_API int readIntMessage(void* socket);  ///< \copydoc readStringMessage(void*)
+GRAVITY_API void sendIntMessage(void* socket, int val,
+                                int flags);            ///< \copydoc sendStringMessage(void*,std::string,int)
+GRAVITY_API uint64_t readUint64Message(void* socket);  ///< \copydoc readStringMessage(void*)
+GRAVITY_API void sendUint64Message(void* socket, uint64_t val,
+                                   int flags);         ///< \copydoc sendStringMessage(void*,std::string,int)
+GRAVITY_API uint32_t readUint32Message(void* socket);  ///< \copydoc readStringMessage(void*)
+GRAVITY_API void sendUint32Message(void* socket, uint32_t val,
+                                   int flags);  ///< \copydoc sendStringMessage(void*,std::string,int)
 
 /**
  * \copydoc sendStringMessage(void*,std::string,int)
  * \return The number of bytes in the message if successful. Otherwise it shall return -1.
  */
-GRAVITY_API int sendGravityDataProduct(void* socket, const GravityDataProduct& dataProduct, int flags); 
-GRAVITY_API int sendProtobufMessage(void* socket, const google::protobuf::Message& pb, int flags); ///< \copydoc sendGravityDataProduct(void*,const GravityDataProduct&,int)
+GRAVITY_API int sendGravityDataProduct(void* socket, const GravityDataProduct& dataProduct, int flags);
+GRAVITY_API int sendProtobufMessage(
+    void* socket, const google::protobuf::Message& pb,
+    int flags);  ///< \copydoc sendGravityDataProduct(void*,const GravityDataProduct&,int)
 
 /**
  * Bind the given zmq socket to the first available port.
  * \return zero if successfully bound to a port. Otherwise it shall return -1.
  * \n <a href="http://api.zeromq.org/3-2:zmq-bind">source</a>
  */
-GRAVITY_API int bindFirstAvailablePort(void *socket, std::string ipAddr, int minPort, int maxPort);
-/** @} */ //ZMQ Socket functions
+GRAVITY_API int bindFirstAvailablePort(void* socket, std::string ipAddr, int minPort, int maxPort);
+/** @} */  //ZMQ Socket functions
 
 /**
  * @name Time functions
@@ -141,7 +146,7 @@ GRAVITY_API int bindFirstAvailablePort(void *socket, std::string ipAddr, int min
  * \param tzp UNUSED - always returns time in UTC
  * \return 0 always
  */
-GRAVITY_API int gettimeofday(struct timeval * tp, struct timezone * tzp);
+GRAVITY_API int gettimeofday(struct timeval* tp, struct timezone* tzp);
 #endif
 
 /**
@@ -150,7 +155,7 @@ GRAVITY_API int gettimeofday(struct timeval * tp, struct timezone * tzp);
  * \param sec seconds to add 
  * \return a timeval structure with the added seconds 
  */
-GRAVITY_API struct timeval addTime(const struct timeval *t1, int sec);
+GRAVITY_API struct timeval addTime(const struct timeval* t1, int sec);
 
 /**
  * Compare two times.
@@ -162,13 +167,13 @@ GRAVITY_API int timevalcmp(const struct timeval* t1, const struct timeval* t2);
  * Return the time difference.
  * \return a timeval structure equivalent to t1 - t2. If t1 > t2, return a timeval structure with time set to 0.  
  */
-GRAVITY_API struct timeval subtractTime(const struct timeval *t1, const struct timeval *t2);
+GRAVITY_API struct timeval subtractTime(const struct timeval* t1, const struct timeval* t2);
 
 /**
  * Return time in milliseconds.
  */
-GRAVITY_API unsigned int timevalToMilliSeconds(const struct timeval *tv);
-/** @} */ //Time functions
+GRAVITY_API unsigned int timevalToMilliSeconds(const struct timeval* tv);
+/** @} */  //Time functions
 
 /**
  * Print the char array to the console.

--- a/src/api/cpp/DomainDataKey.cpp
+++ b/src/api/cpp/DomainDataKey.cpp
@@ -20,38 +20,29 @@
 
 DomainDataKey::DomainDataKey(std::string domain, std::string dataProductID)
 {
-	this->domain = domain;
-	this->dataProductID = dataProductID;
+    this->domain = domain;
+    this->dataProductID = dataProductID;
 }
 
 DomainDataKey::~DomainDataKey(void) {}
 
 bool DomainDataKey::operator<(const DomainDataKey &right) const
 {
-	bool ret = false;
-	if (domain == right.domain)
-	{
-		ret = dataProductID < right.dataProductID;		
-	}
-	else
-	{
-		ret = domain < right.domain;
-	}
+    bool ret = false;
+    if (domain == right.domain)
+    {
+        ret = dataProductID < right.dataProductID;
+    }
+    else
+    {
+        ret = domain < right.domain;
+    }
 
-	return ret;
+    return ret;
 }
 
-bool DomainDataKey::operator>(const DomainDataKey &right) const
-{
-  return (!(*this < right || *this == right));
-}
+bool DomainDataKey::operator>(const DomainDataKey &right) const { return (!(*this < right || *this == right)); }
 
-bool DomainDataKey::operator==(const DomainDataKey &right) const
-{
-	return ( !(*this < right) && !(right < *this) );
-}
+bool DomainDataKey::operator==(const DomainDataKey &right) const { return (!(*this < right) && !(right < *this)); }
 
-bool DomainDataKey::operator!=(const DomainDataKey &right) const
-{
-  return (!(*this == right));
-}
+bool DomainDataKey::operator!=(const DomainDataKey &right) const { return (!(*this == right)); }

--- a/src/api/cpp/DomainDataKey.h
+++ b/src/api/cpp/DomainDataKey.h
@@ -24,18 +24,17 @@
 class DomainDataKey
 {
 private:
-	std::string domain;
-	std::string dataProductID;
+    std::string domain;
+    std::string dataProductID;
 
 public:
-	DomainDataKey(std::string domain, std::string dataProductID);	
-	~DomainDataKey(void);
+    DomainDataKey(std::string domain, std::string dataProductID);
+    ~DomainDataKey(void);
 
-	bool operator<(const DomainDataKey &right) const;
-	bool operator>(const DomainDataKey &right) const;
-	bool operator==(const DomainDataKey &right) const;
-	bool operator!=(const DomainDataKey &right) const;
+    bool operator<(const DomainDataKey &right) const;
+    bool operator>(const DomainDataKey &right) const;
+    bool operator==(const DomainDataKey &right) const;
+    bool operator!=(const DomainDataKey &right) const;
 };
 
 #endif /* DOMAINDATAKEY_H_ */
-

--- a/src/api/cpp/FutureResponse.cpp
+++ b/src/api/cpp/FutureResponse.cpp
@@ -27,31 +27,29 @@
 
 using namespace std;
 
-namespace gravity {
+namespace gravity
+{
 
 FutureResponse::FutureResponse(string url) : GravityDataProduct("FutureResponse")
-{	
-	// Populate protobuf with future response specific fields
-	gravityDataProductPB->set_future_response(true);
-	gravityDataProductPB->set_future_socket_url(url);
+{
+    // Populate protobuf with future response specific fields
+    gravityDataProductPB->set_future_response(true);
+    gravityDataProductPB->set_future_socket_url(url);
 }
 
 FutureResponse::FutureResponse(const void* arrayPtr, int size) : GravityDataProduct(arrayPtr, size) {}
 
 FutureResponse::~FutureResponse() {}
 
-string FutureResponse::getUrl() const
-{
-	return gravityDataProductPB->future_socket_url();
-}
+string FutureResponse::getUrl() const { return gravityDataProductPB->future_socket_url(); }
 
 void FutureResponse::setResponse(const GravityDataProduct& response)
 {
-	int size = response.getSize();
-	char* data = new char[size];
-	response.serializeToArray(data);
-	setData(data, size);
-	delete [] data;
+    int size = response.getSize();
+    char* data = new char[size];
+    response.serializeToArray(data);
+    setData(data, size);
+    delete[] data;
 }
 
 } /* namespace gravity */

--- a/src/api/cpp/FutureResponse.h
+++ b/src/api/cpp/FutureResponse.h
@@ -39,20 +39,20 @@ namespace gravity
 class FutureResponse : public GravityDataProduct
 {
 private:
-	friend class GravityNode;
+    friend class GravityNode;
 
-	/**
+    /**
 	 * Private constructor
-	 */ 
+	 */
     FutureResponse(std::string url);
 
-  /**
+    /**
    * Get socket URL
    */
-	std::string getUrl() const;
+    std::string getUrl() const;
 
 public:
-	/**
+    /**
      * Constructor that deserializes this FutureResponse from array of bytes
      * \param arrayPtr pointer to array of bytes containing serialized FutureResponse
      * \param size size of serialized data
@@ -65,10 +65,10 @@ public:
      */
     GRAVITY_API virtual ~FutureResponse();
 
-	/**
+    /**
 	 * Method for setting the GravityDataProduct response object to be returned to requestor
 	 */
-	GRAVITY_API void setResponse(const GravityDataProduct& response);
+    GRAVITY_API void setResponse(const GravityDataProduct& response);
 };
 
 } /* namespace gravity */

--- a/src/api/cpp/GravityConfigParser.cpp
+++ b/src/api/cpp/GravityConfigParser.cpp
@@ -27,23 +27,19 @@
 #include <iostream>
 
 #ifdef min
-#    undef min
+#undef min
 #endif
 
-namespace gravity {
+namespace gravity
+{
 
 int GravityConfigParser::CONFIG_REQUEST_TIMEOUT = 4000;
 
-bool GravityConfigParser::hasKey(std::string key) {
-	return key_value_map.count(StringCopyToLowerCase(key)) > 0;
-}
+bool GravityConfigParser::hasKey(std::string key) { return key_value_map.count(StringCopyToLowerCase(key)) > 0; }
 
-GravityConfigParser::GravityConfigParser(std::string componentID)
-{
-	this->componentID = componentID;
-}
+GravityConfigParser::GravityConfigParser(std::string componentID) { this->componentID = componentID; }
 
-void GravityConfigParser::ParseConfigFile(const char* config_filename)
+void GravityConfigParser::ParseConfigFile(const char *config_filename)
 {
     std::vector<const char *> sections;
 
@@ -53,53 +49,50 @@ void GravityConfigParser::ParseConfigFile(const char* config_filename)
 
     KeyValueConfigParser parser(config_filename, sections);
 
-	std::vector<std::string> keys = parser.GetKeys();
+    std::vector<std::string> keys = parser.GetKeys();
 
-	for(std::vector<std::string>::iterator i = keys.begin();
-			i != keys.end(); i++)
-	{
-		std::string value = parser.GetString(*i);
+    for (std::vector<std::string>::iterator i = keys.begin(); i != keys.end(); i++)
+    {
+        std::string value = parser.GetString(*i);
         std::string key_lower = StringCopyToLowerCase(*i);
-	    key_value_map[key_lower] = value;
-	}
-	return;
+        key_value_map[key_lower] = value;
+    }
+    return;
 }
-
 
 void GravityConfigParser::ParseConfigService(GravityNode &gn)
 {
-	//Prepare request
-	GravityDataProduct dataproduct("ConfigRequestPB");
-	ConfigRequestPB crpb;
-	crpb.set_componentid(componentID);
-	dataproduct.setData(crpb);
+    //Prepare request
+    GravityDataProduct dataproduct("ConfigRequestPB");
+    ConfigRequestPB crpb;
+    crpb.set_componentid(componentID);
+    dataproduct.setData(crpb);
 
-	//Send Request/Get Response
-	std::shared_ptr<GravityDataProduct> response = gn.request("ConfigService", dataproduct, CONFIG_REQUEST_TIMEOUT);
-	if(response == NULL)
-		return;
+    //Send Request/Get Response
+    std::shared_ptr<GravityDataProduct> response = gn.request("ConfigService", dataproduct, CONFIG_REQUEST_TIMEOUT);
+    if (response == NULL) return;
 
-	ConfigeResponsePB responseMessage;
-	response->populateMessage(responseMessage);
+    ConfigeResponsePB responseMessage;
+    response->populateMessage(responseMessage);
 
-	//Parse Response
-	int config_len = std::min(responseMessage.key_size(), responseMessage.value_size());
-	for(int i = 0; i < config_len; i++)
-	{
-	    std::string key_lower = StringCopyToLowerCase(responseMessage.key(i));
-		if(key_value_map.find(key_lower) == key_value_map.end()) //Don't overwrite keys.
-			key_value_map[key_lower] = responseMessage.value(i);
-	}
+    //Parse Response
+    int config_len = std::min(responseMessage.key_size(), responseMessage.value_size());
+    for (int i = 0; i < config_len; i++)
+    {
+        std::string key_lower = StringCopyToLowerCase(responseMessage.key(i));
+        if (key_value_map.find(key_lower) == key_value_map.end())  //Don't overwrite keys.
+            key_value_map[key_lower] = responseMessage.value(i);
+    }
 }
 
 std::string GravityConfigParser::getString(std::string key, std::string default_value)
 {
-	std::string key_lower = StringCopyToLowerCase(key);
-	std::map<std::string, std::string>::iterator i = key_value_map.find(key_lower);
-	if(i == key_value_map.end())
-		return default_value;
-	else
-		return i->second;
+    std::string key_lower = StringCopyToLowerCase(key);
+    std::map<std::string, std::string>::iterator i = key_value_map.find(key_lower);
+    if (i == key_value_map.end())
+        return default_value;
+    else
+        return i->second;
 }
 
-}
+}  // namespace gravity

--- a/src/api/cpp/GravityConfigParser.h
+++ b/src/api/cpp/GravityConfigParser.h
@@ -25,7 +25,8 @@
 #include <string>
 #include <map>
 
-namespace gravity {
+namespace gravity
+{
 
 /**
  * Class to parse a .ini config file for a specific gravity component.
@@ -41,9 +42,10 @@ public:
     /** Update configuration based on .ini file */
     void ParseConfigFile(const char* config_filename);
     /** Update configuration based on Config Service */
-    void ParseConfigService(GravityNode &gn);
+    void ParseConfigService(GravityNode& gn);
 
     std::string getString(std::string key, std::string default_value = "");
+
 private:
     std::string componentID;
     std::map<std::string, std::string> key_value_map;
@@ -51,6 +53,6 @@ private:
     static int CONFIG_REQUEST_TIMEOUT;
 };
 
-}
+}  // namespace gravity
 
-#endif // GRAVITYCONFIGPARSER_H_
+#endif  // GRAVITYCONFIGPARSER_H_

--- a/src/api/cpp/GravityDataProduct.cpp
+++ b/src/api/cpp/GravityDataProduct.cpp
@@ -25,7 +25,8 @@
 
 #include "GravityDataProduct.h"
 
-namespace gravity {
+namespace gravity
+{
 
 using namespace std;
 
@@ -34,46 +35,38 @@ GravityDataProduct::GravityDataProduct(string dataProductID) : gravityDataProduc
     gravityDataProductPB->set_dataproductid(dataProductID);
 }
 
-GravityDataProduct::GravityDataProduct(const void* arrayPtr, int size) : gravityDataProductPB(new GravityDataProductPB())
+GravityDataProduct::GravityDataProduct(const void* arrayPtr, int size)
+    : gravityDataProductPB(new GravityDataProductPB())
 {
     gravityDataProductPB->ParseFromArray(arrayPtr, size);
 }
 
 GravityDataProduct::~GravityDataProduct() {}
 
-std::string GravityDataProduct::getDataProductID() const
-{
-    return gravityDataProductPB->dataproductid();
-}
+std::string GravityDataProduct::getDataProductID() const { return gravityDataProductPB->dataproductid(); }
 
 void GravityDataProduct::setSoftwareVersion(string softwareVersion)
 {
     gravityDataProductPB->set_softwareversion(softwareVersion);
 }
 
-std::string GravityDataProduct::getSoftwareVersion() const
-{
-    return gravityDataProductPB->softwareversion();
-}
+std::string GravityDataProduct::getSoftwareVersion() const { return gravityDataProductPB->softwareversion(); }
 
 uint64_t GravityDataProduct::getReceivedTimestamp() const
 {
-	uint64_t receivedTimestamp = 0;
-	if (gravityDataProductPB->has_received_timestamp())
-	{
-		receivedTimestamp = gravityDataProductPB->received_timestamp();
-	}
+    uint64_t receivedTimestamp = 0;
+    if (gravityDataProductPB->has_received_timestamp())
+    {
+        receivedTimestamp = gravityDataProductPB->received_timestamp();
+    }
     return receivedTimestamp;
 }
 
-uint64_t GravityDataProduct::getGravityTimestamp() const
-{
-    return gravityDataProductPB->timestamp();
-}
+uint64_t GravityDataProduct::getGravityTimestamp() const { return gravityDataProductPB->timestamp(); }
 
 void GravityDataProduct::setData(const void* data, int size)
 {
-    delete gravityDataProductPB->release_data(); //Looking at the protobuf, this seems necessary.
+    delete gravityDataProductPB->release_data();  //Looking at the protobuf, this seems necessary.
     gravityDataProductPB->set_data(data, size);
 }
 
@@ -81,7 +74,7 @@ void GravityDataProduct::setData(const google::protobuf::Message& data)
 {
     char* vdata = (char*)malloc(data.ByteSize());
     data.SerializeToArray(vdata, data.ByteSize());
-    delete gravityDataProductPB->release_data(); //Looking at the protobuf, this seems necessary.
+    delete gravityDataProductPB->release_data();  //Looking at the protobuf, this seems necessary.
     gravityDataProductPB->set_data(vdata, data.ByteSize());
     free(vdata);
     // Also implicitly set the message protocol and data_type.
@@ -96,20 +89,14 @@ bool GravityDataProduct::getData(void* data, int size) const
     return true;
 }
 
-int GravityDataProduct::getDataSize() const
-{
-    return gravityDataProductPB->data().length();
-}
+int GravityDataProduct::getDataSize() const { return gravityDataProductPB->data().length(); }
 
 bool GravityDataProduct::populateMessage(google::protobuf::Message& data) const
 {
     return data.ParseFromArray((void*)gravityDataProductPB->data().c_str(), getDataSize());
 }
 
-int GravityDataProduct::getSize() const
-{
-    return gravityDataProductPB->ByteSize();
-}
+int GravityDataProduct::getSize() const { return gravityDataProductPB->ByteSize(); }
 
 void GravityDataProduct::parseFromArray(const void* arrayPtr, int size)
 {
@@ -121,85 +108,59 @@ bool GravityDataProduct::serializeToArray(void* arrayPtr) const
     return gravityDataProductPB->SerializeToArray(arrayPtr, gravityDataProductPB->ByteSize());
 }
 
-bool GravityDataProduct::operator==(const GravityDataProduct &gdp) const
+bool GravityDataProduct::operator==(const GravityDataProduct& gdp) const
 {
     // fastest test first...
-    if (getDataSize() != gdp.getDataSize())
-        return false;
-    if (getDataProductID().compare(gdp.getDataProductID()) != 0)
-        return false;
+    if (getDataSize() != gdp.getDataSize()) return false;
+    if (getDataProductID().compare(gdp.getDataProductID()) != 0) return false;
     return memcmp(gravityDataProductPB->data().c_str(), gdp.gravityDataProductPB->data().c_str(), getDataSize()) == 0;
 }
 
-bool GravityDataProduct::operator!=(const GravityDataProduct &gdp) const
-{
-  return !operator==(gdp);
-}
+bool GravityDataProduct::operator!=(const GravityDataProduct& gdp) const { return !operator==(gdp); }
 
-std::string GravityDataProduct::getComponentId() const
-{
-	return gravityDataProductPB->componentid();
-}
+std::string GravityDataProduct::getComponentId() const { return gravityDataProductPB->componentid(); }
 
-std::string GravityDataProduct::getDomain() const
-{
-	return gravityDataProductPB->domain();
-}
+std::string GravityDataProduct::getDomain() const { return gravityDataProductPB->domain(); }
 
-bool GravityDataProduct::isFutureResponse() const
-{
-	return gravityDataProductPB->future_response();
-}
+bool GravityDataProduct::isFutureResponse() const { return gravityDataProductPB->future_response(); }
 
 bool GravityDataProduct::isCachedDataproduct() const
 {
-	return(gravityDataProductPB->has_is_cached_dataproduct() && gravityDataProductPB->is_cached_dataproduct());	
+    return (gravityDataProductPB->has_is_cached_dataproduct() && gravityDataProductPB->is_cached_dataproduct());
 }
 
 void GravityDataProduct::setIsCachedDataproduct(bool cached)
 {
-	gravityDataProductPB->set_is_cached_dataproduct(cached);
-	
+    gravityDataProductPB->set_is_cached_dataproduct(cached);
 }
-std::string GravityDataProduct::getFutureSocketUrl() const
-{
-	return gravityDataProductPB->future_socket_url();
-}
+std::string GravityDataProduct::getFutureSocketUrl() const { return gravityDataProductPB->future_socket_url(); }
 
 bool GravityDataProduct::isRelayedDataproduct() const
 {
-	return(gravityDataProductPB->has_is_relayed_dataproduct() && gravityDataProductPB->is_relayed_dataproduct());
+    return (gravityDataProductPB->has_is_relayed_dataproduct() && gravityDataProductPB->is_relayed_dataproduct());
 }
 
 void GravityDataProduct::setIsRelayedDataproduct(bool relayed)
 {
-	gravityDataProductPB->set_is_relayed_dataproduct(relayed);
+    gravityDataProductPB->set_is_relayed_dataproduct(relayed);
 }
 
-void GravityDataProduct::setProtocol(const std::string& protocol) {
-	gravityDataProductPB->set_protocol(protocol);
-}
+void GravityDataProduct::setProtocol(const std::string& protocol) { gravityDataProductPB->set_protocol(protocol); }
 
-const std::string& GravityDataProduct::getProtocol() const {
-	return gravityDataProductPB->protocol();
-}
+const std::string& GravityDataProduct::getProtocol() const { return gravityDataProductPB->protocol(); }
 
-void GravityDataProduct::setTypeName(const std::string& dataType) {
-	gravityDataProductPB->set_type_name(dataType);
-}
+void GravityDataProduct::setTypeName(const std::string& dataType) { gravityDataProductPB->set_type_name(dataType); }
 
-const std::string& GravityDataProduct::getTypeName() const {
-	return gravityDataProductPB->type_name();
-}
+const std::string& GravityDataProduct::getTypeName() const { return gravityDataProductPB->type_name(); }
 
 uint32_t GravityDataProduct::getRegistrationTime() const
 {
-	uint64_t registrationTime = 0;
-	if (gravityDataProductPB->has_registration_time())
-	{
-		registrationTime = gravityDataProductPB->registration_time();
-	}
-	return registrationTime;
+    uint64_t registrationTime = 0;
+    if (gravityDataProductPB->has_registration_time())
+    {
+        registrationTime = gravityDataProductPB->registration_time();
+    }
+    return registrationTime;
 }
 
 } /* namespace gravity */

--- a/src/api/cpp/GravityDataProduct.h
+++ b/src/api/cpp/GravityDataProduct.h
@@ -45,11 +45,12 @@ class GravityNode;
 class GravityDataProduct
 {
 protected:
-    std::shared_ptr<GravityDataProductPB> gravityDataProductPB; ///< internal protobuf representation of data product
+    std::shared_ptr<GravityDataProductPB> gravityDataProductPB;  ///< internal protobuf representation of data product
     friend class GravityNode;
     friend class GravityMetricsManager;
-	friend class GravityServiceManager;
+    friend class GravityServiceManager;
     friend void* Heartbeat(void*);
+
 public:
     /**
      * Default Constructor
@@ -83,7 +84,7 @@ public:
      */
     GRAVITY_API uint64_t getGravityTimestamp() const;
 
-	/**
+    /**
      * Method to return the timestamp associated with the receipt of this data product
      *  Represents Microseconds since the Unix Epoch
      * \return received timestamp for data (0 if not received via subscription)
@@ -168,48 +169,48 @@ public:
      * \param gdp GravityDataProduct to compare with this one.
      * \return true if the two GravityDataProducts are equivalent, false otherwise.
      */
-    GRAVITY_API bool operator==(const GravityDataProduct &gdp) const;
+    GRAVITY_API bool operator==(const GravityDataProduct& gdp) const;
 
     /**
      * Check non-equivalence between two GravityDataProducts. 
      * \param gdp GravityDataProduct to compare with this one.
      * \return true if the two GravityDataProducts are not equivalent, false otherwise.
      */
-    GRAVITY_API bool operator!=(const GravityDataProduct &gdp) const;
+    GRAVITY_API bool operator!=(const GravityDataProduct& gdp) const;
 
-	/**
+    /**
 	 * Get the component ID of the GravityNode that produced this data product
 	 * \return component ID of the source GravityNode
 	 */
-	GRAVITY_API std::string getComponentId() const;
+    GRAVITY_API std::string getComponentId() const;
 
-	/**
+    /**
 	 * Get the domain of the GravityNode that produced this data product
 	 * \return domain of the source GravityNode
 	 */
-	GRAVITY_API std::string getDomain() const;
+    GRAVITY_API std::string getDomain() const;
 
-	/**
+    /**
 	 * Get the flag indicating if this is a "future" response
 	 * \return future response flag
 	 */
-	GRAVITY_API bool isFutureResponse() const;
+    GRAVITY_API bool isFutureResponse() const;
 
-	/**
+    /**
 	* Get the flag indicated if this was a cached data product.	
 	*/
-	GRAVITY_API bool isCachedDataproduct() const;
-	
-	/**
+    GRAVITY_API bool isCachedDataproduct() const;
+
+    /**
 	* Sets the flag indicating this data product is cached	
 	*/
-	GRAVITY_API void setIsCachedDataproduct(bool cached);
+    GRAVITY_API void setIsCachedDataproduct(bool cached);
 
-	/**
+    /**
 	 * Get the url for the REP socket of a future response
 	 * \return url for REP socket of future response
 	 */
-	GRAVITY_API std::string getFutureSocketUrl() const;
+    GRAVITY_API std::string getFutureSocketUrl() const;
 
     /**
      * Set the timestamp on this GravityDataProduct (typically set by infrastructure at publish)
@@ -217,7 +218,7 @@ public:
      */
     GRAVITY_API void setTimestamp(uint64_t ts) const { gravityDataProductPB->set_timestamp(ts); }
 
-	/**
+    /**
      * Set the received timestamp on this GravityDataProduct (typically set by infrastructure on receipt)
      * \param ts Received timestamp (epoch microseconds) for this GravityDataProduct
      */
@@ -227,56 +228,59 @@ public:
      * Set the component id on this GravityDataProduct (typically set by infrastructure at publish)
      * \param componentId ID of the component that produces this GravityDataProduct
      */
-	GRAVITY_API void setComponentId(std::string componentId) const { gravityDataProductPB->set_componentid(componentId);}
+    GRAVITY_API void setComponentId(std::string componentId) const
+    {
+        gravityDataProductPB->set_componentid(componentId);
+    }
 
     /**
      * Set the domain on this GravityDataProduct (typically set by infrastructure at publish)
      * \param domain name of the domain on which this GravityDataProduct is produced
      */
-	GRAVITY_API void setDomain(std::string domain) const { gravityDataProductPB->set_domain(domain);}
+    GRAVITY_API void setDomain(std::string domain) const { gravityDataProductPB->set_domain(domain); }
 
-	/**
+    /**
 	 * Get the flag indicating if this message has been relayed by a Relay component
 	 */
-	GRAVITY_API bool isRelayedDataproduct() const;
+    GRAVITY_API bool isRelayedDataproduct() const;
 
-	/**
+    /**
 	 * Set the flag indicating whether this message has been relayed or has come from the original source
 	 */
-	GRAVITY_API void setIsRelayedDataproduct(bool relayed);
+    GRAVITY_API void setIsRelayedDataproduct(bool relayed);
 
-	/**
+    /**
 	 * Set the data protocol in this data product (for instance, protobuf2)
 	 */
-	GRAVITY_API void setProtocol(const std::string& protocol);
+    GRAVITY_API void setProtocol(const std::string& protocol);
 
-	/**
+    /**
 	 * Get the data protocol in this data product (for instance, protobuf2)
 	 */
-	GRAVITY_API const std::string& getProtocol() const;
+    GRAVITY_API const std::string& getProtocol() const;
 
-	/**
+    /**
 	 * Set the type of data in this data product (for instance, the full protobuf type name)
 	 */
-	GRAVITY_API void setTypeName(const std::string& dataType);
+    GRAVITY_API void setTypeName(const std::string& dataType);
 
-	/**
+    /**
 	 * Get the type of data in this data product (for instance, the full protobuf type name)
 	 */
-	GRAVITY_API const std::string& getTypeName() const;
+    GRAVITY_API const std::string& getTypeName() const;
 
-	/**
+    /**
 	* Method to return the time associated with the registration of this data product
 	*  Represents Seconds since the Unix Epoch
 	* \return registration time for data (0 if not set)
 	*/
-	GRAVITY_API uint32_t getRegistrationTime() const;
+    GRAVITY_API uint32_t getRegistrationTime() const;
 
-	/**
+    /**
 	* Set the registration time on this GravityDataProduct (typically set by infrastructure when created)
 	* \param ts Registration time (epoch seconds) for this GravityDataProduct
 	*/
-	GRAVITY_API void setRegistrationTime(uint32_t ts) const { gravityDataProductPB->set_registration_time(ts); }
+    GRAVITY_API void setRegistrationTime(uint32_t ts) const { gravityDataProductPB->set_registration_time(ts); }
 };
 
 } /* namespace gravity */

--- a/src/api/cpp/GravityHeartbeat.cpp
+++ b/src/api/cpp/GravityHeartbeat.cpp
@@ -39,195 +39,198 @@ namespace gravity
 
 using namespace std;
 
-std::list<ExpectedMessageQueueElement> Heartbeat::queueElements; //This is so we can reuse these guys.
-std::priority_queue<ExpectedMessageQueueElement*, vector<ExpectedMessageQueueElement*>, EMQComparator> Heartbeat::messageTimes;
+std::list<ExpectedMessageQueueElement> Heartbeat::queueElements;  //This is so we can reuse these guys.
+std::priority_queue<ExpectedMessageQueueElement*, vector<ExpectedMessageQueueElement*>, EMQComparator>
+    Heartbeat::messageTimes;
 std::map<std::string, GravityHeartbeatListener*> Heartbeat::listener;
 
 Semaphore Heartbeat::lock;
 std::set<std::string> Heartbeat::filledHeartbeats;
 
-
-void Heartbeat::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void Heartbeat::subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	lock.Lock();
-	for(size_t i = 0; i < dataProducts.size(); i++)
-		filledHeartbeats.insert(dataProducts[i]->getDataProductID());
-	lock.Unlock();
+    lock.Lock();
+    for (size_t i = 0; i < dataProducts.size(); i++) filledHeartbeats.insert(dataProducts[i]->getDataProductID());
+    lock.Unlock();
 }
-
 
 void* Heartbeat::HeartbeatListenerThrFunc(void* thread_context)
 {
-	HBListenerContext* params = (HBListenerContext*) thread_context;
+    HBListenerContext* params = (HBListenerContext*)thread_context;
 
     void* hbSocket = zmq_socket(params->zmq_context, ZMQ_REP);
     zmq_connect(hbSocket, "inproc://heartbeat_listener");
-	
-	shared_ptr<spdlog::logger> logger = spdlog::get("GravityLogger");
 
-    while(true)
+    shared_ptr<spdlog::logger> logger = spdlog::get("GravityLogger");
+
+    while (true)
     {
-    	if(!messageTimes.empty())
-    	{
-			ExpectedMessageQueueElement& mqe = *messageTimes.top();
+        if (!messageTimes.empty())
+        {
+            ExpectedMessageQueueElement& mqe = *messageTimes.top();
 
-			if (mqe.expectedTime > getCurrentTime())
-			{
-		 		gravity::sleep(100);
-			}
-			else
-			{
-				lock.Lock();
+            if (mqe.expectedTime > getCurrentTime())
+            {
+                gravity::sleep(100);
+            }
+            else
+            {
+                lock.Lock();
 
-				std::set<std::string>::iterator i = filledHeartbeats.find(mqe.dataproductID);
-				bool gotHeartbeat = (i != filledHeartbeats.end());
-				if(gotHeartbeat)
-					filledHeartbeats.erase(i);
-				lock.Unlock();
-				if(listener.find(mqe.dataproductID)!=listener.end())
-				{
-					//chop off "_GravityHeartbeat" before sending DataProductID to listeners
-					std::string componentId = mqe.dataproductID.substr(0,mqe.dataproductID.rfind("_GravityHeartbeat"));
+                std::set<std::string>::iterator i = filledHeartbeats.find(mqe.dataproductID);
+                bool gotHeartbeat = (i != filledHeartbeats.end());
+                if (gotHeartbeat) filledHeartbeats.erase(i);
+                lock.Unlock();
+                if (listener.find(mqe.dataproductID) != listener.end())
+                {
+                    //chop off "_GravityHeartbeat" before sending DataProductID to listeners
+                    std::string componentId = mqe.dataproductID.substr(0, mqe.dataproductID.rfind("_GravityHeartbeat"));
 
-					if(!gotHeartbeat)
-					{
-						int64_t diff = mqe.lastHeartbeatTime == 0 ? -1l : getCurrentTime() - mqe.lastHeartbeatTime;
-						listener[mqe.dataproductID]->MissedHeartbeat(componentId, diff, mqe.timetowaitBetweenHeartbeats);
-					}
-					else
-					{
-						listener[mqe.dataproductID]->ReceivedHeartbeat(componentId, mqe.timetowaitBetweenHeartbeats);
-						mqe.lastHeartbeatTime = getCurrentTime();
-					}
-				}
-				messageTimes.pop();
-				mqe.expectedTime = getCurrentTime() + mqe.timetowaitBetweenHeartbeats; //(Maybe should be lastHeartbeatTime + timetowaitBetweenHeartbeats, but current version allows for drift etc.)
-				messageTimes.push(&mqe);
-			}
+                    if (!gotHeartbeat)
+                    {
+                        int64_t diff = mqe.lastHeartbeatTime == 0 ? -1l : getCurrentTime() - mqe.lastHeartbeatTime;
+                        listener[mqe.dataproductID]->MissedHeartbeat(componentId, diff,
+                                                                     mqe.timetowaitBetweenHeartbeats);
+                    }
+                    else
+                    {
+                        listener[mqe.dataproductID]->ReceivedHeartbeat(componentId, mqe.timetowaitBetweenHeartbeats);
+                        mqe.lastHeartbeatTime = getCurrentTime();
+                    }
+                }
+                messageTimes.pop();
+                mqe.expectedTime =
+                    getCurrentTime() +
+                    mqe.timetowaitBetweenHeartbeats;  //(Maybe should be lastHeartbeatTime + timetowaitBetweenHeartbeats, but current version allows for drift etc.)
+                messageTimes.push(&mqe);
+            }
 
-    	}//Process Messages
+        }  //Process Messages
 
         //Allow Gravity to add Heartbeat listeners.
-    	{
-    		zmq_msg_t msg;
-    	    zmq_msg_init(&msg);
-    	    std::string dataproductID;
-    	    //unsigned short port;
-    	    int64_t maxtime;
+        {
+            zmq_msg_t msg;
+            zmq_msg_init(&msg);
+            std::string dataproductID;
+            //unsigned short port;
+            int64_t maxtime;
 
-    	    if(zmq_recvmsg(hbSocket, &msg, ZMQ_DONTWAIT) != -1)
-    	    {
-				std::string command;
-				int size = zmq_msg_size(&msg);
-				char* c = (char*)malloc(size+1);
-				memcpy(c, zmq_msg_data(&msg), size);
-				c[size] = 0;
-				command.assign(c,size);
-				free(c);
+            if (zmq_recvmsg(hbSocket, &msg, ZMQ_DONTWAIT) != -1)
+            {
+                std::string command;
+                int size = zmq_msg_size(&msg);
+                char* c = (char*)malloc(size + 1);
+                memcpy(c, zmq_msg_data(&msg), size);
+                c[size] = 0;
+                command.assign(c, size);
+                free(c);
 
-				if (command == "register")
-				{
-					zmq_msg_t msg2;
-					zmq_msg_init(&msg2);
-					//Receive Dataproduct ID
-					zmq_recvmsg(hbSocket,&msg2,ZMQ_DONTWAIT);
-					size = zmq_msg_size(&msg2);
-					char* s = (char*)malloc(size+1);
-					memcpy(s, zmq_msg_data(&msg2), size);
-					s[size] = 0;
-					dataproductID.assign(s, size);
-					free(s);
-					zmq_msg_close(&msg2);
+                if (command == "register")
+                {
+                    zmq_msg_t msg2;
+                    zmq_msg_init(&msg2);
+                    //Receive Dataproduct ID
+                    zmq_recvmsg(hbSocket, &msg2, ZMQ_DONTWAIT);
+                    size = zmq_msg_size(&msg2);
+                    char* s = (char*)malloc(size + 1);
+                    memcpy(s, zmq_msg_data(&msg2), size);
+                    s[size] = 0;
+                    dataproductID.assign(s, size);
+                    free(s);
+                    zmq_msg_close(&msg2);
 
-					//Receive address of listener
-					zmq_msg_t msg3;
-					zmq_msg_init(&msg3);
-					intptr_t p;
-					zmq_recvmsg(hbSocket, &msg3, ZMQ_DONTWAIT); //These are guarunteed to not fail since this is a multi part message.
-					memcpy(&p, zmq_msg_data(&msg3), sizeof(intptr_t));
-					zmq_msg_close(&msg3);
+                    //Receive address of listener
+                    zmq_msg_t msg3;
+                    zmq_msg_init(&msg3);
+                    intptr_t p;
+                    zmq_recvmsg(hbSocket, &msg3,
+                                ZMQ_DONTWAIT);  //These are guarunteed to not fail since this is a multi part message.
+                    memcpy(&p, zmq_msg_data(&msg3), sizeof(intptr_t));
+                    zmq_msg_close(&msg3);
 
-					listener[dataproductID] = (GravityHeartbeatListener*) p;
+                    listener[dataproductID] = (GravityHeartbeatListener*)p;
 
-					//Receive maxtime.
-					zmq_msg_t msg4;
-					zmq_msg_init(&msg4);
-					zmq_recvmsg(hbSocket, &msg4, ZMQ_DONTWAIT);
-					memcpy(&maxtime, zmq_msg_data(&msg4), 8);
-					zmq_msg_close(&msg4);
+                    //Receive maxtime.
+                    zmq_msg_t msg4;
+                    zmq_msg_init(&msg4);
+                    zmq_recvmsg(hbSocket, &msg4, ZMQ_DONTWAIT);
+                    memcpy(&maxtime, zmq_msg_data(&msg4), 8);
+                    zmq_msg_close(&msg4);
 
-					ExpectedMessageQueueElement mqe1;
-					mqe1.dataproductID = dataproductID;
-					mqe1.expectedTime = getCurrentTime() + maxtime;
-					mqe1.lastHeartbeatTime = 0;
-					mqe1.timetowaitBetweenHeartbeats = maxtime;
+                    ExpectedMessageQueueElement mqe1;
+                    mqe1.dataproductID = dataproductID;
+                    mqe1.expectedTime = getCurrentTime() + maxtime;
+                    mqe1.lastHeartbeatTime = 0;
+                    mqe1.timetowaitBetweenHeartbeats = maxtime;
 
-					//We should already be subscribed to the Heartbeats.
+                    //We should already be subscribed to the Heartbeats.
 
-					queueElements.push_back(mqe1);
-					messageTimes.push(&queueElements.back()); 
-				}
-				else if (command == "unregister")
-				{
-					lock.Lock();
+                    queueElements.push_back(mqe1);
+                    messageTimes.push(&queueElements.back());
+                }
+                else if (command == "unregister")
+                {
+                    lock.Lock();
 
-					zmq_msg_t msg2;
-					zmq_msg_init(&msg2);
-					//Receive Dataproduct ID
-					zmq_recvmsg(hbSocket,&msg2,ZMQ_DONTWAIT);
-					size = zmq_msg_size(&msg2);
-					char* s = (char*)malloc(size+1);
-					memcpy(s, zmq_msg_data(&msg2), size);
-					s[size] = 0;
-					dataproductID.assign(s, size);
-					free(s);
-					zmq_msg_close(&msg2);
+                    zmq_msg_t msg2;
+                    zmq_msg_init(&msg2);
+                    //Receive Dataproduct ID
+                    zmq_recvmsg(hbSocket, &msg2, ZMQ_DONTWAIT);
+                    size = zmq_msg_size(&msg2);
+                    char* s = (char*)malloc(size + 1);
+                    memcpy(s, zmq_msg_data(&msg2), size);
+                    s[size] = 0;
+                    dataproductID.assign(s, size);
+                    free(s);
+                    zmq_msg_close(&msg2);
 
-					listener.erase(dataproductID);
+                    listener.erase(dataproductID);
 
-					int queueSize = messageTimes.size();
+                    int queueSize = messageTimes.size();
 
-					std::priority_queue<ExpectedMessageQueueElement*, vector<ExpectedMessageQueueElement*>, EMQComparator> tempQueue;
+                    std::priority_queue<ExpectedMessageQueueElement*, vector<ExpectedMessageQueueElement*>,
+                                        EMQComparator>
+                        tempQueue;
 
-					//loop through whole queue to preserve order
-					for(int i = 0; i <queueSize;i++)
-					{
-						ExpectedMessageQueueElement& entry = *messageTimes.top();
-						messageTimes.pop();
-						//add back all heartbeat entries that are not equal to dataProductID
-						if (entry.dataproductID != dataproductID)
-						{		
-							tempQueue.push(&entry);
-						}
-					}
+                    //loop through whole queue to preserve order
+                    for (int i = 0; i < queueSize; i++)
+                    {
+                        ExpectedMessageQueueElement& entry = *messageTimes.top();
+                        messageTimes.pop();
+                        //add back all heartbeat entries that are not equal to dataProductID
+                        if (entry.dataproductID != dataproductID)
+                        {
+                            tempQueue.push(&entry);
+                        }
+                    }
 
-					messageTimes = tempQueue;
-					
-					lock.Unlock();
-				}
-	            else if (command == "kill")
-	            {
-	                break;
-	            }
+                    messageTimes = tempQueue;
 
-				// Send ACK
-				sendStringMessage(hbSocket, "ACK", ZMQ_DONTWAIT);
-    	    }
-			else
-			{
-				int errnum = zmq_errno();
-				if (errnum != EAGAIN)
-				{
-					logger->critical("Heartbeat Message Error: {}",zmq_strerror(errnum));
-					break;
-				}
-			}
+                    lock.Unlock();
+                }
+                else if (command == "kill")
+                {
+                    break;
+                }
 
-	    	zmq_msg_close(&msg);
+                // Send ACK
+                sendStringMessage(hbSocket, "ACK", ZMQ_DONTWAIT);
+            }
+            else
+            {
+                int errnum = zmq_errno();
+                if (errnum != EAGAIN)
+                {
+                    logger->critical("Heartbeat Message Error: {}", zmq_strerror(errnum));
+                    break;
+                }
+            }
 
-    	}//Add Heartbeat listeners
+            zmq_msg_close(&msg);
 
-    }//while(true)
+        }  //Add Heartbeat listeners
+
+    }  //while(true)
 
     zmq_close(hbSocket);
     delete params;
@@ -240,63 +243,64 @@ bool Heartbeat::heartbeatRunning = false;
 
 void Heartbeat::setHeartbeatRunning(bool running)
 {
-	Heartbeat::heartbeatLock.Lock();
-	Heartbeat::heartbeatRunning = running;
-	Heartbeat::heartbeatLock.Unlock();
+    Heartbeat::heartbeatLock.Lock();
+    Heartbeat::heartbeatRunning = running;
+    Heartbeat::heartbeatLock.Unlock();
 }
 
 bool Heartbeat::isHeartbeatRunning()
 {
-	bool running;
-	Heartbeat::heartbeatLock.Lock();
-	running = Heartbeat::heartbeatRunning;
-	Heartbeat::heartbeatLock.Unlock();
-	return running;
+    bool running;
+    Heartbeat::heartbeatLock.Lock();
+    running = Heartbeat::heartbeatRunning;
+    Heartbeat::heartbeatLock.Unlock();
+    return running;
 }
 
 void* Heartbeat(void* thread_context)
 {
-	HBParams* params = (HBParams*) thread_context;
-	GravityDataProduct gdp(params->componentID);
-	gdp.setData((void*)"Good", 5);
+    HBParams* params = (HBParams*)thread_context;
+    GravityDataProduct gdp(params->componentID);
+    gdp.setData((void*)"Good", 5);
 
-	void *heartbeatSocket = zmq_socket(params->zmq_context,ZMQ_PUB);
-	zmq_connect(heartbeatSocket,PUB_MGR_HB_URL);
+    void* heartbeatSocket = zmq_socket(params->zmq_context, ZMQ_PUB);
+    zmq_connect(heartbeatSocket, PUB_MGR_HB_URL);
 
-	Heartbeat::setHeartbeatRunning(true);
-	
-	shared_ptr<spdlog::logger> logger = spdlog::get("GravityLogger");
+    Heartbeat::setHeartbeatRunning(true);
 
-	while(Heartbeat::isHeartbeatRunning())
-	{
-		// Publish heartbeat (via the GravityPublishManager)
-		gdp.setTimestamp(getCurrentTime());
-		gdp.setRegistrationTime(params->registrationTime);
-		logger->trace("{}: Publishing heartbeat", params->componentID);
-		sendStringMessage(heartbeatSocket, "publish", ZMQ_SNDMORE);
-		sendStringMessage(heartbeatSocket, gdp.getDataProductID(), ZMQ_SNDMORE);
-		sendUint64Message(heartbeatSocket, gdp.getGravityTimestamp(), ZMQ_SNDMORE);
-		sendStringMessage(heartbeatSocket, "", ZMQ_SNDMORE);
-		zmq_msg_t msg;
-		zmq_msg_init_size(&msg, gdp.getSize());
-		gdp.serializeToArray(zmq_msg_data(&msg));
-		zmq_sendmsg(heartbeatSocket, &msg, ZMQ_DONTWAIT);
-		zmq_msg_close(&msg);
+    shared_ptr<spdlog::logger> logger = spdlog::get("GravityLogger");
+
+    while (Heartbeat::isHeartbeatRunning())
+    {
+        // Publish heartbeat (via the GravityPublishManager)
+        gdp.setTimestamp(getCurrentTime());
+        gdp.setRegistrationTime(params->registrationTime);
+        logger->trace("{}: Publishing heartbeat", params->componentID);
+        sendStringMessage(heartbeatSocket, "publish", ZMQ_SNDMORE);
+        sendStringMessage(heartbeatSocket, gdp.getDataProductID(), ZMQ_SNDMORE);
+        sendUint64Message(heartbeatSocket, gdp.getGravityTimestamp(), ZMQ_SNDMORE);
+        sendStringMessage(heartbeatSocket, "", ZMQ_SNDMORE);
+        zmq_msg_t msg;
+        zmq_msg_init_size(&msg, gdp.getSize());
+        gdp.serializeToArray(zmq_msg_data(&msg));
+        zmq_sendmsg(heartbeatSocket, &msg, ZMQ_DONTWAIT);
+        zmq_msg_close(&msg);
 #ifdef WIN32
-		Sleep(params->interval_in_microseconds/1000);
+        Sleep(params->interval_in_microseconds / 1000);
 #else
-		struct timespec request;
-		request.tv_sec = params->interval_in_microseconds / 1000000;
-		request.tv_nsec = (params->interval_in_microseconds % 1000000)*1000; //Convert from Microseconds to Nanoseconds
-		clock_nanosleep(CLOCK_REALTIME, 0, &request, NULL);
+        struct timespec request;
+        request.tv_sec = params->interval_in_microseconds / 1000000;
+        request.tv_nsec =
+            (params->interval_in_microseconds % 1000000) * 1000;  //Convert from Microseconds to Nanoseconds
+        clock_nanosleep(CLOCK_REALTIME, 0, &request, NULL);
 #endif
-	}
+    }
 
     zmq_close(heartbeatSocket);
-	// Clean up
-	delete params;
+    // Clean up
+    delete params;
 
-	return NULL;
+    return NULL;
 }
 
-} //namespace gravity
+}  //namespace gravity

--- a/src/api/cpp/GravityHeartbeat.h
+++ b/src/api/cpp/GravityHeartbeat.h
@@ -34,35 +34,38 @@
 namespace gravity
 {
 /** For passing Data to the HB threads. */
-struct HBParams {
-	void* zmq_context;
-	uint64_t interval_in_microseconds;
-	//unsigned short port;
-	std::string componentID;
-	std::string endpoint;
-	int minPort;
-	int maxPort;
-	uint32_t registrationTime;
+struct HBParams
+{
+    void* zmq_context;
+    uint64_t interval_in_microseconds;
+    //unsigned short port;
+    std::string componentID;
+    std::string endpoint;
+    int minPort;
+    int maxPort;
+    uint32_t registrationTime;
 };
 
-struct HBListenerContext {
-	void* zmq_context;
+struct HBListenerContext
+{
+    void* zmq_context;
 };
 
-struct ExpectedMessageQueueElement {
-	uint64_t expectedTime; //Absolute (Maximum amount we can wait).
-	uint64_t lastHeartbeatTime; //Absolute
-	int64_t timetowaitBetweenHeartbeats; //In Microseconds
-	std::string dataproductID;
-	void* socket;
+struct ExpectedMessageQueueElement
+{
+    uint64_t expectedTime;                //Absolute (Maximum amount we can wait).
+    uint64_t lastHeartbeatTime;           //Absolute
+    int64_t timetowaitBetweenHeartbeats;  //In Microseconds
+    std::string dataproductID;
+    void* socket;
 };
 
 struct EMQComparator
 {
-	bool operator() (ExpectedMessageQueueElement* a, ExpectedMessageQueueElement* b)
-	{
-		return a->expectedTime > b->expectedTime;
-	}
+    bool operator()(ExpectedMessageQueueElement* a, ExpectedMessageQueueElement* b)
+    {
+        return a->expectedTime > b->expectedTime;
+    }
 };
 
 /**
@@ -71,15 +74,17 @@ struct EMQComparator
 class Heartbeat : public GravitySubscriber
 {
 private:
-	static Semaphore heartbeatLock;
-	static bool heartbeatRunning;
+    static Semaphore heartbeatLock;
+    static bool heartbeatRunning;
+
 public:
-    virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
 
     static void* HeartbeatListenerThrFunc(void* thread_context);
 
-    static std::list<ExpectedMessageQueueElement> queueElements; //This is so we can reuse these guys.
-    static std::priority_queue<ExpectedMessageQueueElement*, std::vector<ExpectedMessageQueueElement*>, EMQComparator> messageTimes;
+    static std::list<ExpectedMessageQueueElement> queueElements;  //This is so we can reuse these guys.
+    static std::priority_queue<ExpectedMessageQueueElement*, std::vector<ExpectedMessageQueueElement*>, EMQComparator>
+        messageTimes;
     static std::map<std::string, GravityHeartbeatListener*> listener;
 
     static Semaphore lock;
@@ -87,12 +92,12 @@ public:
     /**
      * Set of data product IDs that we have received subscriptions (heartbeats) for
      */
-    static std::set<std::string> filledHeartbeats;	
+    static std::set<std::string> filledHeartbeats;
 
-	static void setHeartbeatRunning(bool running);
-	static bool isHeartbeatRunning();
+    static void setHeartbeatRunning(bool running);
+    static bool isHeartbeatRunning();
 };
 
-} //namespace gravity
+}  //namespace gravity
 
-#endif //GRAVITY_HEARTBEAT_H__
+#endif  //GRAVITY_HEARTBEAT_H__

--- a/src/api/cpp/GravityHeartbeatListener.h
+++ b/src/api/cpp/GravityHeartbeatListener.h
@@ -39,7 +39,7 @@ namespace gravity
 class GravityHeartbeatListener
 {
 public:
-	/**
+    /**
 	 * Called when another component's heartbeat is off by a certain amount.
 	 * \param componentID component id for the component whose heartbeat was missed
 	 * \param microsecond_to_last_heartbeat number of microseconds since the last heartbeat was received, or -1 if
@@ -48,22 +48,23 @@ public:
 	 * will change the interval used in subsequent iterations.  Typed as a signed 64 bit integer to
      * make passing to Java via Swig cleaner.
 	 */
-	GRAVITY_API virtual void MissedHeartbeat(std::string componentID, int64_t microsecond_to_last_heartbeat, int64_t& interval_in_microseconds) = 0;
+    GRAVITY_API virtual void MissedHeartbeat(std::string componentID, int64_t microsecond_to_last_heartbeat,
+                                             int64_t& interval_in_microseconds) = 0;
 
-	/**
+    /**
 	 * Called when another component's heartbeat is received
      * \param componentID component id for the component whose heartbeat was received
      * \param interval_in_microseconds The current heart beat interval for the given component ID.  Updates to this value
      * will change the interval used in subsequent iterations.  Typed as a signed 64 bit integer to
      * make passing to Java via Swig cleaner.
 	 */
-	GRAVITY_API virtual void ReceivedHeartbeat(std::string componentID, int64_t& interval_in_microseconds) = 0;
+    GRAVITY_API virtual void ReceivedHeartbeat(std::string componentID, int64_t& interval_in_microseconds) = 0;
 
     /**
      * Default destructor
      */
-	GRAVITY_API virtual ~GravityHeartbeatListener() { };
+    GRAVITY_API virtual ~GravityHeartbeatListener(){};
 };
 
 } /* namespace gravity */
-#endif //GRAVITYHEARTBEATLISTENER_H_
+#endif  //GRAVITYHEARTBEATLISTENER_H_

--- a/src/api/cpp/GravityLogger.cpp
+++ b/src/api/cpp/GravityLogger.cpp
@@ -39,7 +39,8 @@ using namespace gravity;
 /**
  * Logs to a file
  */
-class FileLogger : public Logger {
+class FileLogger : public Logger
+{
 public:
     FileLogger(const string& log_dir, const string& comp_id, bool close_file);
     /*
@@ -47,8 +48,13 @@ public:
      */
     virtual void Log(int level, const char* messagestr);
     virtual ~FileLogger();
+
 protected:
-    FileLogger(const string& comp_id) {component_id = comp_id; close_file_after_write = false;}  // always keep open here
+    FileLogger(const string& comp_id)
+    {
+        component_id = comp_id;
+        close_file_after_write = false;
+    }  // always keep open here
     string filename;
     FILE* log_file;
     string component_id;
@@ -64,17 +70,17 @@ FileLogger::FileLogger(const string& log_dir, const string& comp_id, bool close_
 #else
     string sep_str = "/";
 #endif
-    if (log_dir.length() == 0 || log_dir.compare (log_dir.length() - sep_str.length(), sep_str.length(), sep_str) == 0)
+    if (log_dir.length() == 0 || log_dir.compare(log_dir.length() - sep_str.length(), sep_str.length(), sep_str) == 0)
         filename = log_dir + component_id + ".log";
     else
         filename = log_dir + sep_str + component_id + ".log";
 
     log_file = fopen(filename.c_str(), "a");
-    if(log_file == NULL)
+    if (log_file == NULL)
     {
         cerr << "[Log::init] Could not open log file: " << filename << endl;
         log_file = fopen("Gravity.log", "a");
-        if(log_file == NULL)
+        if (log_file == NULL)
         {
             log_file = fopen("/dev/null", "a");
             cerr << "[Log::init] Could not open log file: Gravity.log" << endl;
@@ -90,19 +96,19 @@ void FileLogger::Log(int level, const char* messagestr)
 {
     //Format the Logs nicely.
     char timestr[100];
-    struct tm * timeinfo;
+    struct tm* timeinfo;
     time_t rawtime;
     string format = "%m/%d/%y %H:%M:%S";
 
 #ifdef WIN32
-    time ( &rawtime );
-    timeinfo = localtime( &rawtime );
+    time(&rawtime);
+    timeinfo = localtime(&rawtime);
     strftime(timestr, 100, format.c_str(), timeinfo);
 #else
-    struct timeval  tv;
+    struct timeval tv;
     gettimeofday(&tv, NULL);
     rawtime = tv.tv_sec;
-    timeinfo = localtime( &rawtime );
+    timeinfo = localtime(&rawtime);
     format = format + ".%%06u";
     char buffer[100];
     strftime(buffer, 100, format.c_str(), timeinfo);
@@ -112,11 +118,11 @@ void FileLogger::Log(int level, const char* messagestr)
     if (close_file_after_write)
     {
         log_file = fopen(filename.c_str(), "a");
-        if(log_file == NULL)
+        if (log_file == NULL)
         {
             cerr << "[Log::init] Could not open log file: " << filename << endl;
             log_file = fopen("Gravity.log", "a");
-            if(log_file == NULL)
+            if (log_file == NULL)
             {
                 log_file = fopen("/dev/null", "a");
                 cerr << "[Log::init] Could not open log file: Gravity.log" << endl;
@@ -129,7 +135,7 @@ void FileLogger::Log(int level, const char* messagestr)
     fputs(messagestr, log_file);
     fputs("\n", log_file);
 
-    fflush(log_file); //I'm not sure when or how often this should be called.
+    fflush(log_file);  //I'm not sure when or how often this should be called.
 
     if (close_file_after_write)
     {
@@ -137,12 +143,10 @@ void FileLogger::Log(int level, const char* messagestr)
     }
 }
 
-FileLogger::~FileLogger()
-{
-    fclose(log_file);
-}
+FileLogger::~FileLogger() { fclose(log_file); }
 
-void Log::initAndAddFileLogger(const char* log_dir, const char* comp_id, LogLevel local_log_level, bool close_file_after_write)
+void Log::initAndAddFileLogger(const char* log_dir, const char* comp_id, LogLevel local_log_level,
+                               bool close_file_after_write)
 {
     Log::initAndAddLogger(new FileLogger(log_dir, comp_id, close_file_after_write), local_log_level);
 }
@@ -158,7 +162,8 @@ public:
 
 ConsoleLogger::ConsoleLogger(const string& comp_id) : FileLogger(comp_id)
 {
-    log_file = stdout; //fdopen(dup(STDOUT_FILENO), "w"); //Duplicate the file handle so we can close it after we're done with it.
+    log_file =
+        stdout;  //fdopen(dup(STDOUT_FILENO), "w"); //Duplicate the file handle so we can close it after we're done with it.
     //I hope this is the right way to do this.
 }
 
@@ -172,7 +177,7 @@ void Log::initAndAddConsoleLogger(const char* comp_id, LogLevel local_log_level)
 //
 
 //Initialize
-std::list< std::pair<Logger*, int> > Log::loggers;
+std::list<std::pair<Logger*, int> > Log::loggers;
 Semaphore Log::lock;
 
 void Log::initAndAddLogger(Logger* logger, LogLevel log_level)
@@ -182,11 +187,11 @@ void Log::initAndAddLogger(Logger* logger, LogLevel log_level)
     //safeguard against adding duplicate logger
     for (auto i = loggers.begin(); i != loggers.end(); ++i)
     {
-      if (i->first == logger)
-      {
-        lock.Unlock();
-        return;
-      }
+        if (i->first == logger)
+        {
+            lock.Unlock();
+            return;
+        }
     }
 
     loggers.push_back(make_pair(logger, Log::LevelToInt(log_level)));
@@ -195,38 +200,38 @@ void Log::initAndAddLogger(Logger* logger, LogLevel log_level)
 
 void Log::RemoveLogger(Logger* logger)
 {
-  lock.Lock();
-  std::list< std::pair<Logger*, int> >::iterator i = loggers.begin();
-	while(i != loggers.end())
-	{
-		if(i->first == logger)
-		{
-      delete i->first;
-			i = loggers.erase(i);
-		}
-		else
-		{
-		    i++;
-		}
-	}
-  lock.Unlock();
+    lock.Lock();
+    std::list<std::pair<Logger*, int> >::iterator i = loggers.begin();
+    while (i != loggers.end())
+    {
+        if (i->first == logger)
+        {
+            delete i->first;
+            i = loggers.erase(i);
+        }
+        else
+        {
+            i++;
+        }
+    }
+    lock.Unlock();
 }
 
 const char* Log::LogLevelToString(LogLevel level)
 {
-    if(level == Log::FATAL)
+    if (level == Log::FATAL)
         return "FATAL";
-    else if(level == Log::CRITICAL)
+    else if (level == Log::CRITICAL)
         return "CRITICAL";
-    else if(level == Log::WARNING)
+    else if (level == Log::WARNING)
         return "WARNING";
-    else if(level == Log::MESSAGE)
+    else if (level == Log::MESSAGE)
         return "MESSAGE";
-    else if(level == Log::DEBUG)
+    else if (level == Log::DEBUG)
         return "DEBUG";
-    else if(level == Log::TRACE)
+    else if (level == Log::TRACE)
         return "TRACE";
-    return ""; //Get Rid of Warning.
+    return "";  //Get Rid of Warning.
 }
 
 Log::LogLevel Log::LogStringToLevel(const char* level)
@@ -234,17 +239,17 @@ Log::LogLevel Log::LogStringToLevel(const char* level)
     char* llevel = strdup(level);
     StringToLowerCase(llevel, strlen(llevel));
     Log::LogLevel ret = Log::NONE;
-    if(strcmp(llevel, "fatal") == 0)
+    if (strcmp(llevel, "fatal") == 0)
         ret = Log::FATAL;
-    else if(strcmp(llevel, "critical") == 0)
+    else if (strcmp(llevel, "critical") == 0)
         ret = Log::CRITICAL;
-    else if(strcmp(llevel, "warning") == 0)
+    else if (strcmp(llevel, "warning") == 0)
         ret = Log::WARNING;
-    else if(strcmp(llevel, "message") == 0)
+    else if (strcmp(llevel, "message") == 0)
         ret = Log::MESSAGE;
-    else if(strcmp(llevel, "debug") == 0)
+    else if (strcmp(llevel, "debug") == 0)
         ret = Log::DEBUG;
-    else if(strcmp(llevel, "trace") == 0)
+    else if (strcmp(llevel, "trace") == 0)
         ret = Log::TRACE;
     free(llevel);
     return ret;
@@ -252,13 +257,12 @@ Log::LogLevel Log::LogStringToLevel(const char* level)
 
 int32_t Log::detectPercentN(const char* format)
 {
-
     const char subspecs[] = {// flags
                              '-', '+', '0', ' ', '#',
                              // width/precision
                              '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', '*',
                              // modifiers
-                             'h', 'l', 'L', 'z', 'j', 't' };
+                             'h', 'l', 'L', 'z', 'j', 't'};
     size_t pos = 0;
     std::string checkStr(format);
     while (pos < checkStr.length())
@@ -281,9 +285,9 @@ int32_t Log::detectPercentN(const char* format)
 void Log::vLog(int level, const char* format, va_list args)
 {
     lock.Lock();
-    std::list< std::pair<Logger*, int> >::const_iterator i = loggers.begin();
-    std::list< std::pair<Logger*, int> >::const_iterator l_end = loggers.end();
-    if(i != l_end)
+    std::list<std::pair<Logger*, int> >::const_iterator i = loggers.begin();
+    std::list<std::pair<Logger*, int> >::const_iterator l_end = loggers.end();
+    if (i != l_end)
     {
         const uint32_t maxStrLen = 4096;
         char messageStr[maxStrLen];
@@ -309,16 +313,15 @@ void Log::vLog(int level, const char* format, va_list args)
         else
         {
             vsnprintf(messageStr, maxStrLen, format, args);
-			// make sure null terminated
-			messageStr[maxStrLen-1] = (char)NULL;
+            // make sure null terminated
+            messageStr[maxStrLen - 1] = (char)NULL;
         }
 
         do
         {
-            if(i->second & level)
-                i->first->Log(level, messageStr);
+            if (i->second & level) i->first->Log(level, messageStr);
             i++;
-        } while(i != l_end);
+        } while (i != l_end);
     }
     lock.Unlock();
 }
@@ -326,7 +329,7 @@ void Log::vLog(int level, const char* format, va_list args)
 int Log::LevelToInt(LogLevel level)
 {
     int int_level;
-    switch(level)
+    switch (level)
     {
         case FATAL:
             int_level = FATAL;
@@ -347,103 +350,107 @@ int Log::LevelToInt(LogLevel level)
             int_level = FATAL | CRITICAL | WARNING | MESSAGE | DEBUG | TRACE;
             break;
         case NONE:
-        	int_level = 0;
-        	break;
+            int_level = 0;
+            break;
         default:
-        	int_level = FATAL | CRITICAL | WARNING | MESSAGE | DEBUG | TRACE;
-        	break;
+            int_level = FATAL | CRITICAL | WARNING | MESSAGE | DEBUG | TRACE;
+            break;
     }
 
     return int_level;
 }
 
-
 void Log::CloseLoggers()
 {
     lock.Lock();
-    std::list< std::pair<Logger*, int> >::iterator i = loggers.begin();
-    
+    std::list<std::pair<Logger*, int> >::iterator i = loggers.begin();
+
     //Remove all Loggers
-    while(i != loggers.end())  
+    while (i != loggers.end())
     {
-      delete i->first;
-			i = loggers.erase(i);
+        delete i->first;
+        i = loggers.erase(i);
     }
     lock.Unlock();
 }
 
 int Log::NumberOfLoggers()
 {
-  lock.Lock();
-  int size = loggers.size();
-  lock.Unlock(); 
-  return size;
+    lock.Lock();
+    int size = loggers.size();
+    lock.Unlock();
+    return size;
 }
 
 //Using functions instead of macros so we can use namespaces.
 #if COMPILE_GRAVITY_LOGGING_LEVEL >= GRAVITY_LOG_FATAL
-void Log::fatal(const char* message, ...) {
+void Log::fatal(const char* message, ...)
+{
     va_list args;
-    va_start ( args, message );
+    va_start(args, message);
     Log::vLog(FATAL, message, args);
-    va_end ( args );
+    va_end(args);
 }
 #else
-void Log::fatal(const char* message, ...) { }
+void Log::fatal(const char* message, ...) {}
 #endif
 
 #if COMPILE_GRAVITY_LOGGING_LEVEL >= GRAVITY_LOG_CRITICAL
-void Log::critical(const char* message, ...) {
+void Log::critical(const char* message, ...)
+{
     va_list args1;
-    va_start ( args1, message );
+    va_start(args1, message);
     Log::vLog(CRITICAL, message, args1);
-    va_end ( args1 );
+    va_end(args1);
 }
 #else
-void Log::critical(const char* message, ...) { }
+void Log::critical(const char* message, ...) {}
 #endif
 
 #if COMPILE_GRAVITY_LOGGING_LEVEL >= GRAVITY_LOG_WARNING
-void Log::warning(const char* message, ...) {
+void Log::warning(const char* message, ...)
+{
     va_list args;
-    va_start ( args, message );
+    va_start(args, message);
     Log::vLog(WARNING, message, args);
-    va_end ( args );
+    va_end(args);
 }
 #else
-void Log::warning(const char* message, ...) { }
+void Log::warning(const char* message, ...) {}
 #endif
 
 #if COMPILE_GRAVITY_LOGGING_LEVEL >= GRAVITY_LOG_MESSAGE
-void Log::message(const char* message, ...) {
+void Log::message(const char* message, ...)
+{
     va_list args;
-    va_start ( args, message );
+    va_start(args, message);
     Log::vLog(MESSAGE, message, args);
-    va_end ( args );
+    va_end(args);
 }
 #else
-void Log::message(const char* message, ...) { }
+void Log::message(const char* message, ...) {}
 #endif
 
-
 #if COMPILE_GRAVITY_LOGGING_LEVEL >= GRAVITY_LOG_DEBUG
-void Log::debug(const char* message, ...) {
+void Log::debug(const char* message, ...)
+{
     va_list args;
-    va_start ( args, message );
+    va_start(args, message);
     Log::vLog(DEBUG, message, args);
-    va_end ( args );
+    va_end(args);
 }
 #else
-void Log::debug(const char* message, ...) { }
+void Log::debug(const char* message, ...) {}
 #endif
 
 #if COMPILE_GRAVITY_LOGGING_LEVEL >= GRAVITY_LOG_TRACE
-void Log::trace(const char* message, ...) {
+void Log::trace(const char* message, ...)
+{
     va_list args;
-    va_start ( args, message );
+    va_start(args, message);
     Log::vLog(TRACE, message, args);
-    va_end ( args );
+    va_end(args);
 }
 #else
-void Log::trace(const char* message, ...) { }
+void Log::trace(const char* message, ...) {}
 #endif

--- a/src/api/cpp/GravityLogger.h
+++ b/src/api/cpp/GravityLogger.h
@@ -27,7 +27,8 @@
 
 //class GravityNode {};
 
-namespace gravity {
+namespace gravity
+{
 
 #define GRAVITY_LOG_FATAL 0
 #define GRAVITY_LOG_CRITICAL 1
@@ -43,7 +44,8 @@ namespace gravity {
 /**
  * Interface for a log writer.
  */
-class Logger {
+class Logger
+{
 public:
     /** 
      * Called by the logger when the user logs at a level which the instance of this class is set to log at.  
@@ -65,14 +67,15 @@ public:
     /**
      * Log Levels
      */
-    enum LogLevel {
-        NONE = 0, ///< logging is off
-        FATAL = 1, ///< only log fatal level messages
-        CRITICAL = 1 << GRAVITY_LOG_CRITICAL, ///< log critical level messages and above
-        WARNING = 1 << GRAVITY_LOG_WARNING, ///< log warning level messages and above
-        MESSAGE = 1 << GRAVITY_LOG_MESSAGE, ///< log message level  messages and above
-        DEBUG = 1 << GRAVITY_LOG_DEBUG, ///< log debug level messages and above
-        TRACE = 1 << GRAVITY_LOG_TRACE ///< log trace level messages and above
+    enum LogLevel
+    {
+        NONE = 0,                              ///< logging is off
+        FATAL = 1,                             ///< only log fatal level messages
+        CRITICAL = 1 << GRAVITY_LOG_CRITICAL,  ///< log critical level messages and above
+        WARNING = 1 << GRAVITY_LOG_WARNING,    ///< log warning level messages and above
+        MESSAGE = 1 << GRAVITY_LOG_MESSAGE,    ///< log message level  messages and above
+        DEBUG = 1 << GRAVITY_LOG_DEBUG,        ///< log debug level messages and above
+        TRACE = 1 << GRAVITY_LOG_TRACE         ///< log trace level messages and above
     };
     /**
      * @name Helper functions
@@ -86,7 +89,7 @@ public:
      * This function is not case sensitive.
      */
     GRAVITY_API static LogLevel LogStringToLevel(const char* string);
-    /** @} */ //Helper functions
+    /** @} */  //Helper functions
 
     /**
      * Initialize a Logger to log to a file.  
@@ -97,7 +100,8 @@ public:
      * \param local_log_level          The initial local logging level.
      * \param close_file_after_write   Boolean that indicates whether the log file should be kept open between writes.  Defaults to false.
      */
-    GRAVITY_API static void initAndAddFileLogger(const char* directory, const char* comp_id, LogLevel local_log_level, bool close_file_after_write = false);
+    GRAVITY_API static void initAndAddFileLogger(const char* directory, const char* comp_id, LogLevel local_log_level,
+                                                 bool close_file_after_write = false);
 
     /**
      * Initialize a Logger to log to the console.
@@ -136,7 +140,7 @@ public:
     GRAVITY_API static void debug(const char* message, ...);
     GRAVITY_API static void trace(const char* message, ...);
 
-    /** @} */ //Logging Functions
+    /** @} */  //Logging Functions
 
     /**
      * Removes the specified Logger.
@@ -148,12 +152,13 @@ public:
      * Return the number of open loggers.
      */
     GRAVITY_API static int NumberOfLoggers();
+
 private:
     /**
      * Calls the Logger::Log function for each initialized Logger 
      */
     static void vLog(int level, const char* format, va_list args);
-    
+
     /**
      * Returns the LogLevel enum as an int.
      */
@@ -164,9 +169,9 @@ private:
     /**
      * List of all initialized Loggers.
      */
-    static std::list< std::pair<Logger*, int> > loggers;
+    static std::list<std::pair<Logger*, int> > loggers;
     static Semaphore lock;
 };
 
-} //Namespace
+}  // namespace gravity
 #endif

--- a/src/api/cpp/GravityMetrics.cpp
+++ b/src/api/cpp/GravityMetrics.cpp
@@ -30,14 +30,12 @@
 
 using namespace std;
 
-namespace gravity {
+namespace gravity
+{
 
 GravityMetrics::GravityMetrics() : startTime(0), endTime(0) {}
 
-GravityMetrics::GravityMetrics(void* socket)
-{
-    populateFromMessage(socket);
-}
+GravityMetrics::GravityMetrics(void* socket) { populateFromMessage(socket); }
 
 GravityMetrics::~GravityMetrics() {}
 
@@ -46,10 +44,7 @@ void GravityMetrics::incrementMessageCount(string dataProductID, int count)
     metrics[dataProductID].messageCount += count;
 }
 
-void GravityMetrics::incrementByteCount(string dataProductID, int count)
-{
-    metrics[dataProductID].byteCount += count;
-}
+void GravityMetrics::incrementByteCount(string dataProductID, int count) { metrics[dataProductID].byteCount += count; }
 
 void GravityMetrics::reset()
 {
@@ -70,17 +65,14 @@ void GravityMetrics::clear()
     endTime = 0;
 }
 
-void GravityMetrics::remove(std::string dataProductID)
-{
-    metrics.erase(dataProductID);
-}
+void GravityMetrics::remove(std::string dataProductID) { metrics.erase(dataProductID); }
 
 int GravityMetrics::getMessageCount(string dataProductID)
 {
     int count = -1;
     if (metrics.count(dataProductID))
     {
-    	count = metrics[dataProductID].messageCount;
+        count = metrics[dataProductID].messageCount;
     }
     return count;
 }
@@ -90,32 +82,23 @@ int GravityMetrics::getByteCount(string dataProductID)
     int count = -1;
     if (metrics.count(dataProductID))
     {
-    	count = metrics[dataProductID].byteCount;
+        count = metrics[dataProductID].byteCount;
     }
     return count;
 }
 
-uint64_t GravityMetrics::getStartTime()
-{
-    return startTime;
-}
+uint64_t GravityMetrics::getStartTime() { return startTime; }
 
-uint64_t GravityMetrics::getEndTime()
-{
-    return endTime;
-}
+uint64_t GravityMetrics::getEndTime() { return endTime; }
 
-void GravityMetrics::done()
-{
-    endTime = gravity::getCurrentTime();
-}
+void GravityMetrics::done() { endTime = gravity::getCurrentTime(); }
 
 double GravityMetrics::getSamplePeriodSeconds()
 {
     double ret = -1;
     if (startTime > 0 && endTime > 0)
     {
-	// convert from us to s
+        // convert from us to s
         ret = ((double)(endTime - startTime)) / 1e6;
     }
     return ret;
@@ -137,8 +120,8 @@ void GravityMetrics::sendAsMessage(void* socket)
             sendIntMessage(socket, it->second.messageCount, ZMQ_SNDMORE);
             sendIntMessage(socket, it->second.byteCount, ZMQ_SNDMORE);
         }
-	sendUint64Message(socket, startTime, ZMQ_SNDMORE);
-	sendUint64Message(socket, endTime, ZMQ_DONTWAIT);
+        sendUint64Message(socket, startTime, ZMQ_SNDMORE);
+        sendUint64Message(socket, endTime, ZMQ_DONTWAIT);
     }
 }
 

--- a/src/api/cpp/GravityMetrics.h
+++ b/src/api/cpp/GravityMetrics.h
@@ -50,6 +50,7 @@ private:
     std::map<std::string, MetricsSample> metrics;
     uint64_t startTime;
     uint64_t endTime;
+
 public:
     /**
      * Creates an empty GravityMetrics object

--- a/src/api/cpp/GravityMetricsManager.cpp
+++ b/src/api/cpp/GravityMetricsManager.cpp
@@ -35,207 +35,207 @@
 namespace gravity
 {
 
-    using namespace std;
+using namespace std;
 
-    GravityMetricsManager::GravityMetricsManager(void* context)
+GravityMetricsManager::GravityMetricsManager(void* context)
+{
+    // This is the zmq context that is shared with the GravityNode. Must use
+    // a shared context to establish an inproc socket.
+    this->context = context;
+    logger = spdlog::get("GravityLogger");
+}
+
+GravityMetricsManager::~GravityMetricsManager() {}
+
+void GravityMetricsManager::start()
+{
+    metricsPubSocket = zmq_socket(context, ZMQ_PUB);
+    zmq_bind(metricsPubSocket, GRAVITY_METRICS_PUB);
+
+    // Setup inproc socket to subscribe to metrics control messages
+    metricsControlSocket = zmq_socket(context, ZMQ_SUB);
+    zmq_connect(metricsControlSocket, GRAVITY_METRICS_CONTROL);
+    zmq_setsockopt(metricsControlSocket, ZMQ_SUBSCRIBE, NULL, 0);
+
+    // Setup comms channel to request metrics from the GravityPublishManager
+    pubMetricsSocket = zmq_socket(context, ZMQ_REQ);
+    int ret = zmq_connect(pubMetricsSocket, GRAVITY_PUB_METRICS_REQ);
+    while (ret == -1)
     {
-        // This is the zmq context that is shared with the GravityNode. Must use
-        // a shared context to establish an inproc socket.
-        this->context = context;
-		logger = spdlog::get("GravityLogger");
+        sleep(1000);
+        ret = zmq_connect(pubMetricsSocket, GRAVITY_PUB_METRICS_REQ);
     }
 
-    GravityMetricsManager::~GravityMetricsManager() {}
-
-    void GravityMetricsManager::start()
+    // Setup comms channel to request metrics from the GravitySubscriptionManager
+    subMetricsSocket = zmq_socket(context, ZMQ_REQ);
+    ret = zmq_connect(subMetricsSocket, GRAVITY_SUB_METRICS_REQ);
+    while (ret == -1)
     {
-        metricsPubSocket = zmq_socket(context, ZMQ_PUB);
-        zmq_bind(metricsPubSocket, GRAVITY_METRICS_PUB);
-
-        // Setup inproc socket to subscribe to metrics control messages
-        metricsControlSocket = zmq_socket(context, ZMQ_SUB);
-        zmq_connect(metricsControlSocket, GRAVITY_METRICS_CONTROL);
-        zmq_setsockopt(metricsControlSocket, ZMQ_SUBSCRIBE, NULL, 0);
-
-        // Setup comms channel to request metrics from the GravityPublishManager
-        pubMetricsSocket = zmq_socket(context, ZMQ_REQ);
-        int ret = zmq_connect(pubMetricsSocket, GRAVITY_PUB_METRICS_REQ);
-        while (ret == -1)
-        {
-            sleep(1000);
-            ret = zmq_connect(pubMetricsSocket, GRAVITY_PUB_METRICS_REQ);
-        }
-
-        // Setup comms channel to request metrics from the GravitySubscriptionManager
-        subMetricsSocket = zmq_socket(context, ZMQ_REQ);
+        sleep(1000);
         ret = zmq_connect(subMetricsSocket, GRAVITY_SUB_METRICS_REQ);
-        while (ret == -1)
+    }
+
+    // Setup the poll item for control
+    zmq_pollitem_t pollItemControl;
+    pollItemControl.socket = metricsControlSocket;
+    pollItemControl.events = ZMQ_POLLIN;
+    pollItemControl.fd = 0;
+    pollItemControl.revents = 0;
+    pollItems.push_back(pollItemControl);
+
+    // Configured. Signal our readiness
+    ready();
+
+    int pollFlag;
+    int sampleCount = 0;
+    metricsEnabled = false;
+    // Process forever...
+    while (true)
+    {
+        pollFlag = metricsEnabled ? 0 : -1;
+        // Start polling metrics control socket
+        int rc = zmq_poll(&pollItems[0], pollItems.size(), pollFlag);  // 0 --> return immediately, -1 --> blocks
+        if (rc == -1)
         {
-            sleep(1000);
-            ret = zmq_connect(subMetricsSocket, GRAVITY_SUB_METRICS_REQ);
+            // Interrupted
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            // Error
+            break;
         }
 
-        // Setup the poll item for control
-        zmq_pollitem_t pollItemControl;
-        pollItemControl.socket = metricsControlSocket;
-        pollItemControl.events = ZMQ_POLLIN;
-        pollItemControl.fd = 0;
-        pollItemControl.revents = 0;
-        pollItems.push_back(pollItemControl);
-
-        // Configured. Signal our readiness
-        ready();
-
-        int pollFlag;
-        int sampleCount = 0;
-        metricsEnabled = false;
-        // Process forever...
-        while (true)
+        // Process incoming data requests from the gravity node
+        if (pollItems[0].revents & ZMQ_POLLIN)
         {
-            pollFlag = metricsEnabled ? 0 : -1;
-            // Start polling metrics control socket
-            int rc = zmq_poll(&pollItems[0], pollItems.size(), pollFlag); // 0 --> return immediately, -1 --> blocks
-            if (rc == -1)
+            // Get new GravityNode request
+            string command = readStringMessage(metricsControlSocket);
+
+            if (command == "MetricsEnable")
             {
-                // Interrupted
-                if (errno == EINTR)
-                {
-                    continue;
-                }
-                // Error
+                metricsEnabled = true;
+
+                samplePeriod = readIntMessage(metricsControlSocket);
+                samplesPerPublish = readIntMessage(metricsControlSocket);
+                sampleCount = 0;
+
+                componentID = readStringMessage(metricsControlSocket);
+                ipAddr = readStringMessage(metricsControlSocket);
+                regTimestamp = readIntMessage(metricsControlSocket);
+
+                // Send metrics enable message to the collectors
+                sendStringMessage(pubMetricsSocket, command, ZMQ_DONTWAIT);
+                string s = readStringMessage(pubMetricsSocket);
+                sendStringMessage(subMetricsSocket, command, ZMQ_DONTWAIT);
+                s = readStringMessage(subMetricsSocket);
+            }
+            else if (command == "MetricsDisable")
+            {
+                metricsEnabled = false;
+            }
+            else if (command == "kill")
+            {
                 break;
             }
-
-            // Process incoming data requests from the gravity node
-            if (pollItems[0].revents & ZMQ_POLLIN)
+            else
             {
-                // Get new GravityNode request
-                string command = readStringMessage(metricsControlSocket);
-
-                if (command == "MetricsEnable")
-                {
-                    metricsEnabled = true;
-
-                    samplePeriod = readIntMessage(metricsControlSocket);
-                    samplesPerPublish = readIntMessage(metricsControlSocket);
-                    sampleCount = 0;
-
-                    componentID = readStringMessage(metricsControlSocket);
-                    ipAddr = readStringMessage(metricsControlSocket);
-                    regTimestamp = readIntMessage(metricsControlSocket);
-
-                    // Send metrics enable message to the collectors
-                    sendStringMessage(pubMetricsSocket, command, ZMQ_DONTWAIT);
-                    string s = readStringMessage(pubMetricsSocket);
-                    sendStringMessage(subMetricsSocket, command, ZMQ_DONTWAIT);
-                    s = readStringMessage(subMetricsSocket);
-                }
-                else if (command == "MetricsDisable")
-                {
-                    metricsEnabled = false;
-                }
-                else if (command == "kill")
-                {
-                    break;
-                }
-                else
-                {
-					logger->warn("GravityMetricsManager received unknown command '{}' from GravityNode", command);
-                }
-            }
-
-            if (metricsEnabled)
-            {
-                // Wait for samplePeriod seconds and make metrics request
-                gravity::sleep(samplePeriod * 1000);
-                collectMetrics(pubMetricsSocket, GravityMetricsPB::PUBLICATION);
-                collectMetrics(subMetricsSocket, GravityMetricsPB::SUBSCRIPTION);
-
-                // If we've collected samplesPerPublish samples, publish metrics
-                if (++sampleCount == samplesPerPublish)
-                {
-                    publishMetrics();
-                    sampleCount = 0;
-                }
+                logger->warn("GravityMetricsManager received unknown command '{}' from GravityNode", command);
             }
         }
 
-        // Clean up sockets
-        zmq_close(metricsPubSocket);
-        zmq_close(metricsControlSocket);
-        zmq_close(pubMetricsSocket);
-        zmq_close(subMetricsSocket);
-    }
-
-    void GravityMetricsManager::ready()
-    {
-        // Create the request socket
-        void* initSocket = zmq_socket(context, ZMQ_REQ);
-
-        // Connect to service
-        zmq_connect(initSocket, "inproc://gravity_init");
-
-        // Send request to service provider
-        sendStringMessage(initSocket, "GravityMetricsManager", ZMQ_DONTWAIT);
-
-        zmq_close(initSocket);
-    }
-
-    void GravityMetricsManager::collectMetrics(void* socket, GravityMetricsPB_MessageType type)
-    {
-        GravityMetrics metrics;
-        sendStringMessage(socket, "GetMetrics", ZMQ_DONTWAIT);
-        metrics.populateFromMessage(socket);
-
-        vector<string> dataProductIDs = metrics.getDataProductIDs();
-        for (vector<string>::iterator it = dataProductIDs.begin(); it != dataProductIDs.end(); ++it)
+        if (metricsEnabled)
         {
-            string dataProductID = *it;
+            // Wait for samplePeriod seconds and make metrics request
+            gravity::sleep(samplePeriod * 1000);
+            collectMetrics(pubMetricsSocket, GravityMetricsPB::PUBLICATION);
+            collectMetrics(subMetricsSocket, GravityMetricsPB::SUBSCRIPTION);
 
-            pair<string,GravityMetricsPB_MessageType> key (dataProductID, type);
-            GravityMetricsPB gmPB = metricsData[key];
-            if (!gmPB.has_dataproductid())
+            // If we've collected samplesPerPublish samples, publish metrics
+            if (++sampleCount == samplesPerPublish)
             {
-                gmPB.set_dataproductid(dataProductID);
-                gmPB.set_messagetype(type);
+                publishMetrics();
+                sampleCount = 0;
             }
-            gmPB.add_numbytes(metrics.getByteCount(dataProductID));
-            gmPB.add_nummessages(metrics.getMessageCount(dataProductID));
-            gmPB.add_starttime(metrics.getStartTime());
-            gmPB.add_endtime(metrics.getEndTime());
-            metricsData[key] = gmPB;
         }
     }
 
-    void GravityMetricsManager::publishMetrics()
+    // Clean up sockets
+    zmq_close(metricsPubSocket);
+    zmq_close(metricsControlSocket);
+    zmq_close(pubMetricsSocket);
+    zmq_close(subMetricsSocket);
+}
+
+void GravityMetricsManager::ready()
+{
+    // Create the request socket
+    void* initSocket = zmq_socket(context, ZMQ_REQ);
+
+    // Connect to service
+    zmq_connect(initSocket, "inproc://gravity_init");
+
+    // Send request to service provider
+    sendStringMessage(initSocket, "GravityMetricsManager", ZMQ_DONTWAIT);
+
+    zmq_close(initSocket);
+}
+
+void GravityMetricsManager::collectMetrics(void* socket, GravityMetricsPB_MessageType type)
+{
+    GravityMetrics metrics;
+    sendStringMessage(socket, "GetMetrics", ZMQ_DONTWAIT);
+    metrics.populateFromMessage(socket);
+
+    vector<string> dataProductIDs = metrics.getDataProductIDs();
+    for (vector<string>::iterator it = dataProductIDs.begin(); it != dataProductIDs.end(); ++it)
     {
-        GravityMetricsDataPB metrics;
-        metrics.set_componentid(componentID);
-        metrics.set_ipaddress(ipAddr);
+        string dataProductID = *it;
 
-        map<pair<string, GravityMetricsPB_MessageType>, GravityMetricsPB>::iterator it;
-        for (it = metricsData.begin(); it != metricsData.end(); ++it)
+        pair<string, GravityMetricsPB_MessageType> key(dataProductID, type);
+        GravityMetricsPB gmPB = metricsData[key];
+        if (!gmPB.has_dataproductid())
         {
-            GravityMetricsPB* gmPB = metrics.add_metrics();
-            *gmPB = it->second;
+            gmPB.set_dataproductid(dataProductID);
+            gmPB.set_messagetype(type);
         }
-
-        GravityDataProduct gdp(gravity::constants::METRICS_DATA_DPID);
-        gdp.setTimestamp(gravity::getCurrentTime());
-        gdp.setRegistrationTime(regTimestamp);
-        gdp.setData(metrics);
-
-        // Send publish command and empty filter
-        sendStringMessage(metricsPubSocket, "publish", ZMQ_SNDMORE);
-        sendStringMessage(metricsPubSocket, gdp.getDataProductID(), ZMQ_SNDMORE);
-        sendUint64Message(metricsPubSocket, gdp.getGravityTimestamp(), ZMQ_SNDMORE);
-        sendStringMessage(metricsPubSocket, componentID, ZMQ_SNDMORE);
-
-        // Publish metrics
-        sendGravityDataProduct(metricsPubSocket, gdp, ZMQ_DONTWAIT);
-
-        // Clear metrics data for next round
-        metricsData.clear();
+        gmPB.add_numbytes(metrics.getByteCount(dataProductID));
+        gmPB.add_nummessages(metrics.getMessageCount(dataProductID));
+        gmPB.add_starttime(metrics.getStartTime());
+        gmPB.add_endtime(metrics.getEndTime());
+        metricsData[key] = gmPB;
     }
+}
+
+void GravityMetricsManager::publishMetrics()
+{
+    GravityMetricsDataPB metrics;
+    metrics.set_componentid(componentID);
+    metrics.set_ipaddress(ipAddr);
+
+    map<pair<string, GravityMetricsPB_MessageType>, GravityMetricsPB>::iterator it;
+    for (it = metricsData.begin(); it != metricsData.end(); ++it)
+    {
+        GravityMetricsPB* gmPB = metrics.add_metrics();
+        *gmPB = it->second;
+    }
+
+    GravityDataProduct gdp(gravity::constants::METRICS_DATA_DPID);
+    gdp.setTimestamp(gravity::getCurrentTime());
+    gdp.setRegistrationTime(regTimestamp);
+    gdp.setData(metrics);
+
+    // Send publish command and empty filter
+    sendStringMessage(metricsPubSocket, "publish", ZMQ_SNDMORE);
+    sendStringMessage(metricsPubSocket, gdp.getDataProductID(), ZMQ_SNDMORE);
+    sendUint64Message(metricsPubSocket, gdp.getGravityTimestamp(), ZMQ_SNDMORE);
+    sendStringMessage(metricsPubSocket, componentID, ZMQ_SNDMORE);
+
+    // Publish metrics
+    sendGravityDataProduct(metricsPubSocket, gdp, ZMQ_DONTWAIT);
+
+    // Clear metrics data for next round
+    metricsData.clear();
+}
 
 } /* namespace gravity */

--- a/src/api/cpp/GravityMetricsManager.h
+++ b/src/api/cpp/GravityMetricsManager.h
@@ -50,46 +50,46 @@ namespace gravity
 class GravityMetricsManager
 {
 private:
-	void* context;
-	void* metricsControlSocket;
-	void* pubMetricsSocket;
-	void* subMetricsSocket;
-	void* metricsPubSocket;
-	std::vector<zmq_pollitem_t> pollItems;
+    void* context;
+    void* metricsControlSocket;
+    void* pubMetricsSocket;
+    void* subMetricsSocket;
+    void* metricsPubSocket;
+    std::vector<zmq_pollitem_t> pollItems;
 
-	void ready();
-	void publishMetricsReport();
+    void ready();
+    void publishMetricsReport();
 
-	bool metricsEnabled;
-	int samplePeriod;
-	int samplesPerPublish;
-	std::string componentID;
-	std::string ipAddr;
-	int regTimestamp;
-	std::map<std::pair<std::string,GravityMetricsPB_MessageType>,  GravityMetricsPB> metricsData;
+    bool metricsEnabled;
+    int samplePeriod;
+    int samplesPerPublish;
+    std::string componentID;
+    std::string ipAddr;
+    int regTimestamp;
+    std::map<std::pair<std::string, GravityMetricsPB_MessageType>, GravityMetricsPB> metricsData;
 
-	void collectMetrics(void* socket, GravityMetricsPB_MessageType type);
-	void publishMetrics();
-	
-	std::shared_ptr<spdlog::logger> logger;
-	
+    void collectMetrics(void* socket, GravityMetricsPB_MessageType type);
+    void publishMetrics();
+
+    std::shared_ptr<spdlog::logger> logger;
+
 public:
-	/**
+    /**
 	 * Constructor GravityMetricsManager
 	 * \param context The zmq context in which the inproc socket will be established with the GravityNode
 	 */
-	GravityMetricsManager(void* context);
+    GravityMetricsManager(void* context);
 
-	/**
+    /**
 	 * Default destructor
 	 */
-	virtual ~GravityMetricsManager();
+    virtual ~GravityMetricsManager();
 
-	/**
+    /**
 	 * Starts the GravityMetricsManager which will run forever
 	 * Should be executed from GravityNode in its own thread with a shared zmq context.
 	 */
-	void start();
+    void start();
 };
 
 } /* namespace gravity */

--- a/src/api/cpp/GravityMetricsUtil.h
+++ b/src/api/cpp/GravityMetricsUtil.h
@@ -36,6 +36,5 @@ extern const char* GRAVITY_PUB_METRICS_REQ;
 extern const char* GRAVITY_SUB_METRICS_REQ;
 extern const char* GRAVITY_METRICS_PUB;
 
-
 } /* namespace gravity */
 #endif /* GRAVITYMETRICSUTIL_H_ */

--- a/src/api/cpp/GravityNode.cpp
+++ b/src/api/cpp/GravityNode.cpp
@@ -72,50 +72,50 @@
 #include "PublishSink.h"
 #include <mutex>
 
-#include "GravityNode.h" //Needs to be last on Windows so it is included after nb30.h for the DUPLICATE definition.
+#include "GravityNode.h"  //Needs to be last on Windows so it is included after nb30.h for the DUPLICATE definition.
 
 #ifdef WIN32
-    const std::string gravity::GravityNode::file_separator = "\\";
+const std::string gravity::GravityNode::file_separator = "\\";
 #else
-    const std::string gravity::GravityNode::file_separator = "/";
+const std::string gravity::GravityNode::file_separator = "/";
 #endif
 
 using proxy_dist_sink_mt = gravity::proxy_dist_sink<std::mutex>;
 
 static void* startSubscriptionManager(void* context)
 {
-	// Create and start the GravitySubscriptionManager
-	gravity::GravitySubscriptionManager subManager(context);
-	subManager.start();
+    // Create and start the GravitySubscriptionManager
+    gravity::GravitySubscriptionManager subManager(context);
+    subManager.start();
 
-	return NULL;
+    return NULL;
 }
 
 static void* startPublishManager(void* context)
 {
-	// Create and start the GravitySubscriptionManager
-	gravity::GravityPublishManager pubManager(context);
-	pubManager.start();
+    // Create and start the GravitySubscriptionManager
+    gravity::GravityPublishManager pubManager(context);
+    pubManager.start();
 
-	return NULL;
+    return NULL;
 }
 
 static void* startRequestManager(void* context)
 {
-	// Create and start the GravityRequestManager
-	gravity::GravityRequestManager reqManager(context);
-	reqManager.start();
+    // Create and start the GravityRequestManager
+    gravity::GravityRequestManager reqManager(context);
+    reqManager.start();
 
-	return NULL;
+    return NULL;
 }
 
 static void* startServiceManager(void* context)
 {
-	// Create and start the GravityServiceManager
-	gravity::GravityServiceManager serviceManager(context);
-	serviceManager.start();
+    // Create and start the GravityServiceManager
+    gravity::GravityServiceManager serviceManager(context);
+    serviceManager.start();
 
-	return NULL;
+    return NULL;
 }
 
 static void* startMetricsManager(void* context)
@@ -128,12 +128,12 @@ static void* startMetricsManager(void* context)
 }
 
 static int s_interrupted = 0;
-static void (*previousHandlerAbrt)(int); //Function Pointer
-static void (*previousHandlerInt)(int); //Function Pointer
+static void (*previousHandlerAbrt)(int);  //Function Pointer
+static void (*previousHandlerInt)(int);   //Function Pointer
 void s_restore_signals()
 {
-	signal(SIGABRT, previousHandlerAbrt);
-	signal(SIGINT, previousHandlerInt);
+    signal(SIGABRT, previousHandlerAbrt);
+    signal(SIGINT, previousHandlerInt);
 }
 
 static void s_signal_handler(int signal_value)
@@ -144,8 +144,8 @@ static void s_signal_handler(int signal_value)
 
 void s_catch_signals()
 {
-	previousHandlerAbrt = signal(SIGABRT, s_signal_handler);
-	previousHandlerInt = signal(SIGINT, s_signal_handler);
+    previousHandlerAbrt = signal(SIGABRT, s_signal_handler);
+    previousHandlerInt = signal(SIGINT, s_signal_handler);
 }
 
 namespace gravity
@@ -153,11 +153,11 @@ namespace gravity
 
 void* GravityNode::startGravityDomainListener(void* context)
 {
-	//Create and start  the GravityNodeDomainListener
-	GravityNodeDomainListener domainListener(context);
-	domainListener.start();
+    //Create and start  the GravityNodeDomainListener
+    GravityNodeDomainListener domainListener(context);
+    domainListener.start();
 
-	return NULL;
+    return NULL;
 }
 
 //Forward Declarations that we don't want publicly visible (Need to be in gravity namespace).
@@ -166,254 +166,251 @@ int StringToInt(std::string str, int default_value);
 double StringToDouble(std::string str, double default_value);
 void* Heartbeat(void* thread_context);
 
-
 using namespace std;
 
 GravityNode::GravityNodeDomainListener::GravityNodeDomainListener(void* context)
 {
-	this->context=context;
-	sock = 0;
-	running = false;
+    this->context = context;
+    sock = 0;
+    running = false;
 }
 
 GravityNode::GravityNodeDomainListener::~GravityNodeDomainListener()
 {
-	#ifdef _WIN32
-	closesocket(sock);
-	#else
-	close(sock);
-	#endif
+#ifdef _WIN32
+    closesocket(sock);
+#else
+    close(sock);
+#endif
 }
 
 void GravityNode::GravityNodeDomainListener::start()
 {
-	ready=false;
+    ready = false;
 
-	gravityNodeSocket = zmq_socket(context,ZMQ_REP);
-	zmq_connect(gravityNodeSocket,"inproc://gravity_domain_listener");
-	zmq_setsockopt(gravityNodeSocket, ZMQ_SUBSCRIBE, NULL, 0);
+    gravityNodeSocket = zmq_socket(context, ZMQ_REP);
+    zmq_connect(gravityNodeSocket, "inproc://gravity_domain_listener");
+    zmq_setsockopt(gravityNodeSocket, ZMQ_SUBSCRIBE, NULL, 0);
 
-	void* domainSocket=zmq_socket(context,ZMQ_PUB);
-	zmq_connect(domainSocket,"inproc://gravity_domain_receiver");
+    void* domainSocket = zmq_socket(context, ZMQ_PUB);
+    zmq_connect(domainSocket, "inproc://gravity_domain_receiver");
 
-	// Poll the gravity node
-	zmq_pollitem_t pollItem;
-	pollItem.socket = gravityNodeSocket;
-	pollItem.events = ZMQ_POLLIN;
-	pollItem.fd = 0;
-	pollItem.revents = 0;
+    // Poll the gravity node
+    zmq_pollitem_t pollItem;
+    pollItem.socket = gravityNodeSocket;
+    pollItem.events = ZMQ_POLLIN;
+    pollItem.fd = 0;
+    pollItem.revents = 0;
 
-	shared_ptr<spdlog::logger> logger = spdlog::get("GravityLogger");
+    shared_ptr<spdlog::logger> logger = spdlog::get("GravityLogger");
 
-	while(!ready)
-	{
-		// Start polling socket(s), blocking while we wait
-		int rc = zmq_poll(&pollItem, 1, -1); // 0 --> return immediately, -1 --> blocks
-		if (rc == -1)
-		{
-		    if (errno == EINTR)
-		    {
-			continue;
-		    }
-		    logger->debug("GravityNode zmq_poll error, exiting (errno = {})", errno);
-		    break;
-		}
+    while (!ready)
+    {
+        // Start polling socket(s), blocking while we wait
+        int rc = zmq_poll(&pollItem, 1, -1);  // 0 --> return immediately, -1 --> blocks
+        if (rc == -1)
+        {
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            logger->debug("GravityNode zmq_poll error, exiting (errno = {})", errno);
+            break;
+        }
 
-		// Process new subscription requests from the gravity node
-		if (pollItem.revents & ZMQ_POLLIN)
-		{
-			std::string command = readStringMessage(gravityNodeSocket);
-			if(command=="configure")
-			{
-				readDomainListenerParameters();
-				ready=true;
-			}
-		}
-	}
+        // Process new subscription requests from the gravity node
+        if (pollItem.revents & ZMQ_POLLIN)
+        {
+            std::string command = readStringMessage(gravityNodeSocket);
+            if (command == "configure")
+            {
+                readDomainListenerParameters();
+                ready = true;
+            }
+        }
+    }
 
-	time_t serviceDirectoryStartTime = 0;
+    time_t serviceDirectoryStartTime = 0;
 
-	/* Socket */
+    /* Socket */
     struct sockaddr_in broadcastAddr; /* Broadcast Address */
 
     /* Create a best-effort datagram socket using UDP */
     if ((sock = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0)
     {
-		return;
+        return;
     }
 
-
     /* Construct bind structure */
-    memset(&broadcastAddr, 0, sizeof(broadcastAddr));   /* Zero out structure */
-    broadcastAddr.sin_family = AF_INET;                 /* Internet address family */
-    broadcastAddr.sin_addr.s_addr = htonl(INADDR_ANY);  /* Any incoming interface */
-    broadcastAddr.sin_port = htons(port);      /* Broadcast port */
+    memset(&broadcastAddr, 0, sizeof(broadcastAddr));  /* Zero out structure */
+    broadcastAddr.sin_family = AF_INET;                /* Internet address family */
+    broadcastAddr.sin_addr.s_addr = htonl(INADDR_ANY); /* Any incoming interface */
+    broadcastAddr.sin_port = htons(port);              /* Broadcast port */
 
-	//set socket to be re-usable. Must be set for all other listeners for this port
-	int one = 1;
-	setsockopt(sock,SOL_SOCKET,SO_REUSEADDR,(const char*)&one,sizeof(one));
+    //set socket to be re-usable. Must be set for all other listeners for this port
+    int one = 1;
+    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&one, sizeof(one));
 
     /* Bind to the broadcast port */
 #ifdef _WIN32
-	int rc = bind((SOCKET)sock, (const struct sockaddr *) &broadcastAddr, (int)sizeof(broadcastAddr));
+    int rc = bind((SOCKET)sock, (const struct sockaddr*)&broadcastAddr, (int)sizeof(broadcastAddr));
 #else
-	int rc = bind(sock, (struct sockaddr *) &broadcastAddr, sizeof(broadcastAddr));
+    int rc = bind(sock, (struct sockaddr*)&broadcastAddr, sizeof(broadcastAddr));
 #endif
     if (rc < 0)
     {
-		return;
+        return;
     }
 
-	char recvString[MAXRECVSTRING+1]; /* Buffer for received string */
-    int recvStringLen;                /* Length of received string */
-	ServiceDirectoryBroadcastPB broadcastPB;
+    char recvString[MAXRECVSTRING + 1]; /* Buffer for received string */
+    int recvStringLen;                  /* Length of received string */
+    ServiceDirectoryBroadcastPB broadcastPB;
 
-	struct timeval timetowait;
-	timetowait.tv_sec=timeout;
-	timetowait.tv_usec=0;
+    struct timeval timetowait;
+    timetowait.tv_sec = timeout;
+    timetowait.tv_usec = 0;
 
-	//set socket to block forever
+    //set socket to block forever
 #ifdef _WIN32
-	int timeout_int = timevalToMilliSeconds(&timetowait);
-	setsockopt(sock,SOL_SOCKET,SO_RCVTIMEO,(const char*)&timeout_int,sizeof(unsigned int));
+    int timeout_int = timevalToMilliSeconds(&timetowait);
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout_int, sizeof(unsigned int));
 #else
-	//set socket to block forever initially
-	setsockopt(sock,SOL_SOCKET,SO_RCVTIMEO,(char*)&timetowait,sizeof(struct timeval));
+    //set socket to block forever initially
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (char*)&timetowait, sizeof(struct timeval));
 #endif
 
+    running = true;
 
-	running = true;
+    while (running)
+    {
+        //wait for braodcast message to be recieved
+        memset(recvString, 0, MAXRECVSTRING + 1);
 
-	while(running)
-	{
-		//wait for braodcast message to be recieved
-		memset(recvString,0,MAXRECVSTRING+1);
+        /* Receive a broadcast message or timeout */
+        recvStringLen = recvfrom(sock, recvString, MAXRECVSTRING, 0, NULL, 0);
 
-		/* Receive a broadcast message or timeout */
-		recvStringLen = recvfrom(sock, recvString, MAXRECVSTRING, 0, NULL, 0);
-		
-		//check for socket error
-		if(recvStringLen < 0)
-		{
-			//if we received some error
-		    int error = errno;
-		    if (error == EAGAIN)
-		        logger->trace("Timed out waiting for domain broadcast");
-		    else
-		        logger->warn("Received error reading domain listener socket: %d", error);
+        //check for socket error
+        if (recvStringLen < 0)
+        {
+            //if we received some error
+            int error = errno;
+            if (error == EAGAIN)
+                logger->trace("Timed out waiting for domain broadcast");
+            else
+                logger->warn("Received error reading domain listener socket: %d", error);
+        }
+        else  //we received a message
+        {
+            broadcastPB.ParseFromArray(recvString, recvStringLen);
+            //logger->trace("Domain listener received message from domain '{}'", broadcastPB.domain());
 
-		}
-		else //we received a message
-		{
-			broadcastPB.ParseFromArray(recvString,recvStringLen);
-			//logger->trace("Domain listener received message from domain '{}'", broadcastPB.domain());
+            //if the domains match
+            if (domain.compare(broadcastPB.domain()) == 0)
+            {
+                sendStringMessage(domainSocket, "connect", ZMQ_SNDMORE);
+                sendStringMessage(domainSocket, domain, ZMQ_SNDMORE);
+                sendStringMessage(domainSocket, broadcastPB.url(), ZMQ_DONTWAIT);
 
-			//if the domains match
-			if(domain.compare(broadcastPB.domain())==0)
-			{
-                sendStringMessage(domainSocket,"connect",ZMQ_SNDMORE);
-				sendStringMessage(domainSocket,domain,ZMQ_SNDMORE);
-				sendStringMessage(domainSocket,broadcastPB.url(),ZMQ_DONTWAIT);
+                // if it's a new start time...
+                if (serviceDirectoryStartTime < broadcastPB.starttime())
+                {
+                    logger->debug(
+                        "Domain listener found update to our domain, orig SD start time = {}, new SD start time = {}, "
+                        "SD url is now {}",
+                        serviceDirectoryStartTime, broadcastPB.starttime(), broadcastPB.url());
+                    // If we've seen a start time before, then re-register
+                    if (serviceDirectoryStartTime != 0)
+                    {
+                        gravityNode->ServiceDirectoryReregister(compId, broadcastPB.url());
+                    }
+                    serviceDirectoryStartTime = broadcastPB.starttime();
+                }
+            }
+        }
 
-				// if it's a new start time...
-				if (serviceDirectoryStartTime < broadcastPB.starttime())
-				{
-				    logger->debug("Domain listener found update to our domain, orig SD start time = {}, new SD start time = {}, SD url is now {}",
-				                serviceDirectoryStartTime, broadcastPB.starttime(), broadcastPB.url());
-				             // If we've seen a start time before, then re-register
-				    if (serviceDirectoryStartTime != 0)
-				    {
-				        gravityNode->ServiceDirectoryReregister(compId, broadcastPB.url());
-				    }
-				    serviceDirectoryStartTime = broadcastPB.starttime();
-				}
-			}
-		}
+        //check for any gravitynode commands
+        rc = zmq_poll(&pollItem, 1, 0);
+        if (pollItem.revents & ZMQ_POLLIN)
+        {
+            std::string command = readStringMessage(gravityNodeSocket);
+            sendStringMessage(gravityNodeSocket, "ACK", ZMQ_DONTWAIT);
+            if (command == "kill")
+            {
+                running = false;
+                break;
+            }
+        }
 
-		//check for any gravitynode commands
-		rc = zmq_poll(&pollItem, 1, 0);
-		if (pollItem.revents & ZMQ_POLLIN)
-		{
-			std::string command = readStringMessage(gravityNodeSocket);
-			sendStringMessage(gravityNodeSocket,"ACK",ZMQ_DONTWAIT);
-			if(command=="kill")
-			{
-				running=false;
-				break;
-			}
+        //don't set a timeout on the socket if it has already been closed
+        if (running)
+        {
+//set new timeout
+#ifdef _WIN32
+            setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout_int, sizeof(unsigned int));
+#else
+            //set socket to block until the timeout
+            setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (char*)&timetowait, sizeof(struct timeval));
+#endif
+        }
 
-		}
+    }  //end while
 
-		//don't set a timeout on the socket if it has already been closed
-		if(running)
-		{
-			//set new timeout
-			#ifdef _WIN32
-			setsockopt(sock,SOL_SOCKET,SO_RCVTIMEO,(const char*)&timeout_int,sizeof(unsigned int));
-			#else
-			//set socket to block until the timeout
-			setsockopt(sock,SOL_SOCKET,SO_RCVTIMEO,(char*)&timetowait,sizeof(struct timeval));
-			#endif	
-		}
+    logger->warn("Closing Domain Receiver");
 
-	}//end while
-
-	logger->warn("Closing Domain Receiver");
-
-	#ifdef _WIN32
-	closesocket(sock);
-	#else
-	close(sock);
-	#endif
-	zmq_close(gravityNodeSocket);
-	zmq_close(domainSocket);
+#ifdef _WIN32
+    closesocket(sock);
+#else
+    close(sock);
+#endif
+    zmq_close(gravityNodeSocket);
+    zmq_close(domainSocket);
 }
 
 void GravityNode::GravityNodeDomainListener::readDomainListenerParameters()
 {
-	//recieve domain
-	domain=readStringMessage(gravityNodeSocket);
+    //recieve domain
+    domain = readStringMessage(gravityNodeSocket);
 
-	//receive port
-	zmq_msg_t msg;
-	zmq_msg_init(&msg);
-	zmq_recvmsg(gravityNodeSocket,&msg,ZMQ_DONTWAIT);
-	memcpy(&port,zmq_msg_data(&msg),sizeof(unsigned int));
-	zmq_msg_close(&msg);
+    //receive port
+    zmq_msg_t msg;
+    zmq_msg_init(&msg);
+    zmq_recvmsg(gravityNodeSocket, &msg, ZMQ_DONTWAIT);
+    memcpy(&port, zmq_msg_data(&msg), sizeof(unsigned int));
+    zmq_msg_close(&msg);
 
-	//receive timeout
-	zmq_msg_t msg2;
-	zmq_msg_init(&msg2);
-	zmq_recvmsg(gravityNodeSocket,&msg2,ZMQ_DONTWAIT);
-	memcpy(&timeout,zmq_msg_data(&msg2),sizeof(unsigned int));
-	zmq_msg_close(&msg2);
+    //receive timeout
+    zmq_msg_t msg2;
+    zmq_msg_init(&msg2);
+    zmq_recvmsg(gravityNodeSocket, &msg2, ZMQ_DONTWAIT);
+    memcpy(&timeout, zmq_msg_data(&msg2), sizeof(unsigned int));
+    zmq_msg_close(&msg2);
 
-	//receive component ID
-	compId=readStringMessage(gravityNodeSocket);
+    //receive component ID
+    compId = readStringMessage(gravityNodeSocket);
 
-	//receive GravityNode pointer
-	zmq_msg_t msg3;
-	zmq_msg_init(&msg3);
-	zmq_recvmsg(gravityNodeSocket,&msg3,ZMQ_DONTWAIT);
-	memcpy(&gravityNode,zmq_msg_data(&msg3),sizeof(GravityNode*));
-	zmq_msg_close(&msg3);
+    //receive GravityNode pointer
+    zmq_msg_t msg3;
+    zmq_msg_init(&msg3);
+    zmq_recvmsg(gravityNodeSocket, &msg3, ZMQ_DONTWAIT);
+    memcpy(&gravityNode, zmq_msg_data(&msg3), sizeof(GravityNode*));
+    zmq_msg_close(&msg3);
 
-	sendStringMessage(gravityNodeSocket,"ACK",ZMQ_DONTWAIT);
+    sendStringMessage(gravityNodeSocket, "ACK", ZMQ_DONTWAIT);
 }
 
 Semaphore GravityNode::initLock;
 GravityNode::GravityNode()
-{	
-	// Populating (ServiceDirectory) set of reserved data product IDs
-	serviceDirectory_ReservedDataProductIDs.insert(gravity::constants::REGISTERED_PUBLISHERS_DPID);
-	serviceDirectory_ReservedDataProductIDs.insert(gravity::constants::DOMAIN_DETAILS_DPID);
-	serviceDirectory_ReservedDataProductIDs.insert(gravity::constants::DOMAIN_UPDATE_DPID);
-	serviceDirectory_ReservedDataProductIDs.insert(gravity::constants::DIRECTORY_SERVICE_DPID);
-	
-	// Populating (GravityNode) set of reserved data product IDs
-	gravityNode_ReservedDataProductIDs.insert(gravity::constants::METRICS_DATA_DPID);
-	gravityNode_ReservedDataProductIDs.insert(gravity::constants::GRAVITY_SETTINGS_DPID);
-	gravityNode_ReservedDataProductIDs.insert(gravity::constants::GRAVITY_LOGGER_DPID);
+{
+    // Populating (ServiceDirectory) set of reserved data product IDs
+    serviceDirectory_ReservedDataProductIDs.insert(gravity::constants::REGISTERED_PUBLISHERS_DPID);
+    serviceDirectory_ReservedDataProductIDs.insert(gravity::constants::DOMAIN_DETAILS_DPID);
+    serviceDirectory_ReservedDataProductIDs.insert(gravity::constants::DOMAIN_UPDATE_DPID);
+    serviceDirectory_ReservedDataProductIDs.insert(gravity::constants::DIRECTORY_SERVICE_DPID);
+
+    // Populating (GravityNode) set of reserved data product IDs
+    gravityNode_ReservedDataProductIDs.insert(gravity::constants::METRICS_DATA_DPID);
+    gravityNode_ReservedDataProductIDs.insert(gravity::constants::GRAVITY_SETTINGS_DPID);
+    gravityNode_ReservedDataProductIDs.insert(gravity::constants::GRAVITY_LOGGER_DPID);
 
     defaultReceiveLastSentDataproduct = true;
     defaultCacheLastSentDataprodut = true;
@@ -428,13 +425,13 @@ GravityNode::GravityNode()
 
     // Default to no metrics
     metricsEnabled = false;
-	settingsPubEnabled=false;
-	initialized=false;
-	logInitialized = false;
-	listenerEnabled=false;
-	heartbeatStarted=false;
+    settingsPubEnabled = false;
+    initialized = false;
+    logInitialized = false;
+    listenerEnabled = false;
+    heartbeatStarted = false;
 
-	parser = NULL;
+    parser = NULL;
 }
 
 GravityNode::GravityNode(std::string componentID)
@@ -451,14 +448,14 @@ GravityNode::GravityNode(std::string componentID)
 
     // Default to no metrics
     metricsEnabled = false;
-	settingsPubEnabled=false;
-	initialized=false;
-	logInitialized=false;
-	heartbeatStarted=false;
+    settingsPubEnabled = false;
+    initialized = false;
+    logInitialized = false;
+    heartbeatStarted = false;
 
-	parser = NULL;
+    parser = NULL;
 
-	init(componentID);
+    init(componentID);
 }
 
 GravityNode::~GravityNode()
@@ -470,17 +467,17 @@ GravityNode::~GravityNode()
     }
 
     //kill the domain listener
-    if(listenerEnabled)
+    if (listenerEnabled)
     {
         if (domainListenerSWL.socket)
         {
-		  sendStringMessage(domainListenerSWL.socket,"kill",ZMQ_DONTWAIT);
-		  readStringMessage(domainListenerSWL.socket);
-		  zmq_close(domainListenerSWL.socket);
+            sendStringMessage(domainListenerSWL.socket, "kill", ZMQ_DONTWAIT);
+            readStringMessage(domainListenerSWL.socket);
+            zmq_close(domainListenerSWL.socket);
         }
         if (domainRecvSWL.socket)
         {
-          zmq_close(domainRecvSWL.socket);
+            zmq_close(domainRecvSWL.socket);
         }
     }
 
@@ -493,7 +490,7 @@ GravityNode::~GravityNode()
 
     if (subscriptionManagerConfigSWL.socket)
     {
-      zmq_close(subscriptionManagerConfigSWL.socket);
+        zmq_close(subscriptionManagerConfigSWL.socket);
     }
 
     if (requestManagerSWL.socket)
@@ -503,7 +500,7 @@ GravityNode::~GravityNode()
     }
 
     if (requestManagerRepSWL.socket)
-    { 
+    {
         zmq_close(requestManagerRepSWL.socket);
     }
 
@@ -511,7 +508,7 @@ GravityNode::~GravityNode()
     {
         sendStringMessage(publishManagerPublishSWL.socket, "kill", ZMQ_DONTWAIT);
         zmq_close(publishManagerPublishSWL.socket);
-    } 
+    }
 
     if (publishManagerRequestSWL.socket)
     {
@@ -528,7 +525,7 @@ GravityNode::~GravityNode()
     {
         zmq_close(serviceManagerConfigSWL.socket);
     }
-  
+
     if (metricsManagerSocket)
     {
         sendStringMessage(metricsManagerSocket, "kill", ZMQ_DONTWAIT);
@@ -568,641 +565,646 @@ GravityNode::~GravityNode()
 
 void GravityNode::configSpdLoggers()
 {
-	if (logger = spdlog::get("GravityLogger"))
-	{
-		return;
-	}
-	
-	// Get log levels from INI file
-	auto gravity_file_level = spdlog::level::from_str(StringToLowerCase(getStringParam("GravityFileLogLevel", "off")));
-	auto gravity_console_level = spdlog::level::from_str(StringToLowerCase(getStringParam("GravityConsoleLogLevel", "off")));
-	auto app_file_level = spdlog::level::from_str(StringToLowerCase(getStringParam("AppFileLogLevel", "off")));
-	auto app_console_level = spdlog::level::from_str(StringToLowerCase(getStringParam("AppConsoleLogLevel", "off")));
-	auto app_publish_level = spdlog::level::from_str(StringToLowerCase(getStringParam("AppNetworkLogLevel", "off")));
-	
-	bool has_gravity_file_logger = gravity_file_level != SPDLOG_LEVEL_OFF;
-	bool has_app_file_logger = app_file_level != SPDLOG_LEVEL_OFF;
-	bool has_app_console_logger = app_console_level != SPDLOG_LEVEL_OFF;
-	bool has_app_publish_logger = app_publish_level != SPDLOG_LEVEL_OFF;
-	
-	bool has_app_logger = has_app_file_logger || has_app_console_logger || has_app_publish_logger;
-	
-	// Create lists to hold sinks
-	std::list<shared_ptr<spdlog::sinks::sink>> app_sink_list = {};
-	std::list<shared_ptr<spdlog::sinks::sink>> gravity_sink_list = {};
-	
-	// Always create console loggers
-	auto shared_console_sink = make_shared<spdlog::sinks::stdout_color_sink_mt>();
-	auto console_proxy_for_gravity = std::make_shared<proxy_dist_sink_mt>();
-	console_proxy_for_gravity->add_sink(shared_console_sink);
-	console_proxy_for_gravity->set_level(gravity_console_level);
-	gravity_sink_list.push_back(console_proxy_for_gravity);
-	auto console_proxy_for_app = std::make_shared<proxy_dist_sink_mt>();
-	console_proxy_for_app->add_sink(shared_console_sink);
-	console_proxy_for_app->set_level(app_console_level);
-	app_sink_list.push_back(console_proxy_for_app);
-	
-	// Configure file logger (if specified)
-	if (has_gravity_file_logger || has_app_file_logger)
-	{
-		string filename = getStringParam("LogDirectory", ".") + file_separator + componentID + ".log";
-		auto sharedFileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filename);
-		
-		if (has_gravity_file_logger)
-		{
-			auto file_proxy_for_gravity = std::make_shared<proxy_dist_sink_mt>();
-			file_proxy_for_gravity->add_sink(sharedFileSink);
-			file_proxy_for_gravity->set_level(gravity_file_level);
-			gravity_sink_list.push_back(file_proxy_for_gravity);
-		}
-		
-		if (has_app_file_logger)
-		{
-			auto file_proxy_for_app = std::make_shared<proxy_dist_sink_mt>();
-			file_proxy_for_app->add_sink(sharedFileSink);
-			file_proxy_for_app->set_level(app_file_level);
-			app_sink_list.push_back(file_proxy_for_app);
-		}
-		
-	}
-	
-	// Configure publish logger
-	if (has_app_publish_logger)
-	{
-		auto publishSink = std::make_shared<PublishSink<std::mutex>>(this);
-		auto publish_proxy_for_app = std::make_shared<proxy_dist_sink_mt>();
-		publish_proxy_for_app->add_sink(publishSink);
-		publish_proxy_for_app->set_level(app_publish_level);
-		app_sink_list.push_back(publish_proxy_for_app);
-	}
-	
-	// Configure GravityLogger.
-	logger = std::make_shared<spdlog::logger>("GravityLogger");
-	for (auto sink : gravity_sink_list)
-	{
-		logger->sinks().push_back(sink);
-	}
-	logger->set_level(spdlog::level::trace); // logger will pass through all logs to be filtered by sinks
-	logger->flush_on(spdlog::level::trace); // logger will flush on all messages
-	logger->set_pattern("[%Y-%m-%d %T.%f " + componentID + "-%l] %v");
-	spdlog::register_logger(logger);
-	
-	// Configure ApplicationLogger
-	auto app_logger = std::make_shared<spdlog::logger>("GravityApplicationLogger");
-	for (auto sink : app_sink_list)
-	{
-		app_logger->sinks().push_back(sink);
-	}
-	app_logger->set_level(spdlog::level::trace); // logger will pass through all logs to be filtered by sinks
-	app_logger->flush_on(spdlog::level::trace); // logger will flush on all messages
-	app_logger->set_pattern("[%Y-%m-%d %T.%f " + componentID + "-%l] %v");
-	spdlog::register_logger(app_logger);
-	
-	if (has_app_logger)
-	{
-		// Set the ApplicaitonLogger as the default
-		spdlog::set_default_logger(app_logger);
-	}
+    if (logger = spdlog::get("GravityLogger"))
+    {
+        return;
+    }
+
+    // Get log levels from INI file
+    auto gravity_file_level = spdlog::level::from_str(StringToLowerCase(getStringParam("GravityFileLogLevel", "off")));
+    auto gravity_console_level =
+        spdlog::level::from_str(StringToLowerCase(getStringParam("GravityConsoleLogLevel", "off")));
+    auto app_file_level = spdlog::level::from_str(StringToLowerCase(getStringParam("AppFileLogLevel", "off")));
+    auto app_console_level = spdlog::level::from_str(StringToLowerCase(getStringParam("AppConsoleLogLevel", "off")));
+    auto app_publish_level = spdlog::level::from_str(StringToLowerCase(getStringParam("AppNetworkLogLevel", "off")));
+
+    bool has_gravity_file_logger = gravity_file_level != SPDLOG_LEVEL_OFF;
+    bool has_app_file_logger = app_file_level != SPDLOG_LEVEL_OFF;
+    bool has_app_console_logger = app_console_level != SPDLOG_LEVEL_OFF;
+    bool has_app_publish_logger = app_publish_level != SPDLOG_LEVEL_OFF;
+
+    bool has_app_logger = has_app_file_logger || has_app_console_logger || has_app_publish_logger;
+
+    // Create lists to hold sinks
+    std::list<shared_ptr<spdlog::sinks::sink>> app_sink_list = {};
+    std::list<shared_ptr<spdlog::sinks::sink>> gravity_sink_list = {};
+
+    // Always create console loggers
+    auto shared_console_sink = make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    auto console_proxy_for_gravity = std::make_shared<proxy_dist_sink_mt>();
+    console_proxy_for_gravity->add_sink(shared_console_sink);
+    console_proxy_for_gravity->set_level(gravity_console_level);
+    gravity_sink_list.push_back(console_proxy_for_gravity);
+    auto console_proxy_for_app = std::make_shared<proxy_dist_sink_mt>();
+    console_proxy_for_app->add_sink(shared_console_sink);
+    console_proxy_for_app->set_level(app_console_level);
+    app_sink_list.push_back(console_proxy_for_app);
+
+    // Configure file logger (if specified)
+    if (has_gravity_file_logger || has_app_file_logger)
+    {
+        string filename = getStringParam("LogDirectory", ".") + file_separator + componentID + ".log";
+        auto sharedFileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filename);
+
+        if (has_gravity_file_logger)
+        {
+            auto file_proxy_for_gravity = std::make_shared<proxy_dist_sink_mt>();
+            file_proxy_for_gravity->add_sink(sharedFileSink);
+            file_proxy_for_gravity->set_level(gravity_file_level);
+            gravity_sink_list.push_back(file_proxy_for_gravity);
+        }
+
+        if (has_app_file_logger)
+        {
+            auto file_proxy_for_app = std::make_shared<proxy_dist_sink_mt>();
+            file_proxy_for_app->add_sink(sharedFileSink);
+            file_proxy_for_app->set_level(app_file_level);
+            app_sink_list.push_back(file_proxy_for_app);
+        }
+    }
+
+    // Configure publish logger
+    if (has_app_publish_logger)
+    {
+        auto publishSink = std::make_shared<PublishSink<std::mutex>>(this);
+        auto publish_proxy_for_app = std::make_shared<proxy_dist_sink_mt>();
+        publish_proxy_for_app->add_sink(publishSink);
+        publish_proxy_for_app->set_level(app_publish_level);
+        app_sink_list.push_back(publish_proxy_for_app);
+    }
+
+    // Configure GravityLogger.
+    logger = std::make_shared<spdlog::logger>("GravityLogger");
+    for (auto sink : gravity_sink_list)
+    {
+        logger->sinks().push_back(sink);
+    }
+    logger->set_level(spdlog::level::trace);  // logger will pass through all logs to be filtered by sinks
+    logger->flush_on(spdlog::level::trace);   // logger will flush on all messages
+    logger->set_pattern("[%Y-%m-%d %T.%f " + componentID + "-%l] %v");
+    spdlog::register_logger(logger);
+
+    // Configure ApplicationLogger
+    auto app_logger = std::make_shared<spdlog::logger>("GravityApplicationLogger");
+    for (auto sink : app_sink_list)
+    {
+        app_logger->sinks().push_back(sink);
+    }
+    app_logger->set_level(spdlog::level::trace);  // logger will pass through all logs to be filtered by sinks
+    app_logger->flush_on(spdlog::level::trace);   // logger will flush on all messages
+    app_logger->set_pattern("[%Y-%m-%d %T.%f " + componentID + "-%l] %v");
+    spdlog::register_logger(app_logger);
+
+    if (has_app_logger)
+    {
+        // Set the ApplicaitonLogger as the default
+        spdlog::set_default_logger(app_logger);
+    }
 }
 
 GravityReturnCode GravityNode::init()
 {
-	////////////////////////////////////////////////////////
-	//get gravity configuration.
-	parser = new GravityConfigParser("");
+    ////////////////////////////////////////////////////////
+    //get gravity configuration.
+    parser = new GravityConfigParser("");
 
-	parser->ParseConfigFile("Gravity.ini");
+    parser->ParseConfigFile("Gravity.ini");
 
-	std::string id = parser->getString("GravityComponentID","");
+    std::string id = parser->getString("GravityComponentID", "");
 
-	if(id != "")
-	{
-		return init(id);
-	}
-	else
-	{
-		componentID="GravityNode";
-		//Setup Logging if enabled.
-		if(!logInitialized)
-		{
-   			Log::LogLevel local_log_level = Log::LogStringToLevel(getStringParam("LocalLogLevel", "none").c_str());
-			if(local_log_level != Log::NONE)
-				Log::initAndAddFileLogger(getStringParam("LogDirectory", "").c_str(), componentID.c_str(),
-						local_log_level, getBoolParam("CloseLogFileAfterWrite", false));
+    if (id != "")
+    {
+        return init(id);
+    }
+    else
+    {
+        componentID = "GravityNode";
+        //Setup Logging if enabled.
+        if (!logInitialized)
+        {
+            Log::LogLevel local_log_level = Log::LogStringToLevel(getStringParam("LocalLogLevel", "none").c_str());
+            if (local_log_level != Log::NONE)
+                Log::initAndAddFileLogger(getStringParam("LogDirectory", "").c_str(), componentID.c_str(),
+                                          local_log_level, getBoolParam("CloseLogFileAfterWrite", false));
 
-			Log::LogLevel console_log_level = Log::LogStringToLevel(getStringParam("ConsoleLogLevel", "none").c_str());
-			if(console_log_level != Log::NONE)
-				Log::initAndAddConsoleLogger(componentID.c_str(), console_log_level);
+            Log::LogLevel console_log_level = Log::LogStringToLevel(getStringParam("ConsoleLogLevel", "none").c_str());
+            if (console_log_level != Log::NONE) Log::initAndAddConsoleLogger(componentID.c_str(), console_log_level);
 
-			//log an error indicating the componentID was missing
-			logger->error("Field 'GravityComponentID' missing from Gravity.ini, using GravityComponentID='GravityNode'");
+            //log an error indicating the componentID was missing
+            logger->error(
+                "Field 'GravityComponentID' missing from Gravity.ini, using GravityComponentID='GravityNode'");
 
-			logInitialized=true;
-		}
-		return init(componentID);
-	}
-
+            logInitialized = true;
+        }
+        return init(componentID);
+    }
 }
 
 GravityReturnCode GravityNode::init(std::string componentID)
 {
     GravityReturnCode ret = GravityReturnCodes::SUCCESS;
-	this->componentID = componentID;
+    this->componentID = componentID;
 
-	std::string serviceDirectoryUrl="";
-	bool domainTimeout=false;
-	bool iniWarning = false;
+    std::string serviceDirectoryUrl = "";
+    bool domainTimeout = false;
+    bool iniWarning = false;
 
-	gravityNode_ReservedDataProductIDs.insert(componentID + "_GravityHeartbeat");
+    gravityNode_ReservedDataProductIDs.insert(componentID + "_GravityHeartbeat");
 
     initLock.Lock();
 
     // Setup zmq context
-	if(!initialized)
-	{
-		////////////////////////////////////////////////////////
-		//Now that Gravity is set up, get gravity configuration.
-		parser = new GravityConfigParser(componentID);
+    if (!initialized)
+    {
+        ////////////////////////////////////////////////////////
+        //Now that Gravity is set up, get gravity configuration.
+        parser = new GravityConfigParser(componentID);
 
-		parser->ParseConfigFile("Gravity.ini");
-		std::string config_file_name = componentID + ".ini";
-		if(gravity::IsValidFilename(config_file_name))
-		{
-			parser->ParseConfigFile(config_file_name.c_str());
-		}
+        parser->ParseConfigFile("Gravity.ini");
+        std::string config_file_name = componentID + ".ini";
+        if (gravity::IsValidFilename(config_file_name))
+        {
+            parser->ParseConfigFile(config_file_name.c_str());
+        }
 
-		// Setup Logging as soon as config parser is available.
-		if(!logInitialized)
-		{
-			Log::LogLevel local_log_level = Log::LogStringToLevel(getStringParam("LocalLogLevel", "none").c_str());
-			if(local_log_level != Log::NONE)
-				Log::initAndAddFileLogger(getStringParam("LogDirectory", "").c_str(), componentID.c_str(),
-						local_log_level, getBoolParam("CloseLogFileAfterWrite", false));
+        // Setup Logging as soon as config parser is available.
+        if (!logInitialized)
+        {
+            Log::LogLevel local_log_level = Log::LogStringToLevel(getStringParam("LocalLogLevel", "none").c_str());
+            if (local_log_level != Log::NONE)
+                Log::initAndAddFileLogger(getStringParam("LogDirectory", "").c_str(), componentID.c_str(),
+                                          local_log_level, getBoolParam("CloseLogFileAfterWrite", false));
 
-			Log::LogLevel console_log_level = Log::LogStringToLevel(getStringParam("ConsoleLogLevel", "none").c_str());
-			if(console_log_level != Log::NONE)
-				Log::initAndAddConsoleLogger(componentID.c_str(), console_log_level);
-		
-			// Configure spdlog loggers
-			configSpdLoggers();
+            Log::LogLevel console_log_level = Log::LogStringToLevel(getStringParam("ConsoleLogLevel", "none").c_str());
+            if (console_log_level != Log::NONE) Log::initAndAddConsoleLogger(componentID.c_str(), console_log_level);
 
-			logInitialized=true;
-		}
-		
-		context = zmq_init(1);
-		if (!context)
-		{
-			ret = GravityReturnCodes::FAILURE;
-		}
+            // Configure spdlog loggers
+            configSpdLoggers();
 
-		void* initSocket = zmq_socket(context, ZMQ_REP);
-		zmq_bind(initSocket, "inproc://gravity_init");
+            logInitialized = true;
+        }
 
-		// Setup up communication channel to subscription manager
-		subscriptionManagerSWL.socket = zmq_socket(context, ZMQ_PUB);
-		zmq_bind(subscriptionManagerSWL.socket, "inproc://gravity_subscription_manager");
-		subscriptionManagerConfigSWL.socket = zmq_socket(context,ZMQ_PUB);
-		zmq_bind(subscriptionManagerConfigSWL.socket,"inproc://gravity_subscription_manager_configure");
+        context = zmq_init(1);
+        if (!context)
+        {
+            ret = GravityReturnCodes::FAILURE;
+        }
 
-		// Setup the metrics control communication channel
-		metricsManagerSocket = zmq_socket(context, ZMQ_PUB);
-		zmq_bind(metricsManagerSocket, GRAVITY_METRICS_CONTROL);
+        void* initSocket = zmq_socket(context, ZMQ_REP);
+        zmq_bind(initSocket, "inproc://gravity_init");
 
-		// Setup the subscription manager
-    subscriptionManagerThread = std::thread(startSubscriptionManager, context);
+        // Setup up communication channel to subscription manager
+        subscriptionManagerSWL.socket = zmq_socket(context, ZMQ_PUB);
+        zmq_bind(subscriptionManagerSWL.socket, "inproc://gravity_subscription_manager");
+        subscriptionManagerConfigSWL.socket = zmq_socket(context, ZMQ_PUB);
+        zmq_bind(subscriptionManagerConfigSWL.socket, "inproc://gravity_subscription_manager_configure");
 
-		// Setup up publish channel to publish manager
-		publishManagerPublishSWL.socket = zmq_socket(context, ZMQ_PUB);
-		zmq_bind(publishManagerPublishSWL.socket, PUB_MGR_PUB_URL);
+        // Setup the metrics control communication channel
+        metricsManagerSocket = zmq_socket(context, ZMQ_PUB);
+        zmq_bind(metricsManagerSocket, GRAVITY_METRICS_CONTROL);
 
-		// Setup the publish manager
-    std::thread publishManagerThread(startPublishManager, context);
-    publishManagerThread.detach();
+        // Setup the subscription manager
+        subscriptionManagerThread = std::thread(startSubscriptionManager, context);
 
-		// Setup up communication channel to request manager
-		requestManagerSWL.socket = zmq_socket(context, ZMQ_PUB);
-		zmq_bind(requestManagerSWL.socket, "inproc://gravity_request_manager");
-		requestManagerRepSWL.socket = zmq_socket(context, ZMQ_REQ);
-		zmq_bind(requestManagerRepSWL.socket, "inproc://gravity_request_rep");
-		// Setup the request manager
-    std::thread requestManagerThread(startRequestManager, context);
-    requestManagerThread.detach();
+        // Setup up publish channel to publish manager
+        publishManagerPublishSWL.socket = zmq_socket(context, ZMQ_PUB);
+        zmq_bind(publishManagerPublishSWL.socket, PUB_MGR_PUB_URL);
 
-		serviceManagerConfigSWL.socket = zmq_socket(context,ZMQ_PUB);
-		zmq_bind(serviceManagerConfigSWL.socket,"inproc://gravity_service_manager_configure");
+        // Setup the publish manager
+        std::thread publishManagerThread(startPublishManager, context);
+        publishManagerThread.detach();
 
-		// Setup the service manager
-    std::thread serviceManagerThread(startServiceManager, context);
-    serviceManagerThread.detach();
+        // Setup up communication channel to request manager
+        requestManagerSWL.socket = zmq_socket(context, ZMQ_PUB);
+        zmq_bind(requestManagerSWL.socket, "inproc://gravity_request_manager");
+        requestManagerRepSWL.socket = zmq_socket(context, ZMQ_REQ);
+        zmq_bind(requestManagerRepSWL.socket, "inproc://gravity_request_rep");
+        // Setup the request manager
+        std::thread requestManagerThread(startRequestManager, context);
+        requestManagerThread.detach();
 
-		// Start the metrics manager
-    std::thread metricsManagerThread(startMetricsManager, context);
-    metricsManagerThread.detach();
+        serviceManagerConfigSWL.socket = zmq_socket(context, ZMQ_PUB);
+        zmq_bind(serviceManagerConfigSWL.socket, "inproc://gravity_service_manager_configure");
 
-		// Configure to trap Ctrl-C (SIGINT) and SIGTERM signals
-		s_catch_signals();
+        // Setup the service manager
+        std::thread serviceManagerThread(startServiceManager, context);
+        serviceManagerThread.detach();
 
-		// wait for the manager threads to signal their readiness
-		string msgText;
-		int numThreadsWaiting = 5;
-		while (numThreadsWaiting && !s_interrupted)
-		{
-    		// Read message
-    		msgText = readStringMessage(initSocket);
+        // Start the metrics manager
+        std::thread metricsManagerThread(startMetricsManager, context);
+        metricsManagerThread.detach();
 
-    		// respond with ack
-    		sendStringMessage(initSocket, "ack", ZMQ_DONTWAIT);
+        // Configure to trap Ctrl-C (SIGINT) and SIGTERM signals
+        s_catch_signals();
 
-    		// Decrement counter
-    		numThreadsWaiting--;
-		}
-		zmq_close(initSocket);
+        // wait for the manager threads to signal their readiness
+        string msgText;
+        int numThreadsWaiting = 5;
+        while (numThreadsWaiting && !s_interrupted)
+        {
+            // Read message
+            msgText = readStringMessage(initSocket);
 
-		s_restore_signals();
+            // respond with ack
+            sendStringMessage(initSocket, "ack", ZMQ_DONTWAIT);
 
-		if(s_interrupted) {
-		    initLock.Unlock();
-			raise(s_interrupted);
-		}
+            // Decrement counter
+            numThreadsWaiting--;
+        }
+        zmq_close(initSocket);
 
-		// connect down here to make sure manager has bound address.
-		publishManagerRequestSWL.socket = zmq_socket(context, ZMQ_REQ);
-		zmq_connect(publishManagerRequestSWL.socket, PUB_MGR_REQ_URL);
+        s_restore_signals();
 
-		serviceManagerSWL.socket = zmq_socket(context, ZMQ_REQ);
-		zmq_connect(serviceManagerSWL.socket, SERVICE_MGR_URL);
+        if (s_interrupted)
+        {
+            initLock.Unlock();
+            raise(s_interrupted);
+        }
 
-		// Configure high water marks
-		int publishHWM = getIntParam("PublishHWM", 1000);
-		if (publishHWM < 0)
-		{
-			logger->warn("Invalid PublishHWM = {}. Ignoring.", publishHWM);
-		}
-		else
-		{
-			// Send HWM (REQ/REP)
-			sendStringMessage(publishManagerRequestSWL.socket, "set_hwm", ZMQ_SNDMORE);
-			sendIntMessage(publishManagerRequestSWL.socket, publishHWM, ZMQ_DONTWAIT);
-			// Read ACK
-			readStringMessage(publishManagerRequestSWL.socket);
-		}
-		int subscribeHWM = getIntParam("SubscribeHWM", 1000);
-		if (subscribeHWM < 0)
-		{
-			logger->warn("Invalid subscribeHWM = {}. Ignoring.", subscribeHWM);
-		}
-		else
-		{
-			// Send HWM (PUB/SUB)
-			sendStringMessage(subscriptionManagerSWL.socket, "set_hwm", ZMQ_SNDMORE);
-			sendIntMessage(subscriptionManagerSWL.socket, subscribeHWM, ZMQ_DONTWAIT);
-		}
-		
-		// Configure TCP keep-alive
-		if (getBoolParam("TcpKeepAliveEnabled", false))
-		{
-			// Get settings
-			int tcpKeepAliveTime = getIntParam("TcpKeepAliveTime", 7200);
-			int tcpKeepAliveProbes = getIntParam("TcpKeepAliveProbes", 9);
-			int tcpKeepAliveIntvl = getIntParam("TcpKeepAliveIntvl", 75);
-			
-			logger->info("Enabling TCP publisher Keep-Alive with settings (time={}, probes={}, intvl={}).", 
-								tcpKeepAliveTime, tcpKeepAliveProbes, tcpKeepAliveIntvl);
-			
-			// Send TCP keep-alive settings
-			sendStringMessage(publishManagerRequestSWL.socket, "set_tcp_keepalive", ZMQ_SNDMORE);
-			sendIntMessage(publishManagerRequestSWL.socket, tcpKeepAliveTime, ZMQ_DONTWAIT);
-			sendIntMessage(publishManagerRequestSWL.socket, tcpKeepAliveProbes, ZMQ_DONTWAIT);
-			sendIntMessage(publishManagerRequestSWL.socket, tcpKeepAliveIntvl, ZMQ_DONTWAIT);
-			
-			// Read ACK
-			readStringMessage(publishManagerRequestSWL.socket);
-		}
-		
-		//get the Domain name of the Service Directory to connect to
-		std::string serviceDirectoryDomain = getStringParam("Domain");
+        // connect down here to make sure manager has bound address.
+        publishManagerRequestSWL.socket = zmq_socket(context, ZMQ_REQ);
+        zmq_connect(publishManagerRequestSWL.socket, PUB_MGR_REQ_URL);
 
-		//Set Service Directory URL (because we can't connect to the ConfigService without it).
-		serviceDirectoryUrl = getStringParam("ServiceDirectoryURL");
-		if(serviceDirectoryDomain != "" && (componentID != "ServiceDirectory"))
-		{
-			//if the config file specifies both domain and url
-			if( serviceDirectoryUrl != "")
-			{
-				iniWarning=true;
-			}
-			//setup and start the GravityNodeDomainListener
-			else
-			{
-				// Setup up communication channel to subscription manager
-				domainListenerSWL.socket = zmq_socket(context, ZMQ_REQ);
-				zmq_bind(domainListenerSWL.socket, "inproc://gravity_domain_listener");
+        serviceManagerSWL.socket = zmq_socket(context, ZMQ_REQ);
+        zmq_connect(serviceManagerSWL.socket, SERVICE_MGR_URL);
 
-				domainRecvSWL.socket = zmq_socket(context,ZMQ_SUB);
-				zmq_bind(domainRecvSWL.socket,"inproc://gravity_domain_receiver");
-				zmq_setsockopt(domainRecvSWL.socket,ZMQ_SUBSCRIBE,NULL,0);
+        // Configure high water marks
+        int publishHWM = getIntParam("PublishHWM", 1000);
+        if (publishHWM < 0)
+        {
+            logger->warn("Invalid PublishHWM = {}. Ignoring.", publishHWM);
+        }
+        else
+        {
+            // Send HWM (REQ/REP)
+            sendStringMessage(publishManagerRequestSWL.socket, "set_hwm", ZMQ_SNDMORE);
+            sendIntMessage(publishManagerRequestSWL.socket, publishHWM, ZMQ_DONTWAIT);
+            // Read ACK
+            readStringMessage(publishManagerRequestSWL.socket);
+        }
+        int subscribeHWM = getIntParam("SubscribeHWM", 1000);
+        if (subscribeHWM < 0)
+        {
+            logger->warn("Invalid subscribeHWM = {}. Ignoring.", subscribeHWM);
+        }
+        else
+        {
+            // Send HWM (PUB/SUB)
+            sendStringMessage(subscriptionManagerSWL.socket, "set_hwm", ZMQ_SNDMORE);
+            sendIntMessage(subscriptionManagerSWL.socket, subscribeHWM, ZMQ_DONTWAIT);
+        }
 
-        std::thread domainListenerThread(startGravityDomainListener,context);
-        domainListenerThread.detach();
+        // Configure TCP keep-alive
+        if (getBoolParam("TcpKeepAliveEnabled", false))
+        {
+            // Get settings
+            int tcpKeepAliveTime = getIntParam("TcpKeepAliveTime", 7200);
+            int tcpKeepAliveProbes = getIntParam("TcpKeepAliveProbes", 9);
+            int tcpKeepAliveIntvl = getIntParam("TcpKeepAliveIntvl", 75);
 
-				configureNodeDomainListener(serviceDirectoryDomain);
-				int broadcastTimeout = getIntParam("ServiceDirectoryBroadcastTimeout",DEFAULT_BROADCAST_TIMEOUT_SEC);
+            logger->info("Enabling TCP publisher Keep-Alive with settings (time={}, probes={}, intvl={}).",
+                         tcpKeepAliveTime, tcpKeepAliveProbes, tcpKeepAliveIntvl);
 
-				serviceDirectoryUrl.assign(getDomainUrl(broadcastTimeout));
-				if(serviceDirectoryUrl == "")
-				{
-					domainTimeout=true;
-				}
+            // Send TCP keep-alive settings
+            sendStringMessage(publishManagerRequestSWL.socket, "set_tcp_keepalive", ZMQ_SNDMORE);
+            sendIntMessage(publishManagerRequestSWL.socket, tcpKeepAliveTime, ZMQ_DONTWAIT);
+            sendIntMessage(publishManagerRequestSWL.socket, tcpKeepAliveProbes, ZMQ_DONTWAIT);
+            sendIntMessage(publishManagerRequestSWL.socket, tcpKeepAliveIntvl, ZMQ_DONTWAIT);
 
-				listenerEnabled=true;
-				
-			}
-		}
-		defaultCacheLastSentDataprodut = getBoolParam("CacheLastSentDataproduct", true);
-		logger->trace("Default Setting For CacheLastSentDataproduct: {}", defaultCacheLastSentDataprodut ? "TRUE": "FALSE"); 
+            // Read ACK
+            readStringMessage(publishManagerRequestSWL.socket);
+        }
 
-		defaultReceiveLastSentDataproduct = getBoolParam("ReceiveLastSentDataproduct", true);			 
-		logger->trace("Default Setting For ReceiveLastSentDataproduct: {}", defaultReceiveLastSentDataproduct ? "TRUE": "FALSE");
+        //get the Domain name of the Service Directory to connect to
+        std::string serviceDirectoryDomain = getStringParam("Domain");
 
-		initialized = true;
-	}
-	//we are already initialzed, just try to read the SD domain and url
-	else
-	{
-		//get the Domain name of the Service Directory to connect to
-		std::string serviceDirectoryDomain = getStringParam("Domain");
-		//Set Service Directory URL (because we can't connect to the ConfigService without it).
-		serviceDirectoryUrl = getStringParam("ServiceDirectoryURL");
+        //Set Service Directory URL (because we can't connect to the ConfigService without it).
+        serviceDirectoryUrl = getStringParam("ServiceDirectoryURL");
+        if (serviceDirectoryDomain != "" && (componentID != "ServiceDirectory"))
+        {
+            //if the config file specifies both domain and url
+            if (serviceDirectoryUrl != "")
+            {
+                iniWarning = true;
+            }
+            //setup and start the GravityNodeDomainListener
+            else
+            {
+                // Setup up communication channel to subscription manager
+                domainListenerSWL.socket = zmq_socket(context, ZMQ_REQ);
+                zmq_bind(domainListenerSWL.socket, "inproc://gravity_domain_listener");
 
-		if(serviceDirectoryDomain != "" && (componentID != "ServiceDirectory"))
-		{
-			//if the config file specifies both domain and url
-			if( serviceDirectoryUrl != "")
-			{
-				iniWarning=true;
-			}
-			else
-			{
-				int broadcastTimeout = getIntParam("ServiceDirectoryBroadcastTimeout",DEFAULT_BROADCAST_TIMEOUT_SEC);
+                domainRecvSWL.socket = zmq_socket(context, ZMQ_SUB);
+                zmq_bind(domainRecvSWL.socket, "inproc://gravity_domain_receiver");
+                zmq_setsockopt(domainRecvSWL.socket, ZMQ_SUBSCRIBE, NULL, 0);
 
-				//read the domain from the domain listener
-				serviceDirectoryUrl.assign(getDomainUrl(broadcastTimeout));
-				if(serviceDirectoryUrl == "")
-				{
-					domainTimeout=true;
-				}
-				
-			}
-		}
-	}
+                std::thread domainListenerThread(startGravityDomainListener, context);
+                domainListenerThread.detach();
 
-	//If we are able to proceed with trying to connect to the service directory
-	if(!domainTimeout)
-	{
-		// Update service directory location
-		updateServiceDirectoryUrl(serviceDirectoryUrl);
+                configureNodeDomainListener(serviceDirectoryDomain);
+                int broadcastTimeout = getIntParam("ServiceDirectoryBroadcastTimeout", DEFAULT_BROADCAST_TIMEOUT_SEC);
 
-		// Get our domain
-		if (componentID != "ServiceDirectory")
-		{
-			GravityDataProduct request("GetDomain");
-			GravityDataProduct response("DomainResponse");
-			ret = sendRequestToServiceDirectory(request, response);
+                serviceDirectoryUrl.assign(getDomainUrl(broadcastTimeout));
+                if (serviceDirectoryUrl == "")
+                {
+                    domainTimeout = true;
+                }
 
-			if (ret == GravityReturnCodes::SUCCESS)
-			{
-				char* p = (char*)calloc(response.getDataSize(), sizeof(char));
-				response.getData(p, response.getDataSize());
-				myDomain.assign(p, response.getDataSize());
-				free(p);
-			}
-		}
-		else
-		{
-			myDomain = getStringParam("Domain", "");
-		}
+                listenerEnabled = true;
+            }
+        }
+        defaultCacheLastSentDataprodut = getBoolParam("CacheLastSentDataproduct", true);
+        logger->trace("Default Setting For CacheLastSentDataproduct: {}",
+                      defaultCacheLastSentDataprodut ? "TRUE" : "FALSE");
 
-		if (ret == GravityReturnCodes::SUCCESS)
-		{
-			if (componentID != "ServiceDirectory") 
-			{
-				settingsPubEnabled = getBoolParam("GravitySettingsPublishEnabled", false);
-				if (settingsPubEnabled)
-				{
-					registerDataProductInternal(gravity::constants::GRAVITY_SETTINGS_DPID, GravityTransportTypes::TCP, false, false, false, true);
-				}
+        defaultReceiveLastSentDataproduct = getBoolParam("ReceiveLastSentDataproduct", true);
+        logger->trace("Default Setting For ReceiveLastSentDataproduct: {}",
+                      defaultReceiveLastSentDataproduct ? "TRUE" : "FALSE");
 
-				// Enable metrics (if configured)
-				metricsEnabled = getBoolParam("GravityMetricsEnabled", false);
-				if (metricsEnabled)
-				{
-					// Register our metrics data product with the service directory
-					registerDataProductInternal(gravity::constants::METRICS_DATA_DPID, GravityTransportTypes::TCP, false, false, false, true);
+        initialized = true;
+    }
+    //we are already initialzed, just try to read the SD domain and url
+    else
+    {
+        //get the Domain name of the Service Directory to connect to
+        std::string serviceDirectoryDomain = getStringParam("Domain");
+        //Set Service Directory URL (because we can't connect to the ConfigService without it).
+        serviceDirectoryUrl = getStringParam("ServiceDirectoryURL");
 
-					// Command the GravityMetricsManager thread to start collecting metrics
-					sendStringMessage(metricsManagerSocket, "MetricsEnable", ZMQ_SNDMORE);
+        if (serviceDirectoryDomain != "" && (componentID != "ServiceDirectory"))
+        {
+            //if the config file specifies both domain and url
+            if (serviceDirectoryUrl != "")
+            {
+                iniWarning = true;
+            }
+            else
+            {
+                int broadcastTimeout = getIntParam("ServiceDirectoryBroadcastTimeout", DEFAULT_BROADCAST_TIMEOUT_SEC);
 
-					// Get collection parameters from ini file
-					// (default to 10 second sampling, publishing once per min)
-					int samplePeriod = getIntParam("GravityMetricsSamplePeriodSeconds", 10);
-					int samplesPerPublish = getIntParam("GravityMetricsSamplesPerPublish", 6);
+                //read the domain from the domain listener
+                serviceDirectoryUrl.assign(getDomainUrl(broadcastTimeout));
+                if (serviceDirectoryUrl == "")
+                {
+                    domainTimeout = true;
+                }
+            }
+        }
+    }
 
-					// Send collection details to the GravityMetricsManager
-					sendIntMessage(metricsManagerSocket, samplePeriod, ZMQ_SNDMORE);
-					sendIntMessage(metricsManagerSocket, samplesPerPublish, ZMQ_SNDMORE);
+    //If we are able to proceed with trying to connect to the service directory
+    if (!domainTimeout)
+    {
+        // Update service directory location
+        updateServiceDirectoryUrl(serviceDirectoryUrl);
 
-					// Finally, send our component id, ip address, and registration time (to be published with metrics)
-					sendStringMessage(metricsManagerSocket, componentID, ZMQ_SNDMORE);
-					sendStringMessage(metricsManagerSocket, getIP(), ZMQ_SNDMORE);
-					sendIntMessage(metricsManagerSocket, dataRegistrationTimeMap[gravity::constants::METRICS_DATA_DPID] , ZMQ_DONTWAIT);
-				}
-			}
+        // Get our domain
+        if (componentID != "ServiceDirectory")
+        {
+            GravityDataProduct request("GetDomain");
+            GravityDataProduct response("DomainResponse");
+            ret = sendRequestToServiceDirectory(request, response);
 
-			if(componentID != "ConfigServer" && getBoolParam("NoConfigServer", false) != true)
-   			{
-   				parser->ParseConfigService(*this); //Although this is done last, this has the least priority.  We just need to do it last so we know where the service directory is located.
-   			}
-			//parser->ParseCmdLine
+            if (ret == GravityReturnCodes::SUCCESS)
+            {
+                char* p = (char*)calloc(response.getDataSize(), sizeof(char));
+                response.getData(p, response.getDataSize());
+                myDomain.assign(p, response.getDataSize());
+                free(p);
+            }
+        }
+        else
+        {
+            myDomain = getStringParam("Domain", "");
+        }
 
-			configureServiceManager();
-			configureSubscriptionManager();
-	
-			// Auto start heartbeats if specified in INI
-			double heartbeatPeriodSecs = getFloatParam("GravityHeartbeatPeriodSecs", -1);
-			if (heartbeatPeriodSecs > 0)
-			{
-				logger->debug("Starting heartbeats ({} secs)", heartbeatPeriodSecs);
-				int64_t micros = std::round(heartbeatPeriodSecs * 1e6);		
-				startHeartbeat(micros);
-			}
-		}
-	}
-	else
-	{
-		ret=GravityReturnCodes::FAILURE;
-	}
+        if (ret == GravityReturnCodes::SUCCESS)
+        {
+            if (componentID != "ServiceDirectory")
+            {
+                settingsPubEnabled = getBoolParam("GravitySettingsPublishEnabled", false);
+                if (settingsPubEnabled)
+                {
+                    registerDataProductInternal(gravity::constants::GRAVITY_SETTINGS_DPID, GravityTransportTypes::TCP,
+                                                false, false, false, true);
+                }
 
-	if (iniWarning)
-	{
-			logger->warn("Gravity.ini specifies both Domain and URL. Using URL.");
-	}
+                // Enable metrics (if configured)
+                metricsEnabled = getBoolParam("GravityMetricsEnabled", false);
+                if (metricsEnabled)
+                {
+                    // Register our metrics data product with the service directory
+                    registerDataProductInternal(gravity::constants::METRICS_DATA_DPID, GravityTransportTypes::TCP,
+                                                false, false, false, true);
+
+                    // Command the GravityMetricsManager thread to start collecting metrics
+                    sendStringMessage(metricsManagerSocket, "MetricsEnable", ZMQ_SNDMORE);
+
+                    // Get collection parameters from ini file
+                    // (default to 10 second sampling, publishing once per min)
+                    int samplePeriod = getIntParam("GravityMetricsSamplePeriodSeconds", 10);
+                    int samplesPerPublish = getIntParam("GravityMetricsSamplesPerPublish", 6);
+
+                    // Send collection details to the GravityMetricsManager
+                    sendIntMessage(metricsManagerSocket, samplePeriod, ZMQ_SNDMORE);
+                    sendIntMessage(metricsManagerSocket, samplesPerPublish, ZMQ_SNDMORE);
+
+                    // Finally, send our component id, ip address, and registration time (to be published with metrics)
+                    sendStringMessage(metricsManagerSocket, componentID, ZMQ_SNDMORE);
+                    sendStringMessage(metricsManagerSocket, getIP(), ZMQ_SNDMORE);
+                    sendIntMessage(metricsManagerSocket, dataRegistrationTimeMap[gravity::constants::METRICS_DATA_DPID],
+                                   ZMQ_DONTWAIT);
+                }
+            }
+
+            if (componentID != "ConfigServer" && getBoolParam("NoConfigServer", false) != true)
+            {
+                parser->ParseConfigService(
+                    *this);  //Although this is done last, this has the least priority.  We just need to do it last so we know where the service directory is located.
+            }
+            //parser->ParseCmdLine
+
+            configureServiceManager();
+            configureSubscriptionManager();
+
+            // Auto start heartbeats if specified in INI
+            double heartbeatPeriodSecs = getFloatParam("GravityHeartbeatPeriodSecs", -1);
+            if (heartbeatPeriodSecs > 0)
+            {
+                logger->debug("Starting heartbeats ({} secs)", heartbeatPeriodSecs);
+                int64_t micros = std::round(heartbeatPeriodSecs * 1e6);
+                startHeartbeat(micros);
+            }
+        }
+    }
+    else
+    {
+        ret = GravityReturnCodes::FAILURE;
+    }
+
+    if (iniWarning)
+    {
+        logger->warn("Gravity.ini specifies both Domain and URL. Using URL.");
+    }
 
     initLock.Unlock();
 
-	return ret;
+    return ret;
 }
 /*
  * Do a name lookup to convert a hostname to an IP address in ascii 
  * dotted-quad notation.
  */
-static string toDottedQuad(string hostname) {
-   struct addrinfo hints;
-   struct addrinfo *result, *rp;
-   int s;
-   memset(&hints, 0, sizeof(struct addrinfo));
-   hints.ai_family = AF_INET;
-   hints.ai_socktype = SOCK_STREAM;
-   hints.ai_flags = AI_PASSIVE;
-   shared_ptr<spdlog::logger> logger = spdlog::get("GravityLogger");
-   // others zero
-   //logger->debug("Looking up quad for: {}\n", hostname);
-   s = getaddrinfo(hostname.c_str(), NULL, &hints, &result);
-   if (s != 0) {   
+static string toDottedQuad(string hostname)
+{
+    struct addrinfo hints;
+    struct addrinfo *result, *rp;
+    int s;
+    memset(&hints, 0, sizeof(struct addrinfo));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+    shared_ptr<spdlog::logger> logger = spdlog::get("GravityLogger");
+    // others zero
+    //logger->debug("Looking up quad for: {}\n", hostname);
+    s = getaddrinfo(hostname.c_str(), NULL, &hints, &result);
+    if (s != 0)
+    {
         logger->warn("error in getaddrinfo: {}\n", gai_strerror(s));
-		return hostname;
-   }   
-   string quad = hostname;
-   for (rp = result; rp != NULL; rp = rp->ai_next) {
-       struct in_addr pp = (((struct sockaddr_in*)(rp->ai_addr))->sin_addr);
-       //logger->debug("found addr quad for: {} : {}", hostname.c_str(), inet_ntoa(pp));
-       quad.assign(inet_ntoa(pp));
-       break;
-   }
+        return hostname;
+    }
+    string quad = hostname;
+    for (rp = result; rp != NULL; rp = rp->ai_next)
+    {
+        struct in_addr pp = (((struct sockaddr_in*)(rp->ai_addr))->sin_addr);
+        //logger->debug("found addr quad for: {} : {}", hostname.c_str(), inet_ntoa(pp));
+        quad.assign(inet_ntoa(pp));
+        break;
+    }
 
-   freeaddrinfo(result);           /* No longer needed */
-   return quad;
+    freeaddrinfo(result); /* No longer needed */
+    return quad;
 }
 
 void GravityNode::updateServiceDirectoryUrl(string serviceDirectoryUrl)
 {
-	// Extract URL component (transport, ip, and port)
-	serviceDirectoryLock.Lock();
-	size_t pos = serviceDirectoryUrl.find_first_of("://");
-	if (pos != std::string::npos)
-	{
-		serviceDirectoryNode.transport = serviceDirectoryUrl.substr(0, pos);
-		pos += 3;
-	}
-	else
-	{
-		serviceDirectoryNode.transport = "tcp";
-		pos = 0;
-	}
+    // Extract URL component (transport, ip, and port)
+    serviceDirectoryLock.Lock();
+    size_t pos = serviceDirectoryUrl.find_first_of("://");
+    if (pos != std::string::npos)
+    {
+        serviceDirectoryNode.transport = serviceDirectoryUrl.substr(0, pos);
+        pos += 3;
+    }
+    else
+    {
+        serviceDirectoryNode.transport = "tcp";
+        pos = 0;
+    }
 
-	size_t pos1 = serviceDirectoryUrl.find_first_of(":", pos);
-	serviceDirectoryNode.ipAddress = serviceDirectoryUrl.substr(pos, pos1 - pos);
+    size_t pos1 = serviceDirectoryUrl.find_first_of(":", pos);
+    serviceDirectoryNode.ipAddress = serviceDirectoryUrl.substr(pos, pos1 - pos);
 
-	/* The "*" is for the case where they did not define a URL in the Gravity.ini file,
+    /* The "*" is for the case where they did not define a URL in the Gravity.ini file,
 	So the ServiceDirectory broadcasted a URL with a "*" in it
 	*/
-	if (serviceDirectoryNode.ipAddress == "" || serviceDirectoryNode.ipAddress == "*" )
-		serviceDirectoryNode.ipAddress = "localhost";
+    if (serviceDirectoryNode.ipAddress == "" || serviceDirectoryNode.ipAddress == "*")
+        serviceDirectoryNode.ipAddress = "localhost";
 
-	if (serviceDirectoryNode.ipAddress != "localhost" && serviceDirectoryNode.ipAddress != "0.0.0.0" ) {
-                //logger->debug("SD IP originally: {}", serviceDirectoryNode.ipAddress);
-		serviceDirectoryNode.ipAddress = toDottedQuad(serviceDirectoryNode.ipAddress);
-                //logger->debug("SD IP set to: {}", serviceDirectoryNode.ipAddress);
-        }
+    if (serviceDirectoryNode.ipAddress != "localhost" && serviceDirectoryNode.ipAddress != "0.0.0.0")
+    {
+        //logger->debug("SD IP originally: {}", serviceDirectoryNode.ipAddress);
+        serviceDirectoryNode.ipAddress = toDottedQuad(serviceDirectoryNode.ipAddress);
+        //logger->debug("SD IP set to: {}", serviceDirectoryNode.ipAddress);
+    }
 
-	serviceDirectoryNode.port = gravity::StringToInt(serviceDirectoryUrl.substr(pos1 + 1), 5555);
-	serviceDirectoryLock.Unlock();
+    serviceDirectoryNode.port = gravity::StringToInt(serviceDirectoryUrl.substr(pos1 + 1), 5555);
+    serviceDirectoryLock.Unlock();
 
-	// Inform SubscriptionManager of Service Directory location
-	subscriptionManagerSWL.lock.Lock();
-	sendStringMessage(subscriptionManagerSWL.socket, "set_service_dir_url", ZMQ_SNDMORE);
-	sendStringMessage(subscriptionManagerSWL.socket, serviceDirectoryUrl, ZMQ_DONTWAIT);
-	subscriptionManagerSWL.lock.Unlock();
+    // Inform SubscriptionManager of Service Directory location
+    subscriptionManagerSWL.lock.Lock();
+    sendStringMessage(subscriptionManagerSWL.socket, "set_service_dir_url", ZMQ_SNDMORE);
+    sendStringMessage(subscriptionManagerSWL.socket, serviceDirectoryUrl, ZMQ_DONTWAIT);
+    subscriptionManagerSWL.lock.Unlock();
 
-	// Inform RequestManager of Service Directory location
-	requestManagerSWL.lock.Lock();
-	sendStringMessage(requestManagerSWL.socket, "set_service_dir_url", ZMQ_SNDMORE);
-	sendStringMessage(requestManagerSWL.socket, serviceDirectoryUrl, ZMQ_DONTWAIT);
-	requestManagerSWL.lock.Unlock();
+    // Inform RequestManager of Service Directory location
+    requestManagerSWL.lock.Lock();
+    sendStringMessage(requestManagerSWL.socket, "set_service_dir_url", ZMQ_SNDMORE);
+    sendStringMessage(requestManagerSWL.socket, serviceDirectoryUrl, ZMQ_DONTWAIT);
+    requestManagerSWL.lock.Unlock();
 }
 
 void GravityNode::configureNodeDomainListener(std::string domain)
 {
-	sendStringMessage(domainListenerSWL.socket,"configure",ZMQ_SNDMORE);
-	sendStringMessage(domainListenerSWL.socket,domain,ZMQ_SNDMORE);
+    sendStringMessage(domainListenerSWL.socket, "configure", ZMQ_SNDMORE);
+    sendStringMessage(domainListenerSWL.socket, domain, ZMQ_SNDMORE);
 
-	int port = getIntParam("ServiceDirectoryBroadcastPort",DEFAULT_BROADCAST_PORT);
-	int broadcastTimeout = getIntParam("ServiceDirectoryBroadcastTimeout",DEFAULT_BROADCAST_TIMEOUT_SEC);
+    int port = getIntParam("ServiceDirectoryBroadcastPort", DEFAULT_BROADCAST_PORT);
+    int broadcastTimeout = getIntParam("ServiceDirectoryBroadcastTimeout", DEFAULT_BROADCAST_TIMEOUT_SEC);
 
-	zmq_msg_t msg;
-	zmq_msg_init_size(&msg,sizeof(port));
-	memcpy(zmq_msg_data(&msg),&port,sizeof(port));
-	zmq_sendmsg(domainListenerSWL.socket,&msg,ZMQ_SNDMORE);
-	zmq_msg_close(&msg);
+    zmq_msg_t msg;
+    zmq_msg_init_size(&msg, sizeof(port));
+    memcpy(zmq_msg_data(&msg), &port, sizeof(port));
+    zmq_sendmsg(domainListenerSWL.socket, &msg, ZMQ_SNDMORE);
+    zmq_msg_close(&msg);
 
-	zmq_msg_t msg2;
-	zmq_msg_init_size(&msg2,sizeof(broadcastTimeout));
-	memcpy(zmq_msg_data(&msg2),&broadcastTimeout,sizeof(broadcastTimeout));
-	zmq_sendmsg(domainListenerSWL.socket,&msg2,ZMQ_SNDMORE);
-	zmq_msg_close(&msg2);
+    zmq_msg_t msg2;
+    zmq_msg_init_size(&msg2, sizeof(broadcastTimeout));
+    memcpy(zmq_msg_data(&msg2), &broadcastTimeout, sizeof(broadcastTimeout));
+    zmq_sendmsg(domainListenerSWL.socket, &msg2, ZMQ_SNDMORE);
+    zmq_msg_close(&msg2);
 
-	sendStringMessage(domainListenerSWL.socket,componentID,ZMQ_SNDMORE);
+    sendStringMessage(domainListenerSWL.socket, componentID, ZMQ_SNDMORE);
 
-	zmq_msg_t msg3;
-	zmq_msg_init_size(&msg3,sizeof(GravityNode*));
-	GravityNode* tmp = this;
-	memcpy(zmq_msg_data(&msg3),&tmp,sizeof(GravityNode*));
-	zmq_sendmsg(domainListenerSWL.socket,&msg3,ZMQ_DONTWAIT);
-	zmq_msg_close(&msg3);
+    zmq_msg_t msg3;
+    zmq_msg_init_size(&msg3, sizeof(GravityNode*));
+    GravityNode* tmp = this;
+    memcpy(zmq_msg_data(&msg3), &tmp, sizeof(GravityNode*));
+    zmq_sendmsg(domainListenerSWL.socket, &msg3, ZMQ_DONTWAIT);
+    zmq_msg_close(&msg3);
 
-	readStringMessage(domainListenerSWL.socket);
+    readStringMessage(domainListenerSWL.socket);
 }
 
 void GravityNode::configureServiceManager()
 {
+    sendStringMessage(serviceManagerConfigSWL.socket, "configure", ZMQ_SNDMORE);
 
-	sendStringMessage(serviceManagerConfigSWL.socket,"configure",ZMQ_SNDMORE);
+    //send Domain
+    sendStringMessage(serviceManagerConfigSWL.socket, myDomain, ZMQ_SNDMORE);
 
-	//send Domain
-	sendStringMessage(serviceManagerConfigSWL.socket,myDomain,ZMQ_SNDMORE);
-
-	//Send component ID
-	sendStringMessage(serviceManagerConfigSWL.socket,componentID,ZMQ_DONTWAIT);
-
+    //Send component ID
+    sendStringMessage(serviceManagerConfigSWL.socket, componentID, ZMQ_DONTWAIT);
 }
 
 void GravityNode::configureSubscriptionManager()
 {
-	sendStringMessage(subscriptionManagerConfigSWL.socket,"configure",ZMQ_SNDMORE);
+    sendStringMessage(subscriptionManagerConfigSWL.socket, "configure", ZMQ_SNDMORE);
 
-	//send Domain
-	sendStringMessage(subscriptionManagerConfigSWL.socket,myDomain,ZMQ_SNDMORE);
+    //send Domain
+    sendStringMessage(subscriptionManagerConfigSWL.socket, myDomain, ZMQ_SNDMORE);
 
-	//Send component ID
-	sendStringMessage(subscriptionManagerConfigSWL.socket,componentID,ZMQ_DONTWAIT);
+    //Send component ID
+    sendStringMessage(subscriptionManagerConfigSWL.socket, componentID, ZMQ_DONTWAIT);
 
-	//Send ip address
-	sendStringMessage(subscriptionManagerConfigSWL.socket,getIP(),ZMQ_DONTWAIT);
+    //Send ip address
+    sendStringMessage(subscriptionManagerConfigSWL.socket, getIP(), ZMQ_DONTWAIT);
 }
 
 std::string GravityNode::getDomainUrl(int timeout)
 {
-	int waitTime=0;
+    int waitTime = 0;
 
-	zmq_pollitem_t pollItem;
-	pollItem.socket=domainRecvSWL.socket;
-	pollItem.events=ZMQ_POLLIN;
-	pollItem.fd=0;
-	pollItem.revents=0;
-	std::string url="";
-	while(waitTime < timeout*1000)
-	{
-		 // Start polling socket(s), blocking while we wait
-        int rc = zmq_poll(&pollItem, 1, 0); // 0 --> return immediately, -1 --> blocks
+    zmq_pollitem_t pollItem;
+    pollItem.socket = domainRecvSWL.socket;
+    pollItem.events = ZMQ_POLLIN;
+    pollItem.fd = 0;
+    pollItem.revents = 0;
+    std::string url = "";
+    while (waitTime < timeout * 1000)
+    {
+        // Start polling socket(s), blocking while we wait
+        int rc = zmq_poll(&pollItem, 1, 0);  // 0 --> return immediately, -1 --> blocks
         if (rc == -1)
         {
             // Interrupted
@@ -1212,147 +1214,149 @@ std::string GravityNode::getDomainUrl(int timeout)
         // Process new subscription requests from the gravity node
         if (pollItem.revents & ZMQ_POLLIN)
         {
-			std::string command=readStringMessage(domainRecvSWL.socket);
-			if(command=="connect")
-			{
-				std::string domain = readStringMessage(domainRecvSWL.socket);
-				url=readStringMessage(domainRecvSWL.socket);
-				break;
-			}
-		}
+            std::string command = readStringMessage(domainRecvSWL.socket);
+            if (command == "connect")
+            {
+                std::string domain = readStringMessage(domainRecvSWL.socket);
+                url = readStringMessage(domainRecvSWL.socket);
+                break;
+            }
+        }
 
-		sleep(100);
-		waitTime+=100;
-	}
-	return url;
-
+        sleep(100);
+        waitTime += 100;
+    }
+    return url;
 }
 
 void GravityNode::waitForExit()
 {
-  while(subscriptionManagerThread.joinable())
-  {
-    sleep(10000);
-  }
+    while (subscriptionManagerThread.joinable())
+    {
+        sleep(10000);
+    }
 }
 
 GravityReturnCode GravityNode::sendRequestsToServiceProvider(string url, const GravityDataProduct& request,
-        GravityDataProduct& response, int timeout_in_milliseconds, int retries)
+                                                             GravityDataProduct& response, int timeout_in_milliseconds,
+                                                             int retries)
 {
     GravityReturnCode ret = GravityReturnCodes::NOT_INITIALIZED;
 
     int retriesLeft = retries;
-    while(retriesLeft && ret != GravityReturnCodes::FAILURE && ret != GravityReturnCodes::SUCCESS)
+    while (retriesLeft && ret != GravityReturnCodes::FAILURE && ret != GravityReturnCodes::SUCCESS)
     {
-    	--retriesLeft;
-    	ret = sendRequestToServiceProvider(url, request, response, timeout_in_milliseconds);
+        --retriesLeft;
+        ret = sendRequestToServiceProvider(url, request, response, timeout_in_milliseconds);
     }
 
     return ret;
 }
 
 GravityReturnCode GravityNode::sendRequestToServiceProvider(string url, const GravityDataProduct& request,
-        GravityDataProduct& response, int timeout_in_milliseconds)
+                                                            GravityDataProduct& response, int timeout_in_milliseconds)
 {
     GravityReturnCode ret = GravityReturnCodes::SUCCESS;
 
-	// Connect to service provider
-	logger->trace("GravityNode::sendRequestToServiceProvider({},{},{},{})", url, request.getDataProductID(), 
-													response.getDataProductID(), timeout_in_milliseconds);
-    void* socket = zmq_socket(context, ZMQ_REQ); // Socket to connect to service provider
-	zmq_connect(socket, url.c_str());
-	int linger = 0;
+    // Connect to service provider
+    logger->trace("GravityNode::sendRequestToServiceProvider({},{},{},{})", url, request.getDataProductID(),
+                  response.getDataProductID(), timeout_in_milliseconds);
+    void* socket = zmq_socket(context, ZMQ_REQ);  // Socket to connect to service provider
+    zmq_connect(socket, url.c_str());
+    int linger = 0;
     zmq_setsockopt(socket, ZMQ_LINGER, &linger, sizeof(linger));
 
+    // Send message to service provider
+    sendGravityDataProduct(socket, request, ZMQ_DONTWAIT);
 
-	// Send message to service provider
-	sendGravityDataProduct(socket, request, ZMQ_DONTWAIT);
+    // Poll socket for reply with a timeout
+    zmq_pollitem_t items[] = {{socket, 0, ZMQ_POLLIN, 0}};
+    int rc = zmq_poll(items, 1, timeout_in_milliseconds);
+    if (rc == -1)
+    {
+        if (errno == EINTR)
+            ret = GravityReturnCodes::INTERRUPTED;
+        else
+            ret = GravityReturnCodes::FAILURE;
+    }
+    else if (rc == 0)
+        ret = GravityReturnCodes::REQUEST_TIMEOUT;
+    // Got a Response, now process it.  Process the response
+    else if (items[0].revents & ZMQ_POLLIN)
+    {
+        // Get response from service
+        zmq_msg_t resp;
+        zmq_msg_init(&resp);
+        zmq_recvmsg(socket, &resp, 0);
 
-	// Poll socket for reply with a timeout
-	zmq_pollitem_t items[] = {{socket, 0, ZMQ_POLLIN, 0}};
-	int rc = zmq_poll(items, 1, timeout_in_milliseconds);
-	if (rc == -1)
+        bool parserSuccess = true;
+        try
         {
-            if (errno == EINTR)
-	        ret = GravityReturnCodes::INTERRUPTED;
-            else
-                ret = GravityReturnCodes::FAILURE;
+            response.parseFromArray(zmq_msg_data(&resp), zmq_msg_size(&resp));
         }
-	else if(rc == 0)
-		ret = GravityReturnCodes::REQUEST_TIMEOUT;
-	// Got a Response, now process it.  Process the response
-	else if(items[0].revents & ZMQ_POLLIN)
-	{
-		// Get response from service
-		zmq_msg_t resp;
-		zmq_msg_init(&resp);
-		zmq_recvmsg(socket, &resp, 0);
+        catch (char*)
+        {
+            parserSuccess = false;
+        }
 
-		bool parserSuccess = true;
-		try
-		{
-			response.parseFromArray(zmq_msg_data(&resp), zmq_msg_size(&resp));
-		}
-		catch (char*)
-		{
-			parserSuccess = false;
-		}
+        // Clean up message
+        zmq_msg_close(&resp);
 
-		// Clean up message
-		zmq_msg_close(&resp);
+        if (parserSuccess)
+            ret = GravityReturnCodes::SUCCESS;
+        else
+            // Bad response.
+            ret = GravityReturnCodes::LINK_ERROR;
+    }
+    else
+    {
+        ret = GravityReturnCodes::NO_SERVICE_PROVIDER;
+    }
 
-		if (parserSuccess)
-			ret = GravityReturnCodes::SUCCESS;
-		else
-			// Bad response.
-			ret = GravityReturnCodes::LINK_ERROR;
-	}
-	else
-	{
-		ret = GravityReturnCodes::NO_SERVICE_PROVIDER;
-	}
+    // Close socket
+    zmq_close(socket);
 
-	// Close socket
-	zmq_close(socket);
-
-	if(s_interrupted)
-	{
-		ret = GravityReturnCodes::INTERRUPTED;
-		raise(s_interrupted);
-	}
+    if (s_interrupted)
+    {
+        ret = GravityReturnCodes::INTERRUPTED;
+        raise(s_interrupted);
+    }
 
     return ret;
 }
 
-
 GravityReturnCode GravityNode::sendRequestToServiceDirectory(const GravityDataProduct& request,
-        GravityDataProduct& response)
+                                                             GravityDataProduct& response)
 {
-	stringstream ss;
+    stringstream ss;
     serviceDirectoryLock.Lock();
-	ss << serviceDirectoryNode.transport << "://" << serviceDirectoryNode.ipAddress <<
-	                ":" << serviceDirectoryNode.port;
-	string serviceDirectoryURL = ss.str();
-	logger->trace("About to make SD request at URL = {}", serviceDirectoryURL);
+    ss << serviceDirectoryNode.transport << "://" << serviceDirectoryNode.ipAddress << ":" << serviceDirectoryNode.port;
+    string serviceDirectoryURL = ss.str();
+    logger->trace("About to make SD request at URL = {}", serviceDirectoryURL);
 
-	GravityReturnCode ret = sendRequestsToServiceProvider(serviceDirectoryURL, request, response, NETWORK_TIMEOUT, NETWORK_RETRIES);
+    GravityReturnCode ret =
+        sendRequestsToServiceProvider(serviceDirectoryURL, request, response, NETWORK_TIMEOUT, NETWORK_RETRIES);
     serviceDirectoryLock.Unlock();
     return ret;
 }
 
-GravityReturnCode GravityNode::registerDataProduct(string dataProductID, GravityTransportType transportType){
-	return registerDataProduct(dataProductID, transportType, defaultCacheLastSentDataprodut);
+GravityReturnCode GravityNode::registerDataProduct(string dataProductID, GravityTransportType transportType)
+{
+    return registerDataProduct(dataProductID, transportType, defaultCacheLastSentDataprodut);
 }
 
-GravityReturnCode GravityNode::registerDataProduct(string dataProductID, GravityTransportType transportType, bool cacheLastValue)
-{ 
-	return registerDataProductInternal(dataProductID, transportType, cacheLastValue, false, false, false);
+GravityReturnCode GravityNode::registerDataProduct(string dataProductID, GravityTransportType transportType,
+                                                   bool cacheLastValue)
+{
+    return registerDataProductInternal(dataProductID, transportType, cacheLastValue, false, false, false);
 }
 
-GravityReturnCode GravityNode::subscribersExist(std::string dataProductID, bool& hasSubscribersOut) {
-	hasSubscribersOut = true;  // if error and the client doesn't check, safer to assume we have a subscriber
-	GravityReturnCode ret = GravityReturnCode::FAILURE;
-    if (!initialized) {
+GravityReturnCode GravityNode::subscribersExist(std::string dataProductID, bool& hasSubscribersOut)
+{
+    hasSubscribersOut = true;  // if error and the client doesn't check, safer to assume we have a subscriber
+    GravityReturnCode ret = GravityReturnCode::FAILURE;
+    if (!initialized)
+    {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
     publishManagerRequestSWL.lock.Lock();
@@ -1360,40 +1364,47 @@ GravityReturnCode GravityNode::subscribersExist(std::string dataProductID, bool&
     sendStringMessage(publishManagerRequestSWL.socket, dataProductID, ZMQ_DONTWAIT);
     string result = readStringMessage(publishManagerRequestSWL.socket);
     publishManagerRequestSWL.lock.Unlock();
-    if (result == "Y") {
-		hasSubscribersOut = true;
-		ret = GravityReturnCode::SUCCESS;
-    } else if (result == "N") {
-		hasSubscribersOut = false;
-		ret = GravityReturnCode::SUCCESS;
-	} else {
-		logger->warn("Query for subscribers returns error : {}", result);
-		if (result.rfind("Unknown data product", 0) == 0) {
-			ret = GravityReturnCode::NOT_REGISTERED;
-		} // otherwise, leave as generic failure code and hasSubscribersOut=true
+    if (result == "Y")
+    {
+        hasSubscribersOut = true;
+        ret = GravityReturnCode::SUCCESS;
     }
-    return ret;  
+    else if (result == "N")
+    {
+        hasSubscribersOut = false;
+        ret = GravityReturnCode::SUCCESS;
+    }
+    else
+    {
+        logger->warn("Query for subscribers returns error : {}", result);
+        if (result.rfind("Unknown data product", 0) == 0)
+        {
+            ret = GravityReturnCode::NOT_REGISTERED;
+        }  // otherwise, leave as generic failure code and hasSubscribersOut=true
+    }
+    return ret;
 }
 
-
-GravityReturnCode GravityNode::registerDataProductInternal(std::string dataProductID, GravityTransportType transportType,
-		                                                    bool cacheLastValue, bool isRelay, bool localOnly, bool allowReservedIDs)
+GravityReturnCode GravityNode::registerDataProductInternal(std::string dataProductID,
+                                                           GravityTransportType transportType, bool cacheLastValue,
+                                                           bool isRelay, bool localOnly, bool allowReservedIDs)
 {
     if (!initialized)
     {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
 
-	if ((componentID != "ServiceDirectory" && serviceDirectory_ReservedDataProductIDs.find(dataProductID) != serviceDirectory_ReservedDataProductIDs.end()) || 
-		(allowReservedIDs == false && gravityNode_ReservedDataProductIDs.find(dataProductID) != gravityNode_ReservedDataProductIDs.end()))
-	{
-		spdlog::warn("Rejecting attempt to register {}", dataProductID);
-		return GravityReturnCodes::RESERVED_DATA_PRODUCT_ID;
-	}
+    if ((componentID != "ServiceDirectory" && serviceDirectory_ReservedDataProductIDs.find(dataProductID) !=
+                                                  serviceDirectory_ReservedDataProductIDs.end()) ||
+        (allowReservedIDs == false &&
+         gravityNode_ReservedDataProductIDs.find(dataProductID) != gravityNode_ReservedDataProductIDs.end()))
+    {
+        spdlog::warn("Rejecting attempt to register {}", dataProductID);
+        return GravityReturnCodes::RESERVED_DATA_PRODUCT_ID;
+    }
 
     std::string transportType_str;
     GravityReturnCode ret = GravityReturnCodes::SUCCESS;
-
 
     // we can't allow multiple threads to make request calls to the pub manager at the same time
     // because the requests will step on each other.  Manage access to publishMap as well.
@@ -1407,10 +1418,10 @@ GravityReturnCode GravityNode::registerDataProductInternal(std::string dataProdu
     }
 
     string endpoint;
-    if(transportType == GravityTransportTypes::TCP)
+    if (transportType == GravityTransportTypes::TCP)
     {
         transportType_str = "tcp";
-    	  endpoint = getIP();
+        endpoint = getIP();
     }
 #ifndef WIN32
     else if (transportType == GravityTransportTypes::IPC)
@@ -1419,48 +1430,48 @@ GravityReturnCode GravityNode::registerDataProductInternal(std::string dataProdu
         endpoint = "/tmp/" + dataProductID;
     }
 #endif
-    else if(transportType == GravityTransportTypes::INPROC)
+    else if (transportType == GravityTransportTypes::INPROC)
     {
         transportType_str = "inproc";
-    	  endpoint = dataProductID;
+        endpoint = dataProductID;
     }
-    else if(transportType == GravityTransportTypes::PGM)
+    else if (transportType == GravityTransportTypes::PGM)
     {
         transportType_str = "pgm";
-    	  endpoint = dataProductID;
+        endpoint = dataProductID;
     }
-    else if(transportType == GravityTransportTypes::EPGM)
+    else if (transportType == GravityTransportTypes::EPGM)
     {
         transportType_str = "epgm";
-    	  endpoint = dataProductID;
+        endpoint = dataProductID;
     }
 
-	// Registration timestamp - will serve as a unique identifier for this registered publication
-	uint64_t timestamp = getCurrentTime();
-	
+    // Registration timestamp - will serve as a unique identifier for this registered publication
+    uint64_t timestamp = getCurrentTime();
+
     // Send publish details via the request socket.  This allows us to retrieve
     // register url in response so that we can register with the ServiceDirectory.
-	sendStringMessage(publishManagerRequestSWL.socket, "register", ZMQ_SNDMORE);
-	sendStringMessage(publishManagerRequestSWL.socket, dataProductID, ZMQ_SNDMORE);
-	sendIntMessage(publishManagerRequestSWL.socket, cacheLastValue, ZMQ_SNDMORE);
+    sendStringMessage(publishManagerRequestSWL.socket, "register", ZMQ_SNDMORE);
+    sendStringMessage(publishManagerRequestSWL.socket, dataProductID, ZMQ_SNDMORE);
+    sendIntMessage(publishManagerRequestSWL.socket, cacheLastValue, ZMQ_SNDMORE);
     sendStringMessage(publishManagerRequestSWL.socket, transportType_str, ZMQ_SNDMORE);
-    if(transportType == GravityTransportTypes::TCP)
+    if (transportType == GravityTransportTypes::TCP)
     {
         int minPort = getIntParam("MinPort", MIN_PORT);
         int maxPort = getIntParam("MaxPort", MAX_PORT);
         sendIntMessage(publishManagerRequestSWL.socket, minPort, ZMQ_SNDMORE);
         sendIntMessage(publishManagerRequestSWL.socket, maxPort, ZMQ_SNDMORE);
     }
-	sendStringMessage(publishManagerRequestSWL.socket, endpoint, ZMQ_DONTWAIT);
+    sendStringMessage(publishManagerRequestSWL.socket, endpoint, ZMQ_DONTWAIT);
 
-	string connectionURL = readStringMessage(publishManagerRequestSWL.socket);
+    string connectionURL = readStringMessage(publishManagerRequestSWL.socket);
 
-	if (connectionURL.size() == 0)
-	{
-	    ret = GravityReturnCodes::NO_PORTS_AVAILABLE;
-	}
-	else
-	{
+    if (connectionURL.size() == 0)
+    {
+        ret = GravityReturnCodes::NO_PORTS_AVAILABLE;
+    }
+    else
+    {
         if (!serviceDirectoryNode.ipAddress.empty())
         {
             // Create the object describing the data product to register
@@ -1469,12 +1480,12 @@ GravityReturnCode GravityNode::registerDataProductInternal(std::string dataProdu
             registration.set_url(connectionURL);
             registration.set_type(ServiceDirectoryRegistrationPB::DATA);
             registration.set_component_id(componentID);
-			registration.set_timestamp(timestamp);
-			registration.set_is_relay(isRelay);
-			if (localOnly)
-			{
-				registration.set_ip_address(getIP());
-			}
+            registration.set_timestamp(timestamp);
+            registration.set_is_relay(isRelay);
+            if (localOnly)
+            {
+                registration.set_ip_address(getIP());
+            }
 
             // Wrap request in GravityDataProduct
             GravityDataProduct request("RegistrationRequest");
@@ -1502,18 +1513,18 @@ GravityReturnCode GravityNode::registerDataProductInternal(std::string dataProdu
                 {
                     switch (pb.returncode())
                     {
-                    case ServiceDirectoryResponsePB::SUCCESS:
-                        ret = GravityReturnCodes::SUCCESS;
-                        break;
-                    case ServiceDirectoryResponsePB::REGISTRATION_CONFLICT:
-                        ret = GravityReturnCodes::REGISTRATION_CONFLICT;
-                        break;
-                    case ServiceDirectoryResponsePB::DUPLICATE_REGISTRATION:
-                        ret = GravityReturnCodes::DUPLICATE;
-                        break;
-                    case ServiceDirectoryResponsePB::NOT_REGISTERED:
-                        ret = GravityReturnCodes::LINK_ERROR;
-                        break;
+                        case ServiceDirectoryResponsePB::SUCCESS:
+                            ret = GravityReturnCodes::SUCCESS;
+                            break;
+                        case ServiceDirectoryResponsePB::REGISTRATION_CONFLICT:
+                            ret = GravityReturnCodes::REGISTRATION_CONFLICT;
+                            break;
+                        case ServiceDirectoryResponsePB::DUPLICATE_REGISTRATION:
+                            ret = GravityReturnCodes::DUPLICATE;
+                            break;
+                        case ServiceDirectoryResponsePB::NOT_REGISTERED:
+                            ret = GravityReturnCodes::LINK_ERROR;
+                            break;
                     }
                 }
                 else
@@ -1526,27 +1537,27 @@ GravityReturnCode GravityNode::registerDataProductInternal(std::string dataProdu
         {
             ret = GravityReturnCodes::NO_SERVICE_DIRECTORY;
         }
-	}
+    }
 
-	if (ret != GravityReturnCodes::SUCCESS)
-	{
-	    logger->warn("Failed to register {} at url {} with error {}", dataProductID, connectionURL, getCodeString(ret));
-	    // if we didn't succesfully register with the SD, then unregister with the publish manager
-	    sendStringMessage(publishManagerRequestSWL.socket, "unregister", ZMQ_SNDMORE);
-	    sendStringMessage(publishManagerRequestSWL.socket, dataProductID, ZMQ_DONTWAIT);
-	    readStringMessage(publishManagerRequestSWL.socket);
-	}
-	else
-	{
-	    logger->debug("Registered publisher at address: {}", connectionURL);
+    if (ret != GravityReturnCodes::SUCCESS)
+    {
+        logger->warn("Failed to register {} at url {} with error {}", dataProductID, connectionURL, getCodeString(ret));
+        // if we didn't succesfully register with the SD, then unregister with the publish manager
+        sendStringMessage(publishManagerRequestSWL.socket, "unregister", ZMQ_SNDMORE);
+        sendStringMessage(publishManagerRequestSWL.socket, dataProductID, ZMQ_DONTWAIT);
+        readStringMessage(publishManagerRequestSWL.socket);
+    }
+    else
+    {
+        logger->debug("Registered publisher at address: {}", connectionURL);
         publishMap[dataProductID] = connectionURL;
-		urlInstanceMap[connectionURL] = timestamp;
-		dataRegistrationTimeMap[dataProductID] = static_cast<uint32_t>(timestamp / 1e6); // Maintained in epoch seconds
-	}
+        urlInstanceMap[connectionURL] = timestamp;
+        dataRegistrationTimeMap[dataProductID] = static_cast<uint32_t>(timestamp / 1e6);  // Maintained in epoch seconds
+    }
 
     publishManagerRequestSWL.lock.Unlock();
 
-	return ret;
+    return ret;
 }
 
 GravityReturnCode GravityNode::unregisterDataProduct(string dataProductID)
@@ -1567,11 +1578,11 @@ GravityReturnCode GravityNode::unregisterDataProduct(string dataProductID)
         sendStringMessage(publishManagerRequestSWL.socket, "unregister", ZMQ_SNDMORE);
         sendStringMessage(publishManagerRequestSWL.socket, dataProductID, ZMQ_DONTWAIT);
         readStringMessage(publishManagerRequestSWL.socket);
-    	string url = publishMap[dataProductID];
+        string url = publishMap[dataProductID];
         publishMap.erase(dataProductID);
-		urlInstanceMap.erase(url);
-		uint32_t regTime = dataRegistrationTimeMap[dataProductID];
-		dataRegistrationTimeMap.erase(dataProductID);
+        urlInstanceMap.erase(url);
+        uint32_t regTime = dataRegistrationTimeMap[dataProductID];
+        dataRegistrationTimeMap.erase(dataProductID);
 
         if (!serviceDirectoryNode.ipAddress.empty())
         {
@@ -1579,7 +1590,7 @@ GravityReturnCode GravityNode::unregisterDataProduct(string dataProductID)
             unregistration.set_id(dataProductID);
             unregistration.set_url(url);
             unregistration.set_type(ServiceDirectoryUnregistrationPB::DATA);
-			unregistration.set_registration_time(regTime);
+            unregistration.set_registration_time(regTime);
 
             GravityDataProduct request("UnregistrationRequest");
             request.setData(unregistration);
@@ -1607,13 +1618,13 @@ GravityReturnCode GravityNode::unregisterDataProduct(string dataProductID)
                 {
                     switch (pb.returncode())
                     {
-                    case ServiceDirectoryResponsePB::SUCCESS:
-                    case ServiceDirectoryResponsePB::NOT_REGISTERED:
-                        ret = GravityReturnCodes::SUCCESS;
-                        break;
-                    default:
-                        ret = GravityReturnCodes::FAILURE;
-                        break;
+                        case ServiceDirectoryResponsePB::SUCCESS:
+                        case ServiceDirectoryResponsePB::NOT_REGISTERED:
+                            ret = GravityReturnCodes::SUCCESS;
+                            break;
+                        default:
+                            ret = GravityReturnCodes::FAILURE;
+                            break;
                     }
                 }
                 else
@@ -1628,12 +1639,13 @@ GravityReturnCode GravityNode::unregisterDataProduct(string dataProductID)
     return ret;
 }
 
-GravityReturnCode GravityNode::ServiceDirectoryDataProductLookup(std::string dataProductID, vector<PublisherInfoPB> &urls, string& domain)
+GravityReturnCode GravityNode::ServiceDirectoryDataProductLookup(std::string dataProductID,
+                                                                 vector<PublisherInfoPB>& urls, string& domain)
 {
     // Create the object describing the data product to lookup
     ComponentLookupRequestPB lookup;
     lookup.set_lookupid(dataProductID);
-	lookup.set_domain_id(domain);
+    lookup.set_domain_id(domain);
     lookup.set_type(ComponentLookupRequestPB::DATA);
 
     // Wrap request in GravityDataProduct
@@ -1661,8 +1673,7 @@ GravityReturnCode GravityNode::ServiceDirectoryDataProductLookup(std::string dat
 
         if (parserSuccess)
         {
-            for (int i = 0; i < pb.publishers_size(); i++)
-                urls.push_back(pb.publishers(i));
+            for (int i = 0; i < pb.publishers_size(); i++) urls.push_back(pb.publishers(i));
             ret = GravityReturnCodes::SUCCESS;
         }
         else
@@ -1678,26 +1689,32 @@ GravityReturnCode GravityNode::ServiceDirectoryDataProductLookup(std::string dat
     return ret;
 }
 
-GravityReturnCode GravityNode::subscribe(string dataProductID, const GravitySubscriber& subscriber){
-	subscriptionManagerSWL.lock.Lock();
-	GravityReturnCode ret = subscribeInternal(dataProductID, subscriber, "", "", defaultReceiveLastSentDataproduct);
+GravityReturnCode GravityNode::subscribe(string dataProductID, const GravitySubscriber& subscriber)
+{
+    subscriptionManagerSWL.lock.Lock();
+    GravityReturnCode ret = subscribeInternal(dataProductID, subscriber, "", "", defaultReceiveLastSentDataproduct);
     subscriptionManagerSWL.lock.Unlock();
-	return ret;
+    return ret;
 }
-GravityReturnCode GravityNode::subscribe(string dataProductID, const GravitySubscriber& subscriber, string filter){
-	subscriptionManagerSWL.lock.Lock();
-	GravityReturnCode ret = subscribeInternal(dataProductID, subscriber, filter, "", defaultReceiveLastSentDataproduct);
+GravityReturnCode GravityNode::subscribe(string dataProductID, const GravitySubscriber& subscriber, string filter)
+{
+    subscriptionManagerSWL.lock.Lock();
+    GravityReturnCode ret = subscribeInternal(dataProductID, subscriber, filter, "", defaultReceiveLastSentDataproduct);
     subscriptionManagerSWL.lock.Unlock();
-	return ret;
+    return ret;
 }
-GravityReturnCode GravityNode::subscribe(string dataProductID, const GravitySubscriber& subscriber, string filter, string domain){
-	subscriptionManagerSWL.lock.Lock();
-	GravityReturnCode ret = subscribeInternal(dataProductID, subscriber, filter, domain, defaultReceiveLastSentDataproduct);
+GravityReturnCode GravityNode::subscribe(string dataProductID, const GravitySubscriber& subscriber, string filter,
+                                         string domain)
+{
+    subscriptionManagerSWL.lock.Lock();
+    GravityReturnCode ret =
+        subscribeInternal(dataProductID, subscriber, filter, domain, defaultReceiveLastSentDataproduct);
     subscriptionManagerSWL.lock.Unlock();
-	return ret;
+    return ret;
 }
 
-GravityReturnCode GravityNode::subscribe(string dataProductID, const GravitySubscriber& subscriber, string filter, string domain, bool receiveLastCachedValue)
+GravityReturnCode GravityNode::subscribe(string dataProductID, const GravitySubscriber& subscriber, string filter,
+                                         string domain, bool receiveLastCachedValue)
 {
     subscriptionManagerSWL.lock.Lock();
     GravityReturnCode ret = subscribeInternal(dataProductID, subscriber, filter, domain, receiveLastCachedValue);
@@ -1705,7 +1722,8 @@ GravityReturnCode GravityNode::subscribe(string dataProductID, const GravitySubs
     return ret;
 }
 
-GravityReturnCode GravityNode::subscribeInternal(string dataProductID, const GravitySubscriber& subscriber, string filter, string domain, bool receiveLastCachedValue)
+GravityReturnCode GravityNode::subscribeInternal(string dataProductID, const GravitySubscriber& subscriber,
+                                                 string filter, string domain, bool receiveLastCachedValue)
 {
     if (!initialized)
     {
@@ -1721,67 +1739,70 @@ GravityReturnCode GravityNode::subscribeInternal(string dataProductID, const Gra
 
     GravityReturnCode ret;
     ret = ServiceDirectoryDataProductLookup(dataProductID, publisherInfoPBs, domain);
-    if(ret != GravityReturnCodes::SUCCESS) {
+    if (ret != GravityReturnCodes::SUCCESS)
+    {
         return ret;
     }
 
-	logger->trace("Subscribing to [{}] and receiving cached values: {}", dataProductID, receiveLastCachedValue);
-	
-	vector<PublisherInfoPB> registeredPublishersInfo;
-	int tries = 5;
-	while (registeredPublishersInfo.size() == 0 && tries-- > 0)
-	{
-		ret = ServiceDirectoryDataProductLookup(gravity::constants::REGISTERED_PUBLISHERS_DPID, registeredPublishersInfo, myDomain);
-		if(ret != GravityReturnCodes::SUCCESS)
-			return ret;
-		if (registeredPublishersInfo.size() > 1)
-			logger->warn("Found more than one ({}) Service Directory registered for publisher updates?", registeredPublishersInfo.size());
-		else if (registeredPublishersInfo.size() == 1)
-			break;
+    logger->trace("Subscribing to [{}] and receiving cached values: {}", dataProductID, receiveLastCachedValue);
 
-		if (tries > 0)
-			gravity::sleep(500);
-	}
+    vector<PublisherInfoPB> registeredPublishersInfo;
+    int tries = 5;
+    while (registeredPublishersInfo.size() == 0 && tries-- > 0)
+    {
+        ret = ServiceDirectoryDataProductLookup(gravity::constants::REGISTERED_PUBLISHERS_DPID,
+                                                registeredPublishersInfo, myDomain);
+        if (ret != GravityReturnCodes::SUCCESS) return ret;
+        if (registeredPublishersInfo.size() > 1)
+            logger->warn("Found more than one ({}) Service Directory registered for publisher updates?",
+                         registeredPublishersInfo.size());
+        else if (registeredPublishersInfo.size() == 1)
+            break;
 
-	if (registeredPublishersInfo.size() == 0 || !registeredPublishersInfo[0].has_url())
-	{
-		logger->error("Service Directory has not finished initialization ({} not available)", gravity::constants::REGISTERED_PUBLISHERS_DPID);
-		return GravityReturnCodes::NO_SERVICE_DIRECTORY;
-	}
+        if (tries > 0) gravity::sleep(500);
+    }
 
-	// Send subscription details
-	logger->trace("Sending subscription details to subscription manager");
-	sendStringMessage(subscriptionManagerSWL.socket, "subscribe", ZMQ_SNDMORE);
-	sendStringMessage(subscriptionManagerSWL.socket, dataProductID, ZMQ_SNDMORE);
-	sendIntMessage(subscriptionManagerSWL.socket, receiveLastCachedValue, ZMQ_SNDMORE);
-	sendUint32Message(subscriptionManagerSWL.socket, publisherInfoPBs.size(), ZMQ_SNDMORE);
-	for (unsigned int i = 0; i < publisherInfoPBs.size(); i++)
-	{
-		sendProtobufMessage(subscriptionManagerSWL.socket, publisherInfoPBs[i], ZMQ_SNDMORE);
-	}
-	sendStringMessage(subscriptionManagerSWL.socket, filter, ZMQ_SNDMORE);
-	sendStringMessage(subscriptionManagerSWL.socket, domain, ZMQ_SNDMORE);
+    if (registeredPublishersInfo.size() == 0 || !registeredPublishersInfo[0].has_url())
+    {
+        logger->error("Service Directory has not finished initialization ({} not available)",
+                      gravity::constants::REGISTERED_PUBLISHERS_DPID);
+        return GravityReturnCodes::NO_SERVICE_DIRECTORY;
+    }
+
+    // Send subscription details
+    logger->trace("Sending subscription details to subscription manager");
+    sendStringMessage(subscriptionManagerSWL.socket, "subscribe", ZMQ_SNDMORE);
+    sendStringMessage(subscriptionManagerSWL.socket, dataProductID, ZMQ_SNDMORE);
+    sendIntMessage(subscriptionManagerSWL.socket, receiveLastCachedValue, ZMQ_SNDMORE);
+    sendUint32Message(subscriptionManagerSWL.socket, publisherInfoPBs.size(), ZMQ_SNDMORE);
+    for (unsigned int i = 0; i < publisherInfoPBs.size(); i++)
+    {
+        sendProtobufMessage(subscriptionManagerSWL.socket, publisherInfoPBs[i], ZMQ_SNDMORE);
+    }
+    sendStringMessage(subscriptionManagerSWL.socket, filter, ZMQ_SNDMORE);
+    sendStringMessage(subscriptionManagerSWL.socket, domain, ZMQ_SNDMORE);
     sendStringMessage(subscriptionManagerSWL.socket, registeredPublishersInfo[0].url(), ZMQ_SNDMORE);
 
-	zmq_msg_t msg;
-	zmq_msg_init_size(&msg, sizeof(&subscriber));
-	void* v = (void*)&subscriber;
-	memcpy(zmq_msg_data(&msg), &v, sizeof(&subscriber));
-	zmq_sendmsg(subscriptionManagerSWL.socket, &msg, ZMQ_DONTWAIT);
-	zmq_msg_close(&msg);
+    zmq_msg_t msg;
+    zmq_msg_init_size(&msg, sizeof(&subscriber));
+    void* v = (void*)&subscriber;
+    memcpy(zmq_msg_data(&msg), &v, sizeof(&subscriber));
+    zmq_sendmsg(subscriptionManagerSWL.socket, &msg, ZMQ_DONTWAIT);
+    zmq_msg_close(&msg);
 
-	SubscriptionDetails details;
-	details.dataProductID = dataProductID;
-	details.domain = domain;
-	details.filter = filter;
-	details.receiveLastCachedValue = receiveLastCachedValue;
-	details.subscriber = &subscriber;
-	subscriptionList.push_back(details);
-	
+    SubscriptionDetails details;
+    details.dataProductID = dataProductID;
+    details.domain = domain;
+    details.filter = filter;
+    details.receiveLastCachedValue = receiveLastCachedValue;
+    details.subscriber = &subscriber;
+    subscriptionList.push_back(details);
+
     return GravityReturnCodes::SUCCESS;
 }
 
-GravityReturnCode GravityNode::unsubscribe(string dataProductID, const GravitySubscriber& subscriber, string filter, string domain)
+GravityReturnCode GravityNode::unsubscribe(string dataProductID, const GravitySubscriber& subscriber, string filter,
+                                           string domain)
 {
     subscriptionManagerSWL.lock.Lock();
     GravityReturnCode ret = unsubscribeInternal(dataProductID, subscriber, filter, domain);
@@ -1790,49 +1811,51 @@ GravityReturnCode GravityNode::unsubscribe(string dataProductID, const GravitySu
     return ret;
 }
 
-GravityReturnCode GravityNode::unsubscribeInternal(string dataProductID, const GravitySubscriber& subscriber, string filter, string domain)
+GravityReturnCode GravityNode::unsubscribeInternal(string dataProductID, const GravitySubscriber& subscriber,
+                                                   string filter, string domain)
 {
     if (!initialized)
     {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
 
-	if (domain.empty())
-	{
-		domain = myDomain;
-	}
-	// Send unsubscribe details
-	sendStringMessage(subscriptionManagerSWL.socket, "unsubscribe", ZMQ_SNDMORE);
-	sendStringMessage(subscriptionManagerSWL.socket, dataProductID, ZMQ_SNDMORE);
-	sendStringMessage(subscriptionManagerSWL.socket, filter, ZMQ_SNDMORE);
-	sendStringMessage(subscriptionManagerSWL.socket, domain, ZMQ_SNDMORE);
+    if (domain.empty())
+    {
+        domain = myDomain;
+    }
+    // Send unsubscribe details
+    sendStringMessage(subscriptionManagerSWL.socket, "unsubscribe", ZMQ_SNDMORE);
+    sendStringMessage(subscriptionManagerSWL.socket, dataProductID, ZMQ_SNDMORE);
+    sendStringMessage(subscriptionManagerSWL.socket, filter, ZMQ_SNDMORE);
+    sendStringMessage(subscriptionManagerSWL.socket, domain, ZMQ_SNDMORE);
 
-	// Send subscriber
-	zmq_msg_t msg;
-	zmq_msg_init_size(&msg, sizeof(&subscriber));
-	void* v = (void*)&subscriber;
-	memcpy(zmq_msg_data(&msg), &v, sizeof(&subscriber));
-	zmq_sendmsg(subscriptionManagerSWL.socket, &msg, ZMQ_DONTWAIT);
-	zmq_msg_close(&msg);
+    // Send subscriber
+    zmq_msg_t msg;
+    zmq_msg_init_size(&msg, sizeof(&subscriber));
+    void* v = (void*)&subscriber;
+    memcpy(zmq_msg_data(&msg), &v, sizeof(&subscriber));
+    zmq_sendmsg(subscriptionManagerSWL.socket, &msg, ZMQ_DONTWAIT);
+    zmq_msg_close(&msg);
 
-	list<SubscriptionDetails>::iterator iter = subscriptionList.begin();
-	while (iter != subscriptionList.end())
-	{
-	    if (iter->dataProductID == dataProductID && iter->domain == domain &&
-	        iter->filter == filter && iter->subscriber == &subscriber)
-	    {
-	        iter = subscriptionList.erase(iter);
-	    }
-	    else
-	    {
-	        ++iter;
-	    }
-	}
+    list<SubscriptionDetails>::iterator iter = subscriptionList.begin();
+    while (iter != subscriptionList.end())
+    {
+        if (iter->dataProductID == dataProductID && iter->domain == domain && iter->filter == filter &&
+            iter->subscriber == &subscriber)
+        {
+            iter = subscriptionList.erase(iter);
+        }
+        else
+        {
+            ++iter;
+        }
+    }
 
-	return GravityReturnCodes::SUCCESS;
+    return GravityReturnCodes::SUCCESS;
 }
 
-GravityReturnCode GravityNode::publish(const GravityDataProduct& dataProduct, std::string filterText, uint64_t timestamp)
+GravityReturnCode GravityNode::publish(const GravityDataProduct& dataProduct, std::string filterText,
+                                       uint64_t timestamp)
 {
     if (!initialized)
     {
@@ -1840,45 +1863,44 @@ GravityReturnCode GravityNode::publish(const GravityDataProduct& dataProduct, st
     }
 
     string dataProductID = dataProduct.getDataProductID();
-	logger->trace("Publishing {}", dataProductID);
+    logger->trace("Publishing {}", dataProductID);
 
-	// keep original info if this message has been relayed from somewhere else
-	if (!dataProduct.isRelayedDataproduct())
-	{
-		//Set Timestamp
-		if (timestamp == 0)
-		{
-			dataProduct.setTimestamp(getCurrentTime());
-		}
-		else
-		{
-			dataProduct.setTimestamp(timestamp);
-		}
+    // keep original info if this message has been relayed from somewhere else
+    if (!dataProduct.isRelayedDataproduct())
+    {
+        //Set Timestamp
+        if (timestamp == 0)
+        {
+            dataProduct.setTimestamp(getCurrentTime());
+        }
+        else
+        {
+            dataProduct.setTimestamp(timestamp);
+        }
 
-		//set Component ID
-		dataProduct.setComponentId(componentID);
+        //set Component ID
+        dataProduct.setComponentId(componentID);
 
-		//set Domain
-		dataProduct.setDomain(myDomain);
-	}
+        //set Domain
+        dataProduct.setDomain(myDomain);
+    }
 
     // Set registration time
     dataProduct.setRegistrationTime(dataRegistrationTimeMap[dataProductID]);
 
-	// Send subscription details
+    // Send subscription details
     publishManagerPublishSWL.lock.Lock();
 
     sendStringMessage(publishManagerPublishSWL.socket, "publish", ZMQ_SNDMORE);
     sendStringMessage(publishManagerPublishSWL.socket, dataProductID, ZMQ_SNDMORE);
     sendUint64Message(publishManagerPublishSWL.socket, dataProduct.getGravityTimestamp(), ZMQ_SNDMORE);
-	sendStringMessage(publishManagerPublishSWL.socket, filterText, ZMQ_SNDMORE);
+    sendStringMessage(publishManagerPublishSWL.socket, filterText, ZMQ_SNDMORE);
 
-	
-	zmq_msg_t msg;
-	zmq_msg_init_size(&msg, dataProduct.getSize());
-	dataProduct.serializeToArray(zmq_msg_data(&msg));
-	zmq_sendmsg(publishManagerPublishSWL.socket, &msg, ZMQ_DONTWAIT);
-	zmq_msg_close(&msg);
+    zmq_msg_t msg;
+    zmq_msg_init_size(&msg, dataProduct.getSize());
+    dataProduct.serializeToArray(zmq_msg_data(&msg));
+    zmq_sendmsg(publishManagerPublishSWL.socket, &msg, ZMQ_DONTWAIT);
+    zmq_msg_close(&msg);
 
     publishManagerPublishSWL.lock.Unlock();
 
@@ -1894,8 +1916,8 @@ GravityReturnCode GravityNode::ServiceDirectoryReregister(string componentId, st
 
     logger->warn("ServiceDirectory restart detected, attempting to re-register...");
 
-	// Update service directory location
-	updateServiceDirectoryUrl(url);
+    // Update service directory location
+    updateServiceDirectoryUrl(url);
 
     // GravityPublishManager already has this info, so just need to update the ServiceDirectory
     publishManagerRequestSWL.lock.Lock();
@@ -1906,7 +1928,7 @@ GravityReturnCode GravityNode::ServiceDirectoryReregister(string componentId, st
         registration.set_url(iter->second);
         registration.set_type(ServiceDirectoryRegistrationPB::DATA);
         registration.set_component_id(componentId);
-		registration.set_timestamp(urlInstanceMap[iter->second]);
+        registration.set_timestamp(urlInstanceMap[iter->second]);
 
         // Wrap request in GravityDataProduct
         GravityDataProduct request("RegistrationRequest");
@@ -1944,7 +1966,7 @@ GravityReturnCode GravityNode::ServiceDirectoryReregister(string componentId, st
         registration.set_url(iter->second);
         registration.set_type(ServiceDirectoryRegistrationPB::SERVICE);
         registration.set_component_id(componentId);
-		registration.set_timestamp(urlInstanceMap[iter->second]);
+        registration.set_timestamp(urlInstanceMap[iter->second]);
 
         // Wrap request in GravityDataProduct
         GravityDataProduct request("RegistrationRequest");
@@ -1980,211 +2002,215 @@ GravityReturnCode GravityNode::ServiceDirectoryReregister(string componentId, st
 
     for (list<SubscriptionDetails>::const_iterator iter = origList.begin(); iter != origList.end(); ++iter)
     {
-		GravityReturnCode subRet = subscribeInternal(iter->dataProductID, *iter->subscriber, iter->filter, iter->domain);
+        GravityReturnCode subRet =
+            subscribeInternal(iter->dataProductID, *iter->subscriber, iter->filter, iter->domain);
         int numTries = 3;
         while (subRet != GravityReturnCodes::SUCCESS && numTries-- > 0)
         {
-			logger->debug("Error re-subscribing, retrying...");
+            logger->debug("Error re-subscribing, retrying...");
             subRet = subscribeInternal(iter->dataProductID, *iter->subscriber, iter->filter, iter->domain);
         }
         logger->info("Successfully re-subscribed {}", iter->dataProductID);
     }
     subscriptionManagerSWL.lock.Unlock();
 
-    if (ret == GravityReturnCodes::SUCCESS)
-        logger->warn("Successfully re-registered with the ServiceDirectory");
+    if (ret == GravityReturnCodes::SUCCESS) logger->warn("Successfully re-registered with the ServiceDirectory");
 
     return ret;
 }
 
-GravityReturnCode GravityNode::ServiceDirectoryServiceLookup(std::string serviceID, std::string &url, string &domain, uint32_t &regTime)
+GravityReturnCode GravityNode::ServiceDirectoryServiceLookup(std::string serviceID, std::string& url, string& domain,
+                                                             uint32_t& regTime)
 {
-	// Create the object describing the data product to lookup
-	ComponentLookupRequestPB lookup;
-	lookup.set_lookupid(serviceID);
-	lookup.set_domain_id(domain);
-	lookup.set_type(ComponentLookupRequestPB::SERVICE);
+    // Create the object describing the data product to lookup
+    ComponentLookupRequestPB lookup;
+    lookup.set_lookupid(serviceID);
+    lookup.set_domain_id(domain);
+    lookup.set_type(ComponentLookupRequestPB::SERVICE);
 
-	// Wrap request in GravityDataProduct
-	GravityDataProduct requestDataProduct("ComponentLookupRequest");
-	requestDataProduct.setData(lookup);
+    // Wrap request in GravityDataProduct
+    GravityDataProduct requestDataProduct("ComponentLookupRequest");
+    requestDataProduct.setData(lookup);
 
-	// GravityDataProduct for response
-	GravityDataProduct responseDataProduct("ComponentLookupResponse");
+    // GravityDataProduct for response
+    GravityDataProduct responseDataProduct("ComponentLookupResponse");
 
-	// Send request to service directory
-	GravityReturnCode ret = sendRequestToServiceDirectory(requestDataProduct, responseDataProduct);
+    // Send request to service directory
+    GravityReturnCode ret = sendRequestToServiceDirectory(requestDataProduct, responseDataProduct);
 
-	if (ret == GravityReturnCodes::SUCCESS)
-	{
-		ComponentServiceLookupResponsePB pb;
-		bool parserSuccess = true;
-		try
-		{
-			responseDataProduct.populateMessage(pb);
-		}
-		catch (char*)
-		{
-			parserSuccess = false;
-		}
+    if (ret == GravityReturnCodes::SUCCESS)
+    {
+        ComponentServiceLookupResponsePB pb;
+        bool parserSuccess = true;
+        try
+        {
+            responseDataProduct.populateMessage(pb);
+        }
+        catch (char*)
+        {
+            parserSuccess = false;
+        }
 
-		if (parserSuccess)
-		{
-			if (!pb.url().empty())
-			{
-				url = pb.url();
-				regTime = pb.registration_time();
-				return GravityReturnCodes::SUCCESS;
-			}
-			else
-			{
-				ret = GravityReturnCodes::NO_SUCH_SERVICE;
-			}
-		}
-		else
-		{
-			ret = GravityReturnCodes::LINK_ERROR;
-		}
-	}
-	else
-	{
-		ret = GravityReturnCodes::NO_SERVICE_DIRECTORY;
-	}
+        if (parserSuccess)
+        {
+            if (!pb.url().empty())
+            {
+                url = pb.url();
+                regTime = pb.registration_time();
+                return GravityReturnCodes::SUCCESS;
+            }
+            else
+            {
+                ret = GravityReturnCodes::NO_SUCH_SERVICE;
+            }
+        }
+        else
+        {
+            ret = GravityReturnCodes::LINK_ERROR;
+        }
+    }
+    else
+    {
+        ret = GravityReturnCodes::NO_SERVICE_DIRECTORY;
+    }
 
-	return ret;
+    return ret;
 }
 
 //Asynchronous Request with Service Directory Lookup
 GravityReturnCode GravityNode::request(string serviceID, const GravityDataProduct& dataProduct,
-        const GravityRequestor& requestor, string requestID, int timeout_milliseconds, string domain)
+                                       const GravityRequestor& requestor, string requestID, int timeout_milliseconds,
+                                       string domain)
 {
     if (!initialized)
     {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
-	std::string url;
-	uint32_t regTime;
-	GravityReturnCode ret = ServiceDirectoryServiceLookup(serviceID, url, domain, regTime);
-	if(ret != GravityReturnCodes::SUCCESS)
-		return ret;
-	return request(url, serviceID, dataProduct, requestor, regTime, requestID, timeout_milliseconds);
+    std::string url;
+    uint32_t regTime;
+    GravityReturnCode ret = ServiceDirectoryServiceLookup(serviceID, url, domain, regTime);
+    if (ret != GravityReturnCodes::SUCCESS) return ret;
+    return request(url, serviceID, dataProduct, requestor, regTime, requestID, timeout_milliseconds);
 }
 
 //Asynchronous Request with URL
 GravityReturnCode GravityNode::request(string connectionURL, string serviceID, const GravityDataProduct& dataProduct,
-	const GravityRequestor& requestor, uint32_t regTime, string requestID, int timeout_milliseconds)
+                                       const GravityRequestor& requestor, uint32_t regTime, string requestID,
+                                       int timeout_milliseconds)
 {
     if (!initialized)
     {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
-	// Send subscription details
+    // Send subscription details
     requestManagerSWL.lock.Lock();
 
-	//set Component ID
-	dataProduct.setComponentId(componentID);
+    //set Component ID
+    dataProduct.setComponentId(componentID);
 
-	//set Domain
-	dataProduct.setDomain(myDomain);
+    //set Domain
+    dataProduct.setDomain(myDomain);
 
-	sendStringMessage(requestManagerSWL.socket, "request", ZMQ_SNDMORE);
-	sendStringMessage(requestManagerSWL.socket, serviceID, ZMQ_SNDMORE);
-	sendStringMessage(requestManagerSWL.socket, connectionURL, ZMQ_SNDMORE);
-	sendStringMessage(requestManagerSWL.socket, requestID, ZMQ_SNDMORE);
-	sendIntMessage(requestManagerSWL.socket, timeout_milliseconds, ZMQ_SNDMORE);
-	sendUint32Message(requestManagerSWL.socket, regTime, ZMQ_SNDMORE);
+    sendStringMessage(requestManagerSWL.socket, "request", ZMQ_SNDMORE);
+    sendStringMessage(requestManagerSWL.socket, serviceID, ZMQ_SNDMORE);
+    sendStringMessage(requestManagerSWL.socket, connectionURL, ZMQ_SNDMORE);
+    sendStringMessage(requestManagerSWL.socket, requestID, ZMQ_SNDMORE);
+    sendIntMessage(requestManagerSWL.socket, timeout_milliseconds, ZMQ_SNDMORE);
+    sendUint32Message(requestManagerSWL.socket, regTime, ZMQ_SNDMORE);
 
-	zmq_msg_t msg;
-	zmq_msg_init_size(&msg, dataProduct.getSize());
-	dataProduct.serializeToArray(zmq_msg_data(&msg));
-	zmq_sendmsg(requestManagerSWL.socket, &msg, ZMQ_SNDMORE);
-	zmq_msg_close(&msg);
+    zmq_msg_t msg;
+    zmq_msg_init_size(&msg, dataProduct.getSize());
+    dataProduct.serializeToArray(zmq_msg_data(&msg));
+    zmq_sendmsg(requestManagerSWL.socket, &msg, ZMQ_SNDMORE);
+    zmq_msg_close(&msg);
 
-	zmq_msg_init_size(&msg, sizeof(&requestor));
-	void* v = (void*)&requestor;
-	memcpy(zmq_msg_data(&msg), &v, sizeof(&requestor));
-	zmq_sendmsg(requestManagerSWL.socket, &msg, ZMQ_DONTWAIT);
-	zmq_msg_close(&msg);
+    zmq_msg_init_size(&msg, sizeof(&requestor));
+    void* v = (void*)&requestor;
+    memcpy(zmq_msg_data(&msg), &v, sizeof(&requestor));
+    zmq_sendmsg(requestManagerSWL.socket, &msg, ZMQ_DONTWAIT);
+    zmq_msg_close(&msg);
 
     requestManagerSWL.lock.Unlock();
 
-	return GravityReturnCodes::SUCCESS;
+    return GravityReturnCodes::SUCCESS;
 }
 
 //Synchronous Request
 std::shared_ptr<GravityDataProduct> GravityNode::request(string serviceID, const GravityDataProduct& request,
-													int timeout_milliseconds, string domain)
+                                                         int timeout_milliseconds, string domain)
 {
     if (!initialized)
     {
         return std::shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
     }
-	//set Component ID
-	request.setComponentId(componentID);
+    //set Component ID
+    request.setComponentId(componentID);
 
-	//set Domain
-	request.setDomain(myDomain);
+    //set Domain
+    request.setDomain(myDomain);
 
-	logger->trace("Synchronous request('{}','{}')", serviceID, request.getDataProductID());
+    logger->trace("Synchronous request('{}','{}')", serviceID, request.getDataProductID());
 
-	std::string connectionURL;
-	uint32_t regTime;
-	GravityReturnCode ret = ServiceDirectoryServiceLookup(serviceID, connectionURL, domain, regTime);
-	if(ret != GravityReturnCodes::SUCCESS)
-	{
-		//special case for ConfigService. Since this happens frequently, log message not warning.
-		if (serviceID=="ConfigService")
-		{
-			logger->info("Unable to find service {}: {}", serviceID, getCodeString(ret));
-		}
-		else
-		{
-			logger->warn("Unable to find service {}: {}", serviceID, getCodeString(ret));
-		}
-		return std::shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
-	}
+    std::string connectionURL;
+    uint32_t regTime;
+    GravityReturnCode ret = ServiceDirectoryServiceLookup(serviceID, connectionURL, domain, regTime);
+    if (ret != GravityReturnCodes::SUCCESS)
+    {
+        //special case for ConfigService. Since this happens frequently, log message not warning.
+        if (serviceID == "ConfigService")
+        {
+            logger->info("Unable to find service {}: {}", serviceID, getCodeString(ret));
+        }
+        else
+        {
+            logger->warn("Unable to find service {}: {}", serviceID, getCodeString(ret));
+        }
+        return std::shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
+    }
 
-	uint64_t t1 = gravity::getCurrentTime();
-	std::shared_ptr<GravityDataProduct> response(new GravityDataProduct(serviceID));
-	logger->trace("Sending request to service provider @ {}", connectionURL);
-	ret = sendRequestToServiceProvider(connectionURL, request, *response, timeout_milliseconds);
-	if(ret != GravityReturnCodes::SUCCESS)
-	{
-		logger->warn("service request returned error: {}", getCodeString(ret));
-		return std::shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
-	}
-	if (response->getRegistrationTime() != regTime)
-	{
-		logger->warn("Received service ({}) response from invalid service [{} != {}]", serviceID, response->getRegistrationTime(), regTime);
-		return std::shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
-	}
+    uint64_t t1 = gravity::getCurrentTime();
+    std::shared_ptr<GravityDataProduct> response(new GravityDataProduct(serviceID));
+    logger->trace("Sending request to service provider @ {}", connectionURL);
+    ret = sendRequestToServiceProvider(connectionURL, request, *response, timeout_milliseconds);
+    if (ret != GravityReturnCodes::SUCCESS)
+    {
+        logger->warn("service request returned error: {}", getCodeString(ret));
+        return std::shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
+    }
+    if (response->getRegistrationTime() != regTime)
+    {
+        logger->warn("Received service ({}) response from invalid service [{} != {}]", serviceID,
+                     response->getRegistrationTime(), regTime);
+        return std::shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
+    }
 
-	if (response->isFutureResponse())
-	{
-		logger->trace("Synchronous Request: received a future response");
-		if (timeout_milliseconds > 0)
-		{
-			timeout_milliseconds -= (int)((gravity::getCurrentTime() - t1) / 1e3);
-			if (timeout_milliseconds <= 0)
-			{
-				timeout_milliseconds = 1;
-			}
-		}
-		logger->trace("Sending request to future response socket (url='{}', timeout={})", response->getFutureSocketUrl(), timeout_milliseconds);
-		ret = sendRequestToServiceProvider(response->getFutureSocketUrl(), request, *response, timeout_milliseconds);
-		if(ret != GravityReturnCodes::SUCCESS)
-		{
-			logger->warn("service request returned error: {}", getCodeString(ret));
-			return std::shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
-		}
-		logger->trace("Received future response's response");
-	}
+    if (response->isFutureResponse())
+    {
+        logger->trace("Synchronous Request: received a future response");
+        if (timeout_milliseconds > 0)
+        {
+            timeout_milliseconds -= (int)((gravity::getCurrentTime() - t1) / 1e3);
+            if (timeout_milliseconds <= 0)
+            {
+                timeout_milliseconds = 1;
+            }
+        }
+        logger->trace("Sending request to future response socket (url='{}', timeout={})",
+                      response->getFutureSocketUrl(), timeout_milliseconds);
+        ret = sendRequestToServiceProvider(response->getFutureSocketUrl(), request, *response, timeout_milliseconds);
+        if (ret != GravityReturnCodes::SUCCESS)
+        {
+            logger->warn("service request returned error: {}", getCodeString(ret));
+            return std::shared_ptr<GravityDataProduct>((GravityDataProduct*)NULL);
+        }
+        logger->trace("Received future response's response");
+    }
 
-	return response;
+    return response;
 }
 
 GravityReturnCode GravityNode::registerService(string serviceID, GravityTransportType transportType,
-        const GravityServiceProvider& server)
+                                               const GravityServiceProvider& server)
 {
     if (!initialized)
     {
@@ -2201,10 +2227,9 @@ GravityReturnCode GravityNode::registerService(string serviceID, GravityTranspor
         return GravityReturnCodes::SUCCESS;
     }
 
-
     // Build the connection string
     string endpoint;
-    if(transportType == GravityTransportTypes::TCP)
+    if (transportType == GravityTransportTypes::TCP)
     {
         transportType_str = "tcp";
         endpoint = getIP();
@@ -2216,30 +2241,30 @@ GravityReturnCode GravityNode::registerService(string serviceID, GravityTranspor
         endpoint = "/tmp/" + serviceID;
     }
 #endif
-    else if(transportType == GravityTransportTypes::INPROC)
+    else if (transportType == GravityTransportTypes::INPROC)
     {
-        transportType_str ="inproc";
-    	  endpoint = serviceID;
+        transportType_str = "inproc";
+        endpoint = serviceID;
     }
-    else if(transportType == GravityTransportTypes::PGM)
+    else if (transportType == GravityTransportTypes::PGM)
     {
-        transportType_str ="pgm";
-    	  endpoint = serviceID;
+        transportType_str = "pgm";
+        endpoint = serviceID;
     }
-    else if(transportType == GravityTransportTypes::EPGM)
+    else if (transportType == GravityTransportTypes::EPGM)
     {
-        transportType_str ="epgm";
-    	  endpoint = serviceID;
+        transportType_str = "epgm";
+        endpoint = serviceID;
     }
 
-	// Send subscription details
-	uint64_t timestamp = getCurrentTime();
+    // Send subscription details
+    uint64_t timestamp = getCurrentTime();
 
-	sendStringMessage(serviceManagerSWL.socket, "register", ZMQ_SNDMORE);
-	sendStringMessage(serviceManagerSWL.socket, serviceID, ZMQ_SNDMORE);
-	sendStringMessage(serviceManagerSWL.socket, transportType_str, ZMQ_SNDMORE);
+    sendStringMessage(serviceManagerSWL.socket, "register", ZMQ_SNDMORE);
+    sendStringMessage(serviceManagerSWL.socket, serviceID, ZMQ_SNDMORE);
+    sendStringMessage(serviceManagerSWL.socket, transportType_str, ZMQ_SNDMORE);
 
-    if(transportType == GravityTransportTypes::TCP)
+    if (transportType == GravityTransportTypes::TCP)
     {
         int minPort = getIntParam("MinPort", MIN_PORT);
         int maxPort = getIntParam("MaxPort", MAX_PORT);
@@ -2247,17 +2272,17 @@ GravityReturnCode GravityNode::registerService(string serviceID, GravityTranspor
         sendIntMessage(serviceManagerSWL.socket, maxPort, ZMQ_SNDMORE);
     }
     sendStringMessage(serviceManagerSWL.socket, endpoint, ZMQ_SNDMORE);
-	sendUint32Message(serviceManagerSWL.socket, static_cast<uint32_t>(timestamp/1e6), ZMQ_SNDMORE);
+    sendUint32Message(serviceManagerSWL.socket, static_cast<uint32_t>(timestamp / 1e6), ZMQ_SNDMORE);
 
-	// Include the server
-	zmq_msg_t msg;
-	zmq_msg_init_size(&msg, sizeof(&server));
-	void* v = (void*)&server;
-	memcpy(zmq_msg_data(&msg), &v, sizeof(&server));
-	zmq_sendmsg(serviceManagerSWL.socket, &msg, ZMQ_DONTWAIT);
-	zmq_msg_close(&msg);
+    // Include the server
+    zmq_msg_t msg;
+    zmq_msg_init_size(&msg, sizeof(&server));
+    void* v = (void*)&server;
+    memcpy(zmq_msg_data(&msg), &v, sizeof(&server));
+    zmq_sendmsg(serviceManagerSWL.socket, &msg, ZMQ_DONTWAIT);
+    zmq_msg_close(&msg);
 
-    string connectionURL = readStringMessage(serviceManagerSWL.socket);	
+    string connectionURL = readStringMessage(serviceManagerSWL.socket);
 
     GravityReturnCode ret = GravityReturnCodes::SUCCESS;
 
@@ -2269,7 +2294,7 @@ GravityReturnCode GravityNode::registerService(string serviceID, GravityTranspor
         registration.set_url(connectionURL);
         registration.set_type(ServiceDirectoryRegistrationPB::SERVICE);
         registration.set_component_id(componentID);
-		registration.set_timestamp(timestamp);
+        registration.set_timestamp(timestamp);
 
         // Wrap request in GravityDataProduct
         GravityDataProduct request("RegistrationRequest");
@@ -2298,18 +2323,18 @@ GravityReturnCode GravityNode::registerService(string serviceID, GravityTranspor
             {
                 switch (pb.returncode())
                 {
-                case ServiceDirectoryResponsePB::SUCCESS:
-                    ret = GravityReturnCodes::SUCCESS;
-                    break;
-                case ServiceDirectoryResponsePB::REGISTRATION_CONFLICT:
-                    ret = GravityReturnCodes::REGISTRATION_CONFLICT;
-                    break;
-                case ServiceDirectoryResponsePB::DUPLICATE_REGISTRATION:
-                    ret = GravityReturnCodes::DUPLICATE;
-                    break;
-                case ServiceDirectoryResponsePB::NOT_REGISTERED:
-                    ret = GravityReturnCodes::LINK_ERROR;
-                    break;
+                    case ServiceDirectoryResponsePB::SUCCESS:
+                        ret = GravityReturnCodes::SUCCESS;
+                        break;
+                    case ServiceDirectoryResponsePB::REGISTRATION_CONFLICT:
+                        ret = GravityReturnCodes::REGISTRATION_CONFLICT;
+                        break;
+                    case ServiceDirectoryResponsePB::DUPLICATE_REGISTRATION:
+                        ret = GravityReturnCodes::DUPLICATE;
+                        break;
+                    case ServiceDirectoryResponsePB::NOT_REGISTERED:
+                        ret = GravityReturnCodes::LINK_ERROR;
+                        break;
                 }
             }
             else
@@ -2331,7 +2356,7 @@ GravityReturnCode GravityNode::registerService(string serviceID, GravityTranspor
     {
         logger->debug("Registered service at address: {} ({})", connectionURL, timestamp);
         serviceMap[serviceID] = connectionURL;
-		urlInstanceMap[connectionURL] = timestamp;
+        urlInstanceMap[connectionURL] = timestamp;
     }
     serviceManagerSWL.lock.Unlock();
     return ret;
@@ -2343,7 +2368,7 @@ GravityReturnCode GravityNode::unregisterService(string serviceID)
     {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
-	GravityReturnCode ret = GravityReturnCodes::SUCCESS;
+    GravityReturnCode ret = GravityReturnCodes::SUCCESS;
     serviceManagerSWL.lock.Lock();
     if (serviceMap.count(serviceID) == 0)
     {
@@ -2355,7 +2380,7 @@ GravityReturnCode GravityNode::unregisterService(string serviceID)
         sendStringMessage(serviceManagerSWL.socket, serviceID, ZMQ_DONTWAIT);
         string url = serviceMap[serviceID];
         serviceMap.erase(serviceID);
-		urlInstanceMap.erase(url);
+        urlInstanceMap.erase(url);
 
         string status = readStringMessage(serviceManagerSWL.socket);
 
@@ -2392,13 +2417,13 @@ GravityReturnCode GravityNode::unregisterService(string serviceID)
                 {
                     switch (pb.returncode())
                     {
-                    case ServiceDirectoryResponsePB::SUCCESS:
-                    case ServiceDirectoryResponsePB::NOT_REGISTERED:
-                        ret = GravityReturnCodes::SUCCESS;
-                        break;
-                    default:
-                        ret = GravityReturnCodes::FAILURE;
-                        break;
+                        case ServiceDirectoryResponsePB::SUCCESS:
+                        case ServiceDirectoryResponsePB::NOT_REGISTERED:
+                            ret = GravityReturnCodes::SUCCESS;
+                            break;
+                        default:
+                            ret = GravityReturnCodes::FAILURE;
+                            break;
                     }
                 }
                 else
@@ -2419,20 +2444,20 @@ GravityReturnCode GravityNode::stopHeartbeat()
     {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
-	GravityReturnCode ret = gravity::GravityReturnCodes::SUCCESS;
-	if (heartbeatStarted)
-	{
-		heartbeatStarted = false;
+    GravityReturnCode ret = gravity::GravityReturnCodes::SUCCESS;
+    if (heartbeatStarted)
+    {
+        heartbeatStarted = false;
 
-		// Send signal to heartbeat thread to stop
-		Heartbeat::setHeartbeatRunning(false);
+        // Send signal to heartbeat thread to stop
+        Heartbeat::setHeartbeatRunning(false);
 
-		// Unregister heartbeat with Service Directory
-		std::string heartbeatName = componentID + "_GravityHeartbeat";
-		ret = unregisterDataProduct(heartbeatName);
-	}
+        // Unregister heartbeat with Service Directory
+        std::string heartbeatName = componentID + "_GravityHeartbeat";
+        ret = unregisterDataProduct(heartbeatName);
+    }
 
-	return ret;
+    return ret;
 }
 
 GravityReturnCode GravityNode::startHeartbeat(int64_t interval_in_microseconds)
@@ -2441,88 +2466,86 @@ GravityReturnCode GravityNode::startHeartbeat(int64_t interval_in_microseconds)
     {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
-	if(interval_in_microseconds < 0)
-		return gravity::GravityReturnCodes::FAILURE;
+    if (interval_in_microseconds < 0) return gravity::GravityReturnCodes::FAILURE;
 
-	if(heartbeatStarted)
-		return gravity::GravityReturnCodes::FAILURE; //We shouldn't be able to start this guy twice
+    if (heartbeatStarted) return gravity::GravityReturnCodes::FAILURE;  //We shouldn't be able to start this guy twice
 
-	std::string heartbeatName;
-	//Gravity Heartbeats named by component ID
-	heartbeatName = componentID + "_GravityHeartbeat";
+    std::string heartbeatName;
+    //Gravity Heartbeats named by component ID
+    heartbeatName = componentID + "_GravityHeartbeat";
 
-	this->registerDataProductInternal(heartbeatName, GravityTransportTypes::TCP, false, false, false, true);
+    this->registerDataProductInternal(heartbeatName, GravityTransportTypes::TCP, false, false, false, true);
 
-	HBParams* params = new HBParams(); //(freed by thread)
-	params->zmq_context = context;
-	params->interval_in_microseconds = interval_in_microseconds;
-	params->componentID = heartbeatName;
-	params->minPort = getIntParam("MinPort", MIN_PORT);
-	params->maxPort = getIntParam("MaxPort", MAX_PORT);
-	params->endpoint = getIP();
-	params->registrationTime = dataRegistrationTimeMap[heartbeatName];
+    HBParams* params = new HBParams();  //(freed by thread)
+    params->zmq_context = context;
+    params->interval_in_microseconds = interval_in_microseconds;
+    params->componentID = heartbeatName;
+    params->minPort = getIntParam("MinPort", MIN_PORT);
+    params->maxPort = getIntParam("MaxPort", MAX_PORT);
+    params->endpoint = getIP();
+    params->registrationTime = dataRegistrationTimeMap[heartbeatName];
 
-  std::thread heartbeatThread(Heartbeat, (void*)params);
-  heartbeatThread.detach();
-	heartbeatStarted=true;
+    std::thread heartbeatThread(Heartbeat, (void*)params);
+    heartbeatThread.detach();
+    heartbeatStarted = true;
 
-	return gravity::GravityReturnCodes::SUCCESS;
+    return gravity::GravityReturnCodes::SUCCESS;
 }
 
-GravityReturnCode GravityNode::registerHeartbeatListener(string componentID, int64_t timebetweenMessages, 
-									const GravityHeartbeatListener& listener, string domain)
+GravityReturnCode GravityNode::registerHeartbeatListener(string componentID, int64_t timebetweenMessages,
+                                                         const GravityHeartbeatListener& listener, string domain)
 {
     if (!initialized)
     {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
-	void* HeartbeatListener(void*); //Forward declaration.
-	static class Heartbeat hbSub;
-	GravityReturnCode ret = GravityReturnCodes::SUCCESS;
-	if(hbSocket == NULL)
-	{
-		//Initialize Heartbeat thread.
-		hbSocket = zmq_socket(context, ZMQ_REQ);
-		zmq_bind(hbSocket, "inproc://heartbeat_listener");
-		HBListenerContext* thread_context = new HBListenerContext();
-		thread_context->zmq_context = this->context;
-    std::thread heartbeatListenerThread(Heartbeat::HeartbeatListenerThrFunc, thread_context);
-    heartbeatListenerThread.detach();
-  }
+    void* HeartbeatListener(void*);  //Forward declaration.
+    static class Heartbeat hbSub;
+    GravityReturnCode ret = GravityReturnCodes::SUCCESS;
+    if (hbSocket == NULL)
+    {
+        //Initialize Heartbeat thread.
+        hbSocket = zmq_socket(context, ZMQ_REQ);
+        zmq_bind(hbSocket, "inproc://heartbeat_listener");
+        HBListenerContext* thread_context = new HBListenerContext();
+        thread_context->zmq_context = this->context;
+        std::thread heartbeatListenerThread(Heartbeat::HeartbeatListenerThrFunc, thread_context);
+        heartbeatListenerThread.detach();
+    }
 
-	std::string heartbeatName;
+    std::string heartbeatName;
 
-	//Gravity Heartbeats named by component ID
-	heartbeatName = componentID + "_GravityHeartbeat";
+    //Gravity Heartbeats named by component ID
+    heartbeatName = componentID + "_GravityHeartbeat";
 
-	ret = this->subscribe(heartbeatName, hbSub,"",domain);
+    ret = this->subscribe(heartbeatName, hbSub, "", domain);
 
-	if (ret==GravityReturnCodes::SUCCESS)
-	{
-		//Send the DataproductID
-		sendStringMessage(hbSocket, "register", ZMQ_SNDMORE);
-		sendStringMessage(hbSocket, heartbeatName, ZMQ_SNDMORE);
+    if (ret == GravityReturnCodes::SUCCESS)
+    {
+        //Send the DataproductID
+        sendStringMessage(hbSocket, "register", ZMQ_SNDMORE);
+        sendStringMessage(hbSocket, heartbeatName, ZMQ_SNDMORE);
 
-		//Send the address of the listener
-		zmq_msg_t msg1;
-		zmq_msg_init_size(&msg1, sizeof(GravityHeartbeatListener*));
-		intptr_t p = (intptr_t) &listener;
-		memcpy(zmq_msg_data(&msg1), &p, sizeof(GravityHeartbeatListener*));
-		zmq_sendmsg(hbSocket, &msg1, ZMQ_SNDMORE);
-		zmq_msg_close(&msg1);
+        //Send the address of the listener
+        zmq_msg_t msg1;
+        zmq_msg_init_size(&msg1, sizeof(GravityHeartbeatListener*));
+        intptr_t p = (intptr_t)&listener;
+        memcpy(zmq_msg_data(&msg1), &p, sizeof(GravityHeartbeatListener*));
+        zmq_sendmsg(hbSocket, &msg1, ZMQ_SNDMORE);
+        zmq_msg_close(&msg1);
 
-		//Send the Max time between messages
-		zmq_msg_t msg;
-		zmq_msg_init_size(&msg, 8);
-		memcpy(zmq_msg_data(&msg), &timebetweenMessages, 8);
-		zmq_sendmsg(hbSocket, &msg, ZMQ_DONTWAIT);
-		zmq_msg_close(&msg);
+        //Send the Max time between messages
+        zmq_msg_t msg;
+        zmq_msg_init_size(&msg, 8);
+        memcpy(zmq_msg_data(&msg), &timebetweenMessages, 8);
+        zmq_sendmsg(hbSocket, &msg, ZMQ_DONTWAIT);
+        zmq_msg_close(&msg);
 
-		// Read the ACK
-		readStringMessage(hbSocket);
-	}
+        // Read the ACK
+        readStringMessage(hbSocket);
+    }
 
-	return ret;
+    return ret;
 }
 
 GravityReturnCode GravityNode::unregisterHeartbeatListener(string componentID, string domain)
@@ -2531,29 +2554,31 @@ GravityReturnCode GravityNode::unregisterHeartbeatListener(string componentID, s
     {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
-	static class Heartbeat hbSub;
-	
-	std::string heartbeatName;
-	heartbeatName = componentID + "_GravityHeartbeat";
+    static class Heartbeat hbSub;
 
-	this->unsubscribe(heartbeatName,hbSub);
+    std::string heartbeatName;
+    heartbeatName = componentID + "_GravityHeartbeat";
 
-	//Send the DataproductID
-	sendStringMessage(hbSocket,"unregister",ZMQ_SNDMORE);
-	sendStringMessage(hbSocket, heartbeatName, ZMQ_DONTWAIT);
+    this->unsubscribe(heartbeatName, hbSub);
 
-	// Read the ACK
-	readStringMessage(hbSocket);
+    //Send the DataproductID
+    sendStringMessage(hbSocket, "unregister", ZMQ_SNDMORE);
+    sendStringMessage(hbSocket, heartbeatName, ZMQ_DONTWAIT);
 
-	return GravityReturnCodes::SUCCESS;
+    // Read the ACK
+    readStringMessage(hbSocket);
+
+    return GravityReturnCodes::SUCCESS;
 }
 
-GravityReturnCode GravityNode::registerRelay(string dataProductID, const GravitySubscriber& subscriber, bool localOnly, GravityTransportType transportType)
+GravityReturnCode GravityNode::registerRelay(string dataProductID, const GravitySubscriber& subscriber, bool localOnly,
+                                             GravityTransportType transportType)
 {
-	return registerRelay(dataProductID, subscriber, localOnly, transportType, false);
+    return registerRelay(dataProductID, subscriber, localOnly, transportType, false);
 }
 
-GravityReturnCode GravityNode::registerRelay(string dataProductID, const GravitySubscriber& subscriber, bool localOnly, GravityTransportType transportType, bool cacheLastValue)
+GravityReturnCode GravityNode::registerRelay(string dataProductID, const GravitySubscriber& subscriber, bool localOnly,
+                                             GravityTransportType transportType, bool cacheLastValue)
 {
     if (!initialized)
     {
@@ -2561,12 +2586,14 @@ GravityReturnCode GravityNode::registerRelay(string dataProductID, const Gravity
     }
     if (cacheLastValue)
     {
-        logger->warn("Using a Relay with cacheLastValue=true is atypical and may result in duplicate messages received by subscribers during the relay start/stop transition");
+        logger->warn(
+            "Using a Relay with cacheLastValue=true is atypical and may result in duplicate messages received by "
+            "subscribers during the relay start/stop transition");
     }
-	GravityReturnCode ret = registerDataProductInternal(dataProductID, transportType, cacheLastValue, true, localOnly, false);
-	if (ret != GravityReturnCodes::SUCCESS)
-		return ret;
-	return subscribe(dataProductID, subscriber, "", "", false);
+    GravityReturnCode ret =
+        registerDataProductInternal(dataProductID, transportType, cacheLastValue, true, localOnly, false);
+    if (ret != GravityReturnCodes::SUCCESS) return ret;
+    return subscribe(dataProductID, subscriber, "", "", false);
 }
 
 GravityReturnCode GravityNode::unregisterRelay(std::string dataProductID, const GravitySubscriber& subscriber)
@@ -2580,15 +2607,12 @@ GravityReturnCode GravityNode::unregisterRelay(std::string dataProductID, const 
     {
         // try to unsubscribe in any case
         unsubscribe(dataProductID, subscriber);
-        return ret; // but return unregister error
+        return ret;  // but return unregister error
     }
     return unsubscribe(dataProductID, subscriber);
 }
 
-string GravityNode::getDomain()
-{
-    return myDomain;
-}
+string GravityNode::getDomain() { return myDomain; }
 
 std::shared_ptr<FutureResponse> GravityNode::createFutureResponse()
 {
@@ -2596,33 +2620,33 @@ std::shared_ptr<FutureResponse> GravityNode::createFutureResponse()
     {
         return std::shared_ptr<FutureResponse>((FutureResponse*)NULL);
     }
-	// Send request to create future response
+    // Send request to create future response
     requestManagerRepSWL.lock.Lock();
 
-	// Get data required for socket creation
-	string ip = getIP();
-	int minPort = getIntParam("MinPort", MIN_PORT);
+    // Get data required for socket creation
+    string ip = getIP();
+    int minPort = getIntParam("MinPort", MIN_PORT);
     int maxPort = getIntParam("MaxPort", MAX_PORT);
 
-	// Send request for FutureResponse and info required to create socket
-	sendStringMessage(requestManagerRepSWL.socket, "createFutureResponse", ZMQ_SNDMORE);
-	sendStringMessage(requestManagerRepSWL.socket, ip, ZMQ_SNDMORE);
-	sendIntMessage(requestManagerRepSWL.socket, minPort, ZMQ_SNDMORE);
-	sendIntMessage(requestManagerRepSWL.socket, maxPort, ZMQ_DONTWAIT);
+    // Send request for FutureResponse and info required to create socket
+    sendStringMessage(requestManagerRepSWL.socket, "createFutureResponse", ZMQ_SNDMORE);
+    sendStringMessage(requestManagerRepSWL.socket, ip, ZMQ_SNDMORE);
+    sendIntMessage(requestManagerRepSWL.socket, minPort, ZMQ_SNDMORE);
+    sendIntMessage(requestManagerRepSWL.socket, maxPort, ZMQ_DONTWAIT);
 
-	// Get URL for FutureResponse from GravityRequestManager
-	string url = readStringMessage(requestManagerRepSWL.socket, 0);
+    // Get URL for FutureResponse from GravityRequestManager
+    string url = readStringMessage(requestManagerRepSWL.socket, 0);
 
-	if (url.empty())
-	{
-		logger->critical("Could not find available port for FutureResponse");
-		return std::shared_ptr<FutureResponse>((FutureResponse*)NULL);
-	}
+    if (url.empty())
+    {
+        logger->critical("Could not find available port for FutureResponse");
+        return std::shared_ptr<FutureResponse>((FutureResponse*)NULL);
+    }
 
-	requestManagerRepSWL.lock.Unlock();
+    requestManagerRepSWL.lock.Unlock();
 
-	std::shared_ptr<FutureResponse> futureResponse(new FutureResponse(url));
-	return futureResponse;
+    std::shared_ptr<FutureResponse> futureResponse(new FutureResponse(url));
+    return futureResponse;
 }
 
 GravityReturnCode GravityNode::sendFutureResponse(const FutureResponse& futureResponse)
@@ -2631,103 +2655,104 @@ GravityReturnCode GravityNode::sendFutureResponse(const FutureResponse& futureRe
     {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
-	requestManagerRepSWL.lock.Lock();
-	
-	sendStringMessage(requestManagerRepSWL.socket, "sendFutureResponse", ZMQ_SNDMORE);
-	sendStringMessage(requestManagerRepSWL.socket, futureResponse.getUrl(), ZMQ_SNDMORE);
-	
-	// Send the response object
-	int size = futureResponse.getDataSize();
-	char *bytes = new char[size];		
-	futureResponse.getData(bytes, size);
-	GravityDataProduct response(bytes, size);
-	response.setComponentId(componentID);
-	response.setDomain(myDomain);
-	sendGravityDataProduct(requestManagerRepSWL.socket, response, ZMQ_DONTWAIT);
-	delete [] bytes;
+    requestManagerRepSWL.lock.Lock();
 
-	// Get results back from GravityRequestManager
-	int ret = readIntMessage(requestManagerRepSWL.socket);
-	
-	requestManagerRepSWL.lock.Unlock();
+    sendStringMessage(requestManagerRepSWL.socket, "sendFutureResponse", ZMQ_SNDMORE);
+    sendStringMessage(requestManagerRepSWL.socket, futureResponse.getUrl(), ZMQ_SNDMORE);
 
-	return static_cast<GravityReturnCode>(ret);
+    // Send the response object
+    int size = futureResponse.getDataSize();
+    char* bytes = new char[size];
+    futureResponse.getData(bytes, size);
+    GravityDataProduct response(bytes, size);
+    response.setComponentId(componentID);
+    response.setDomain(myDomain);
+    sendGravityDataProduct(requestManagerRepSWL.socket, response, ZMQ_DONTWAIT);
+    delete[] bytes;
+
+    // Get results back from GravityRequestManager
+    int ret = readIntMessage(requestManagerRepSWL.socket);
+
+    requestManagerRepSWL.lock.Unlock();
+
+    return static_cast<GravityReturnCode>(ret);
 }
 
-GravityReturnCode GravityNode::setSubscriptionTimeoutMonitor(string dataProductID, const GravitySubscriptionMonitor& monitor, 
-			int milliSecondTimeout, string filter, string domain)
+GravityReturnCode GravityNode::setSubscriptionTimeoutMonitor(string dataProductID,
+                                                             const GravitySubscriptionMonitor& monitor,
+                                                             int milliSecondTimeout, string filter, string domain)
 {
     if (!initialized)
     {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
-	if (domain.empty())
+    if (domain.empty())
     {
         domain = myDomain;
     }
 
-	if(milliSecondTimeout <= 0)
-	{
-		return GravityReturnCodes::INVALID_PARAMETER;
-	}
+    if (milliSecondTimeout <= 0)
+    {
+        return GravityReturnCodes::INVALID_PARAMETER;
+    }
 
-	subscriptionManagerSWL.lock.Lock();
+    subscriptionManagerSWL.lock.Lock();
 
-	sendStringMessage(subscriptionManagerSWL.socket, "set_monitor", ZMQ_SNDMORE);
-	sendStringMessage(subscriptionManagerSWL.socket, dataProductID, ZMQ_SNDMORE);
-	
-	//Send the address of the monitor
-	zmq_msg_t msg;
-	zmq_msg_init_size(&msg, sizeof(GravitySubscriptionMonitor*));
-	intptr_t p = (intptr_t) &monitor;
-	memcpy(zmq_msg_data(&msg), &p, sizeof(GravitySubscriptionMonitor*));
-	zmq_sendmsg(subscriptionManagerSWL.socket, &msg, ZMQ_SNDMORE);
-	zmq_msg_close(&msg);
+    sendStringMessage(subscriptionManagerSWL.socket, "set_monitor", ZMQ_SNDMORE);
+    sendStringMessage(subscriptionManagerSWL.socket, dataProductID, ZMQ_SNDMORE);
 
-	//Send the Max time between messages
-	sendIntMessage(subscriptionManagerSWL.socket,milliSecondTimeout,ZMQ_SNDMORE);
+    //Send the address of the monitor
+    zmq_msg_t msg;
+    zmq_msg_init_size(&msg, sizeof(GravitySubscriptionMonitor*));
+    intptr_t p = (intptr_t)&monitor;
+    memcpy(zmq_msg_data(&msg), &p, sizeof(GravitySubscriptionMonitor*));
+    zmq_sendmsg(subscriptionManagerSWL.socket, &msg, ZMQ_SNDMORE);
+    zmq_msg_close(&msg);
 
-	sendStringMessage(subscriptionManagerSWL.socket, filter, ZMQ_SNDMORE);
+    //Send the Max time between messages
+    sendIntMessage(subscriptionManagerSWL.socket, milliSecondTimeout, ZMQ_SNDMORE);
 
-	sendStringMessage(subscriptionManagerSWL.socket, domain, ZMQ_DONTWAIT);
+    sendStringMessage(subscriptionManagerSWL.socket, filter, ZMQ_SNDMORE);
 
-	//int ret = readIntMessage(subscriptionManagerSWL.socket);
-	
-	subscriptionManagerSWL.lock.Unlock();
+    sendStringMessage(subscriptionManagerSWL.socket, domain, ZMQ_DONTWAIT);
 
-	return GravityReturnCodes::SUCCESS;
+    //int ret = readIntMessage(subscriptionManagerSWL.socket);
 
+    subscriptionManagerSWL.lock.Unlock();
+
+    return GravityReturnCodes::SUCCESS;
 }
 
-GravityReturnCode GravityNode::clearSubscriptionTimeoutMonitor(std::string dataProductID, const GravitySubscriptionMonitor& monitor, 
-			string filter, string domain)
+GravityReturnCode GravityNode::clearSubscriptionTimeoutMonitor(std::string dataProductID,
+                                                               const GravitySubscriptionMonitor& monitor, string filter,
+                                                               string domain)
 {
     if (!initialized)
     {
         return GravityReturnCodes::NOT_INITIALIZED;
     }
-	subscriptionManagerSWL.lock.Lock();
+    subscriptionManagerSWL.lock.Lock();
 
-	sendStringMessage(subscriptionManagerSWL.socket, "clear_monitor", ZMQ_SNDMORE);
-	sendStringMessage(subscriptionManagerSWL.socket, dataProductID, ZMQ_SNDMORE);
-	
-	//Send the address of the monitor
-	zmq_msg_t msg;
-	zmq_msg_init_size(&msg, sizeof(GravitySubscriptionMonitor*));
-	intptr_t p = (intptr_t) &monitor;
-	memcpy(zmq_msg_data(&msg), &p, sizeof(GravitySubscriptionMonitor*));
-	zmq_sendmsg(subscriptionManagerSWL.socket, &msg, ZMQ_SNDMORE);
-	zmq_msg_close(&msg);
+    sendStringMessage(subscriptionManagerSWL.socket, "clear_monitor", ZMQ_SNDMORE);
+    sendStringMessage(subscriptionManagerSWL.socket, dataProductID, ZMQ_SNDMORE);
 
-	sendStringMessage(subscriptionManagerSWL.socket, filter, ZMQ_SNDMORE);
+    //Send the address of the monitor
+    zmq_msg_t msg;
+    zmq_msg_init_size(&msg, sizeof(GravitySubscriptionMonitor*));
+    intptr_t p = (intptr_t)&monitor;
+    memcpy(zmq_msg_data(&msg), &p, sizeof(GravitySubscriptionMonitor*));
+    zmq_sendmsg(subscriptionManagerSWL.socket, &msg, ZMQ_SNDMORE);
+    zmq_msg_close(&msg);
 
-	sendStringMessage(subscriptionManagerSWL.socket, domain, ZMQ_DONTWAIT);
+    sendStringMessage(subscriptionManagerSWL.socket, filter, ZMQ_SNDMORE);
 
-	//int ret = readIntMessage(subscriptionManagerSWL.socket);
-	
-	subscriptionManagerSWL.lock.Unlock();
+    sendStringMessage(subscriptionManagerSWL.socket, domain, ZMQ_DONTWAIT);
 
-	return GravityReturnCodes::SUCCESS;
+    //int ret = readIntMessage(subscriptionManagerSWL.socket);
+
+    subscriptionManagerSWL.lock.Unlock();
+
+    return GravityReturnCodes::SUCCESS;
 }
 
 string GravityNode::getIP()
@@ -2743,7 +2768,7 @@ string GravityNode::getIP()
 
     if (!serviceDirectoryNode.ipAddress.empty() && serviceDirectoryNode.ipAddress != "localhost")
     {
-		//Reads the IP used to connect to the Service Directory.
+        //Reads the IP used to connect to the Service Directory.
         int buflen = 16;
         char* buffer = (char*)malloc(buflen);
 
@@ -2771,7 +2796,7 @@ string GravityNode::getIP()
         assert(p);
 
 #ifdef WIN32
-		closesocket(sock);
+        closesocket(sock);
 #else
         close(sock);
 #endif
@@ -2786,63 +2811,62 @@ string GravityNode::getIP()
     return ip;
 }
 
-std::string GravityNode::getStringParam(std::string key, std::string default_value) {
-
-	configParamPB.set_key(key);
-
-	if (parser == NULL || !(parser->hasKey(key))) {
-		configParamPB.set_value(default_value);
-		configParamPB.set_is_default(true);
-	}
-	else {
-		configParamPB.set_value(parser->getString(key, default_value));
-		configParamPB.set_is_default(false);
-	}
-
-	if (settingsPubEnabled && initialized && !(publishedSettings.count(configParamPB.key()) == 1 && publishedSettings.at(configParamPB.key()) == configParamPB.value())) {
-		settingsGDP.setData(configParamPB);
-		publish(settingsGDP, componentID);
-		publishedSettings[configParamPB.key()] = configParamPB.value();
-	}
-
-	return configParamPB.value();
-}
-
-int GravityNode::getIntParam(std::string key, int default_value) {
-
-	std::string s = getStringParam(key, std::to_string(default_value));
-	return StringToInt(s, default_value);
-}
-
-double GravityNode::getFloatParam(std::string key, double default_value) {
-
-	std::string s = getStringParam(key, std::to_string(default_value));
-	return StringToDouble(s, default_value);
-}
-
-bool GravityNode::getBoolParam(std::string key, bool default_value) {
-
-	std::string val = StringToLowerCase(getStringParam(key, default_value ? "true" : "false"));
-
-	if( val == "true" ||
-		val == "t" ||
-		val == "yes" ||
-		val == "y" ) {
-
-		return true;
-	}
-	else {
-		return false;
-	}
-}
-
-std::string GravityNode::getComponentID()
+std::string GravityNode::getStringParam(std::string key, std::string default_value)
 {
-    return componentID;
+    configParamPB.set_key(key);
+
+    if (parser == NULL || !(parser->hasKey(key)))
+    {
+        configParamPB.set_value(default_value);
+        configParamPB.set_is_default(true);
+    }
+    else
+    {
+        configParamPB.set_value(parser->getString(key, default_value));
+        configParamPB.set_is_default(false);
+    }
+
+    if (settingsPubEnabled && initialized &&
+        !(publishedSettings.count(configParamPB.key()) == 1 &&
+          publishedSettings.at(configParamPB.key()) == configParamPB.value()))
+    {
+        settingsGDP.setData(configParamPB);
+        publish(settingsGDP, componentID);
+        publishedSettings[configParamPB.key()] = configParamPB.value();
+    }
+
+    return configParamPB.value();
 }
 
-static std::map<GravityReturnCode,std::string> code_strings =
-  {
+int GravityNode::getIntParam(std::string key, int default_value)
+{
+    std::string s = getStringParam(key, std::to_string(default_value));
+    return StringToInt(s, default_value);
+}
+
+double GravityNode::getFloatParam(std::string key, double default_value)
+{
+    std::string s = getStringParam(key, std::to_string(default_value));
+    return StringToDouble(s, default_value);
+}
+
+bool GravityNode::getBoolParam(std::string key, bool default_value)
+{
+    std::string val = StringToLowerCase(getStringParam(key, default_value ? "true" : "false"));
+
+    if (val == "true" || val == "t" || val == "yes" || val == "y")
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+std::string GravityNode::getComponentID() { return componentID; }
+
+static std::map<GravityReturnCode, std::string> code_strings = {
     {GravityReturnCodes::SUCCESS, "SUCCESS"},
     {GravityReturnCodes::FAILURE, "FAILURE"},
     {GravityReturnCodes::NO_SERVICE_DIRECTORY, "NO_SERVICE_DIRECTORY"},
@@ -2856,17 +2880,19 @@ static std::map<GravityReturnCode,std::string> code_strings =
     {GravityReturnCodes::NO_SERVICE_PROVIDER, "NO_SERVICE_PROVIDER"},
     {GravityReturnCodes::NO_PORTS_AVAILABLE, "NO_PORTS_AVAILABLE"},
     {GravityReturnCodes::INVALID_PARAMETER, "INVALID_PARAMETER"},
-    {GravityReturnCodes::NOT_INITIALIZED, "NOT_INITIALIZED"}
-  };
+    {GravityReturnCodes::NOT_INITIALIZED, "NOT_INITIALIZED"}};
 
-
-string GravityNode::getCodeString(GravityReturnCode code) {
+string GravityNode::getCodeString(GravityReturnCode code)
+{
     std::string s;
-    if (code_strings.count(code) == 0) {
+    if (code_strings.count(code) == 0)
+    {
         ostringstream convert;
         convert << code;
         s = convert.str();
-    } else {
+    }
+    else
+    {
         s = code_strings[code];
     }
     return s;

--- a/src/api/cpp/GravityNode.h
+++ b/src/api/cpp/GravityNode.h
@@ -63,28 +63,30 @@ namespace GravityReturnCodes
     /**
      * Return codes used on a Gravity system.
      */
-    GRAVITY_API enum Codes
-    {
+    GRAVITY_API enum Codes {
         /*
          * If you add to this list, also add to GravityNode::getCodeString()
          */
-        SUCCESS = 0, ///< The request was successful
-        FAILURE = -1, ///< The request failed
-        NO_SERVICE_DIRECTORY = -2, ///< Could not find Service Directory
-        REQUEST_TIMEOUT = -3, ///< The request timed out while waiting for a response.
-        DUPLICATE = -4, ///< Attempting to register an existing data product ID
-        REGISTRATION_CONFLICT = -5, ///< Attempting to unregister from a service or dataProductID that is not currently registered.
-        NOT_REGISTERED = -6, ///< TBD
-        NO_SUCH_SERVICE = -7, ///< Made a bad request (Ex: used a non-existent domain or submitted a request before service was available)
-        LINK_ERROR = -8, ///< Error serializing or deserializing a Gravity Data Product 
-        INTERRUPTED = -9, ///< Received an interruption.
-        NO_SERVICE_PROVIDER = -10, ///< No service provider found.
-        NO_PORTS_AVAILABLE = -11, ///< No ports available
-		INVALID_PARAMETER = -12, ///< Invalid parameter. (Ex: entered a negative number for time)
-		NOT_INITIALIZED = -13,  ///< The GravityNode has not successfully completed initialization yet (i.e. init has not been called or did not succeed).
-        RESERVED_DATA_PRODUCT_ID = -14 ///< Data Product IDs used internally by Gravity
+        SUCCESS = 0,                ///< The request was successful
+        FAILURE = -1,               ///< The request failed
+        NO_SERVICE_DIRECTORY = -2,  ///< Could not find Service Directory
+        REQUEST_TIMEOUT = -3,       ///< The request timed out while waiting for a response.
+        DUPLICATE = -4,             ///< Attempting to register an existing data product ID
+        REGISTRATION_CONFLICT =
+            -5,  ///< Attempting to unregister from a service or dataProductID that is not currently registered.
+        NOT_REGISTERED = -6,  ///< TBD
+        NO_SUCH_SERVICE =
+            -7,  ///< Made a bad request (Ex: used a non-existent domain or submitted a request before service was available)
+        LINK_ERROR = -8,            ///< Error serializing or deserializing a Gravity Data Product
+        INTERRUPTED = -9,           ///< Received an interruption.
+        NO_SERVICE_PROVIDER = -10,  ///< No service provider found.
+        NO_PORTS_AVAILABLE = -11,   ///< No ports available
+        INVALID_PARAMETER = -12,    ///< Invalid parameter. (Ex: entered a negative number for time)
+        NOT_INITIALIZED =
+            -13,  ///< The GravityNode has not successfully completed initialization yet (i.e. init has not been called or did not succeed).
+        RESERVED_DATA_PRODUCT_ID = -14  ///< Data Product IDs used internally by Gravity
     };
-}
+}  // namespace GravityReturnCodes
 typedef GravityReturnCodes::Codes GravityReturnCode;
 
 /**
@@ -92,26 +94,26 @@ typedef GravityReturnCodes::Codes GravityReturnCode;
  */
 namespace GravityTransportTypes
 {
-   /**
+    /**
     * Network transport protocols available on a Gravity system. 
     */
-   enum Types
-   {
-      TCP = 0, ///< Transmission Control Protocol
-      INPROC = 1, ///< In-process (Inter-thread) Communication 
-      PGM = 2, ///< Pragmatic General Multicast Protocol
-      EPGM= 3, ///< Encapsulated PGM
+    enum Types
+    {
+        TCP = 0,     ///< Transmission Control Protocol
+        INPROC = 1,  ///< In-process (Inter-thread) Communication
+        PGM = 2,     ///< Pragmatic General Multicast Protocol
+        EPGM = 3,    ///< Encapsulated PGM
 #ifndef WIN32
-      IPC = 4 ///< Inter-Process Communication
+        IPC = 4  ///< Inter-Process Communication
 #endif
-   };
-}
+    };
+}  // namespace GravityTransportTypes
 typedef GravityTransportTypes::Types GravityTransportType;
 
 typedef struct SocketWithLock
 {
-	void *socket = nullptr;
-	Semaphore lock;
+    void* socket = nullptr;
+    Semaphore lock;
 } SocketWithLock;
 
 /*
@@ -136,49 +138,50 @@ class FutureResponse;
 class GravityNode
 {
 private:
-    template<typename Mutex> friend class PublishSink;
+    template <typename Mutex>
+    friend class PublishSink;
 
-    // set of reservedDataProduct IDs 
+    // set of reservedDataProduct IDs
     std::set<std::string> serviceDirectory_ReservedDataProductIDs;
     std::set<std::string> gravityNode_ReservedDataProductIDs;
 
-  /**
+    /**
    * Domain change listener for a GravityNode.
    */
-	class GravityNodeDomainListener
-	{
-	public:
-    /**
+    class GravityNodeDomainListener
+    {
+    public:
+        /**
      * Return the current Gravity domain.
      */
-		std::string getDomainUrl();
+        std::string getDomainUrl();
 
-    /**
+        /**
      * Listen for and implement a gravity domain change for the given GravityNode.
      * Continues until the it is interruption or receives a kill command. 
      */
-		void start();
+        void start();
 
-		GravityNodeDomainListener(void *context);
+        GravityNodeDomainListener(void* context);
 
-		virtual ~GravityNodeDomainListener();
+        virtual ~GravityNodeDomainListener();
 
-	private:
-		int sock;
-		bool running;
-		bool ready;
-		void* context;
-		std::string domain;
-		std::string compId;
-		int port;
-		int timeout;
-		GravityNode* gravityNode;
-		void* gravityNodeSocket;
+    private:
+        int sock;
+        bool running;
+        bool ready;
+        void* context;
+        std::string domain;
+        std::string compId;
+        int port;
+        int timeout;
+        GravityNode* gravityNode;
+        void* gravityNodeSocket;
 
-		Semaphore lock;
+        Semaphore lock;
 
-		void readDomainListenerParameters();
-	};
+        void readDomainListenerParameters();
+    };
 
     typedef struct NetworkNode
     {
@@ -193,26 +196,26 @@ private:
         std::string domain;
         std::string dataProductID;
         std::string filter;
-		bool receiveLastCachedValue;
-		bool isRelay;
+        bool receiveLastCachedValue;
+        bool isRelay;
         const GravitySubscriber* subscriber;
     } SubscriptionDetails;
 
-    static const int NETWORK_TIMEOUT = 3000; // msec
-    static const int NETWORK_RETRIES = 3; // attempts to connect
+    static const int NETWORK_TIMEOUT = 3000;  // msec
+    static const int NETWORK_RETRIES = 3;     // attempts to connect
     static Semaphore initLock;
 
     bool settingsPubEnabled;
     bool metricsEnabled;
-	bool initialized;
-	bool logInitialized;
-	bool listenerEnabled;
-	bool heartbeatStarted;
+    bool initialized;
+    bool logInitialized;
+    bool listenerEnabled;
+    bool heartbeatStarted;
 
-	bool defaultCacheLastSentDataprodut;
-	bool defaultReceiveLastSentDataproduct;
-	
-  std::thread subscriptionManagerThread;
+    bool defaultCacheLastSentDataprodut;
+    bool defaultReceiveLastSentDataproduct;
+
+    std::thread subscriptionManagerThread;
 
     void* context = nullptr;
     SocketWithLock subscriptionManagerSWL;
@@ -220,69 +223,75 @@ private:
     SocketWithLock publishManagerRequestSWL;
     SocketWithLock publishManagerPublishSWL;
     SocketWithLock serviceManagerSWL;
-	SocketWithLock serviceManagerConfigSWL;
+    SocketWithLock serviceManagerConfigSWL;
     SocketWithLock requestManagerSWL;
-	SocketWithLock requestManagerRepSWL;
-	SocketWithLock domainListenerSWL;
-	SocketWithLock domainRecvSWL;
-    void* metricsManagerSocket = nullptr; // only used in init, no lock needed
-    void* hbSocket; // Inproc socket for adding requests to heartbeat listener thread.
+    SocketWithLock requestManagerRepSWL;
+    SocketWithLock domainListenerSWL;
+    SocketWithLock domainRecvSWL;
+    void* metricsManagerSocket = nullptr;  // only used in init, no lock needed
+    void* hbSocket;                        // Inproc socket for adding requests to heartbeat listener thread.
 
-	std::string listenForBroadcastURL(std::string domain, int port, int timeout);
-   
+    std::string listenForBroadcastURL(std::string domain, int port, int timeout);
+
     GravityReturnCode sendRequestToServiceDirectory(const GravityDataProduct& request, GravityDataProduct& response);
-    GravityReturnCode sendRequestsToServiceProvider(std::string url, const GravityDataProduct& request, GravityDataProduct& response,
-    		int timeout_in_milliseconds, int retries);
-    GravityReturnCode sendRequestToServiceProvider(std::string url, const GravityDataProduct& request, GravityDataProduct& response,
-    		int timeout_in_milliseconds);
+    GravityReturnCode sendRequestsToServiceProvider(std::string url, const GravityDataProduct& request,
+                                                    GravityDataProduct& response, int timeout_in_milliseconds,
+                                                    int retries);
+    GravityReturnCode sendRequestToServiceProvider(std::string url, const GravityDataProduct& request,
+                                                   GravityDataProduct& response, int timeout_in_milliseconds);
 
     NetworkNode serviceDirectoryNode;
     Semaphore serviceDirectoryLock;
-    std::map<std::string,std::string> publishMap;
-    std::map<std::string,std::string> serviceMap; ///< Maps serviceID to url
+    std::map<std::string, std::string> publishMap;
+    std::map<std::string, std::string> serviceMap;  ///< Maps serviceID to url
     std::list<SubscriptionDetails> subscriptionList;
-    std::map<std::string,std::string> publishedSettings;
-	std::map<std::string,uint64_t> urlInstanceMap;
+    std::map<std::string, std::string> publishedSettings;
+    std::map<std::string, uint64_t> urlInstanceMap;
     std::string myDomain;
     std::string componentID;
-	std::map<std::string, uint32_t> dataRegistrationTimeMap; // Maps data product id to registration time
-	GravityConfigParser* parser;
+    std::map<std::string, uint32_t> dataRegistrationTimeMap;  // Maps data product id to registration time
+    GravityConfigParser* parser;
 
     GravityConfigParamPB configParamPB;
     GravityDataProduct settingsGDP = GravityDataProduct(gravity::constants::GRAVITY_SETTINGS_DPID);
 
-	GravityReturnCode ServiceDirectoryServiceLookup(std::string serviceOrDPID, std::string &url, std::string &domain, uint32_t &regTime);
-	GravityReturnCode ServiceDirectoryDataProductLookup(std::string serviceOrDPID, std::vector<gravity::PublisherInfoPB> &urls, std::string &domain);
+    GravityReturnCode ServiceDirectoryServiceLookup(std::string serviceOrDPID, std::string& url, std::string& domain,
+                                                    uint32_t& regTime);
+    GravityReturnCode ServiceDirectoryDataProductLookup(std::string serviceOrDPID,
+                                                        std::vector<gravity::PublisherInfoPB>& urls,
+                                                        std::string& domain);
     GravityReturnCode ServiceDirectoryReregister(std::string componentId, std::string url);
 
-	void updateServiceDirectoryUrl(std::string serviceDirectoryUrl);
+    void updateServiceDirectoryUrl(std::string serviceDirectoryUrl);
 
     // Separate actual functionality of sub/unsub methods so that they can be locked correctly
     GravityReturnCode subscribeInternal(std::string dataProductID, const GravitySubscriber& subscriber,
-                                            std::string filter, std::string domain, bool receiveLastCachedValue = true);
+                                        std::string filter, std::string domain, bool receiveLastCachedValue = true);
     GravityReturnCode unsubscribeInternal(std::string dataProductID, const GravitySubscriber& subscriber,
-                                                std::string filter, std::string domain);
+                                          std::string filter, std::string domain);
 
     GravityReturnCode request(std::string connectionURL, std::string serviceID, const GravityDataProduct& dataProduct,
-		const GravityRequestor& requestor, uint32_t regTime, std::string requestID = "", int timeout_milliseconds = -1);
+                              const GravityRequestor& requestor, uint32_t regTime, std::string requestID = "",
+                              int timeout_milliseconds = -1);
 
-    GRAVITY_API GravityReturnCode registerDataProductInternal(std::string dataProductID, GravityTransportType transportType,
-    		                                                  bool cacheLastValue, bool isRelay, bool localOnly, bool allowReservedIDs);
+    GRAVITY_API GravityReturnCode registerDataProductInternal(std::string dataProductID,
+                                                              GravityTransportType transportType, bool cacheLastValue,
+                                                              bool isRelay, bool localOnly, bool allowReservedIDs);
 
-	static void* startGravityDomainListener(void* context);
-	
-	void configureNodeDomainListener(std::string domain);
-	
-	void configureServiceManager();
-	void configureSubscriptionManager();
+    static void* startGravityDomainListener(void* context);
 
-	std::string getDomainUrl(int timeout);
-	
-	// SpdLog 
-	std::shared_ptr<spdlog::logger> logger;
-	void configSpdLoggers();
-	
-	static const std::string file_separator;
+    void configureNodeDomainListener(std::string domain);
+
+    void configureServiceManager();
+    void configureSubscriptionManager();
+
+    std::string getDomainUrl(int timeout);
+
+    // SpdLog
+    std::shared_ptr<spdlog::logger> logger;
+    void configSpdLoggers();
+
+    static const std::string file_separator;
 
 public:
     /**
@@ -290,18 +299,18 @@ public:
      */
     GRAVITY_API GravityNode();
 
-	/**
+    /**
 	* Constructor that also initializes
 	* \param componentID ID of the component to initialize
 	*/
-	GRAVITY_API GravityNode(std::string componentID);
+    GRAVITY_API GravityNode(std::string componentID);
 
     /**
      * Default Destructor
      */
     GRAVITY_API virtual ~GravityNode();
 
-	/**
+    /**
      * Initialize the Gravity infrastructure.
 	   * Reads the ComponentID from the Gravity.ini file.
      * \return GravityReturnCode code to identify any errors that occur during initialization
@@ -326,28 +335,31 @@ public:
      * \param subscriber object that implements the GravitySubscriber interface and will be notified of data availability
      * \return success flag
      */
-	GRAVITY_API GravityReturnCode subscribe(std::string dataProductID, const GravitySubscriber& subscriber);
+    GRAVITY_API GravityReturnCode subscribe(std::string dataProductID, const GravitySubscriber& subscriber);
 
     /**
      * \copybrief subscribe(std::string,const GravitySubscriber&)
      * \param filter text filter to apply to subscription
      * \copydetails subscribe(std::string,const GravitySubscriber&)
      */
-	GRAVITY_API GravityReturnCode subscribe(std::string dataProductID, const GravitySubscriber& subscriber, std::string filter);
+    GRAVITY_API GravityReturnCode subscribe(std::string dataProductID, const GravitySubscriber& subscriber,
+                                            std::string filter);
 
     /**
      * \copybrief subscribe(std::string,const GravitySubscriber&,std::string)
      * \param domain domain of the network components
      * \copydetails subscribe(std::string,const GravitySubscriber&,std::string)
      */
-	GRAVITY_API GravityReturnCode subscribe(std::string dataProductID, const GravitySubscriber& subscriber, std::string filter, std::string domain);
+    GRAVITY_API GravityReturnCode subscribe(std::string dataProductID, const GravitySubscriber& subscriber,
+                                            std::string filter, std::string domain);
 
     /**
      * \copybrief subscribe(std::string,const GravitySubscriber&,std::string,std::string)
      * \param receiveLastCachedValue
      * \copydetails subscribe(std::string,const GravitySubscriber&,std::string,std::string)
      */
-	GRAVITY_API GravityReturnCode subscribe(std::string dataProductID, const GravitySubscriber& subscriber, std::string filter, std::string domain, bool receiveLastCachedValue);
+    GRAVITY_API GravityReturnCode subscribe(std::string dataProductID, const GravitySubscriber& subscriber,
+                                            std::string filter, std::string domain, bool receiveLastCachedValue);
 
     /**
      * Un-subscribe from a data product
@@ -357,8 +369,8 @@ public:
      * \param domain domain of the network components
      * \return success flag
      */
-    GRAVITY_API GravityReturnCode unsubscribe(std::string dataProductID, const GravitySubscriber& subscriber, 
-												std::string filter="", std::string domain = "");
+    GRAVITY_API GravityReturnCode unsubscribe(std::string dataProductID, const GravitySubscriber& subscriber,
+                                              std::string filter = "", std::string domain = "");
 
     /**
      * Publish a data product to the Gravity Service Directory.
@@ -367,7 +379,8 @@ public:
      * \param timestamp time dataProduct was created
      * \return success flag
      */
-    GRAVITY_API GravityReturnCode publish(const GravityDataProduct& dataProduct, std::string filterText = "", uint64_t timestamp = 0);
+    GRAVITY_API GravityReturnCode publish(const GravityDataProduct& dataProduct, std::string filterText = "",
+                                          uint64_t timestamp = 0);
 
     /**
      * Determine whether there are any subscribers for this DataProduct
@@ -375,7 +388,7 @@ public:
 	 * \param hasSubscribersOut (output only) false if there are no subscribers, otherwise true
      * \return success flag
      **/
-    GRAVITY_API GravityReturnCode  subscribersExist(std::string dataProductID, bool& hasSubscribersOut);
+    GRAVITY_API GravityReturnCode subscribersExist(std::string dataProductID, bool& hasSubscribersOut);
 
     /**
      * Make an asynchronous request against a service provider through the Gravity Service Directory
@@ -388,8 +401,8 @@ public:
      * \return success flag
      */
     GRAVITY_API GravityReturnCode request(std::string serviceID, const GravityDataProduct& request,
-										const GravityRequestor& requestor, std::string requestID = "", 
-										int timeout_milliseconds = -1, std::string domain = "");	
+                                          const GravityRequestor& requestor, std::string requestID = "",
+                                          int timeout_milliseconds = -1, std::string domain = "");
 
     /**
      * Make a synchronous request against a service provider
@@ -400,7 +413,7 @@ public:
      * \return shared_ptr<GravityDataProduct> pointer to the data product representation of the response. NULL upon failure.
      */
     GRAVITY_API std::shared_ptr<GravityDataProduct> request(std::string serviceID, const GravityDataProduct& request,
-										int timeout_milliseconds = -1, std::string domain = "");
+                                                            int timeout_milliseconds = -1, std::string domain = "");
 
     /**
      * Starts a heart beat for this GravityNode.
@@ -410,11 +423,11 @@ public:
      */
     GRAVITY_API GravityReturnCode startHeartbeat(int64_t interval_in_microseconds);
 
-	/**
+    /**
      * Stops the heart beat for this GravityNode.
      * \return success flag
 	 */
-	GRAVITY_API GravityReturnCode stopHeartbeat();
+    GRAVITY_API GravityReturnCode stopHeartbeat();
 
     /**
      * @name Gravity.ini parsing functions
@@ -427,7 +440,7 @@ public:
     GRAVITY_API int getIntParam(std::string key, int default_value = -1);
     GRAVITY_API double getFloatParam(std::string key, double default_value = 0.0);
     GRAVITY_API bool getBoolParam(std::string key, bool default_value = false);
-    /** @} */ //Gravity.ini parsing functions
+    /** @} */  //Gravity.ini parsing functions
 
     /**
      * Get the ID of this gravity node (given in the init function).
@@ -448,8 +461,8 @@ public:
      * \param transportType transport type (e.g. 'tcp', 'ipc')
      * \return success flag
      */
-	GRAVITY_API GravityReturnCode registerDataProduct(std::string dataProductID, GravityTransportType transportType);
-	 /**
+    GRAVITY_API GravityReturnCode registerDataProduct(std::string dataProductID, GravityTransportType transportType);
+    /**
      * Register a data product with the Gravity, and optionally, the Directory Service, making it available to the
      * rest of the Gravity-enabled system.
      * \param dataProductID string ID used to uniquely identify this published data product
@@ -457,7 +470,8 @@ public:
 	 * \param cacheLastValue flag used to signify whether or not GravityNode will cache the last sent value for a published dataproduct
      * \return success flag
      */
-    GRAVITY_API GravityReturnCode registerDataProduct(std::string dataProductID, GravityTransportType transportType, bool cacheLastValue);
+    GRAVITY_API GravityReturnCode registerDataProduct(std::string dataProductID, GravityTransportType transportType,
+                                                      bool cacheLastValue);
 
     /**
      * Un-register a data product, resulting in its removal from the Gravity Service Directory
@@ -472,7 +486,7 @@ public:
      * \return success flag
      */
     GRAVITY_API GravityReturnCode registerService(std::string serviceID, GravityTransportType transportType,
-            const GravityServiceProvider& server);
+                                                  const GravityServiceProvider& server);
     /**
      * Unregister as a service provider with the Gravity Service Directory
      * \param serviceID Unique ID with which the service was originally registered
@@ -489,10 +503,11 @@ public:
 	 * \param domain name of domain for the componentID
      * \return success flag
      */
-    GRAVITY_API GravityReturnCode registerHeartbeatListener(std::string componentID, int64_t interval_in_microseconds, 
-			const GravityHeartbeatListener& listener, std::string domain = "");
+    GRAVITY_API GravityReturnCode registerHeartbeatListener(std::string componentID, int64_t interval_in_microseconds,
+                                                            const GravityHeartbeatListener& listener,
+                                                            std::string domain = "");
 
-	  /**
+    /**
      * Unregisters a callback for when we get a heartbeat from another component.
 	   * \param componentID name of component we are currently registered to
 	   * \param domain name of domain for the componentID
@@ -512,7 +527,8 @@ public:
      * \param transportType transport type (e.g. 'tcp', 'ipc')
      * \return success flag
      */
-    GRAVITY_API GravityReturnCode registerRelay(std::string dataProductID, const GravitySubscriber& subscriber, bool localOnly, GravityTransportType transportType);
+    GRAVITY_API GravityReturnCode registerRelay(std::string dataProductID, const GravitySubscriber& subscriber,
+                                                bool localOnly, GravityTransportType transportType);
 
     /**
      * Register a Relay that will act as a pass-through for the given dataProductID.  It will be a publisher and subscriber
@@ -528,7 +544,9 @@ public:
      *                       with cachedLastValue=true is atypical and may result in duplicate messages received by subscribers during the relay start/stop transition
      * \return success flag
      */
-    GRAVITY_API GravityReturnCode registerRelay(std::string dataProductID, const GravitySubscriber& subscriber, bool localOnly, GravityTransportType transportType, bool cacheLastValue);
+    GRAVITY_API GravityReturnCode registerRelay(std::string dataProductID, const GravitySubscriber& subscriber,
+                                                bool localOnly, GravityTransportType transportType,
+                                                bool cacheLastValue);
 
     /**
      * Unregister a relay for the given dataProductID.  Handles unregistering as a publisher and subscriber.
@@ -538,50 +556,52 @@ public:
      * \return success flag
      */
     GRAVITY_API GravityReturnCode unregisterRelay(std::string dataProductID, const GravitySubscriber& subscriber);
-    /** @} */ //Registration functions
+    /** @} */  //Registration functions
 
     /**
      * Returns a string representation of the provided error code.
      */
     GRAVITY_API std::string getCodeString(GravityReturnCode code);
 
-	/**
+    /**
 	* Utility method to get the host machine's IP address
 	**/
-	GRAVITY_API std::string getIP();  
+    GRAVITY_API std::string getIP();
 
-	/**
+    /**
 	 * Returns the domain with which this node is associated
 	 **/
-	GRAVITY_API std::string getDomain();
+    GRAVITY_API std::string getDomain();
 
-	/**
+    /**
 	 * Creates and returns a FutureReponse pointer for delayed response to requests
 	 */
-	GRAVITY_API std::shared_ptr<FutureResponse> createFutureResponse();
+    GRAVITY_API std::shared_ptr<FutureResponse> createFutureResponse();
 
-	/**
+    /**
 	 * Send a FutureResponse
    * \return success flag
 	 */
-	GRAVITY_API GravityReturnCode sendFutureResponse(const FutureResponse& futureResponse);
+    GRAVITY_API GravityReturnCode sendFutureResponse(const FutureResponse& futureResponse);
 
-  /**
+    /**
    * Setup a GravitySubscriptionMonitor to receive subscription timeout information through the Gravity Service Directory.
    * \param dataProductID the ID of the data product to monitor 
    * \param milliSecondTimeout the time elapsed since receiving a new data product that qualifies as a subscription timeout 
    * \return success flag
    */
-	GRAVITY_API GravityReturnCode setSubscriptionTimeoutMonitor(std::string dataProductID, const GravitySubscriptionMonitor& monitor, 
-			int milliSecondTimeout, std::string filter="", std::string domain="");
+    GRAVITY_API GravityReturnCode setSubscriptionTimeoutMonitor(std::string dataProductID,
+                                                                const GravitySubscriptionMonitor& monitor,
+                                                                int milliSecondTimeout, std::string filter = "",
+                                                                std::string domain = "");
 
-  /**
+    /**
    * Remove the given dataProductID from the given GravitySubscriptionMonitor. 
    * \return success  flag
    */
-	GRAVITY_API GravityReturnCode clearSubscriptionTimeoutMonitor(std::string dataProductID, const GravitySubscriptionMonitor& monitor, 
-			std::string filter="", std::string domain="");
-
+    GRAVITY_API GravityReturnCode clearSubscriptionTimeoutMonitor(std::string dataProductID,
+                                                                  const GravitySubscriptionMonitor& monitor,
+                                                                  std::string filter = "", std::string domain = "");
 };
 
 } /* namespace gravity */

--- a/src/api/cpp/GravityPublishManager.cpp
+++ b/src/api/cpp/GravityPublishManager.cpp
@@ -36,49 +36,49 @@ namespace gravity
 
 using namespace std;
 
-bool sortCacheValues (const std::shared_ptr<CacheValue> &i, const std::shared_ptr<CacheValue> &j)
+bool sortCacheValues(const std::shared_ptr<CacheValue>& i, const std::shared_ptr<CacheValue>& j)
 {
     return i->timestamp < j->timestamp;
 }
 
 GravityPublishManager::GravityPublishManager(void* context)
 {
-	// This is the zmq context that is shared with the GravityNode. Must use
-	// a shared context to establish an inproc socket.
-	this->context = context;
+    // This is the zmq context that is shared with the GravityNode. Must use
+    // a shared context to establish an inproc socket.
+    this->context = context;
 
     // Default to no metrics
     metricsEnabled = false;
-	
-	// Default TCP KeepAlive status
-	tcpKeepAliveEnabled = false;
-	tcpKeepAliveTime = -1;
-	tcpKeepAliveProbes = -1;
-	tcpKeepAliveIntvl = -1;
 
-	// Default high water mark
-	publishHWM = 1000;
-	
-	// Get the gravity logger
-	logger = spdlog::get("GravityLogger");
+    // Default TCP KeepAlive status
+    tcpKeepAliveEnabled = false;
+    tcpKeepAliveTime = -1;
+    tcpKeepAliveProbes = -1;
+    tcpKeepAliveIntvl = -1;
+
+    // Default high water mark
+    publishHWM = 1000;
+
+    // Get the gravity logger
+    logger = spdlog::get("GravityLogger");
 }
 
 GravityPublishManager::~GravityPublishManager() {}
 
 void GravityPublishManager::start()
 {
-	// Messages
-	zmq_msg_t event;
+    // Messages
+    zmq_msg_t event;
 
-	// Set up the inproc sockets to subscribe and unsubscribe to messages from
-	// the GravityNode
-	gravityNodeResponseSocket = zmq_socket(context, ZMQ_REP);
-	zmq_bind(gravityNodeResponseSocket, PUB_MGR_REQ_URL);
+    // Set up the inproc sockets to subscribe and unsubscribe to messages from
+    // the GravityNode
+    gravityNodeResponseSocket = zmq_socket(context, ZMQ_REP);
+    zmq_bind(gravityNodeResponseSocket, PUB_MGR_REQ_URL);
 
-	gravityNodeSubscribeSocket = zmq_socket(context, ZMQ_SUB);
+    gravityNodeSubscribeSocket = zmq_socket(context, ZMQ_SUB);
     zmq_connect(gravityNodeSubscribeSocket, PUB_MGR_PUB_URL);
-	// Create the socket to receive heartbeat publish messages
-	zmq_bind(gravityNodeSubscribeSocket,PUB_MGR_HB_URL);
+    // Create the socket to receive heartbeat publish messages
+    zmq_bind(gravityNodeSubscribeSocket, PUB_MGR_HB_URL);
     zmq_setsockopt(gravityNodeSubscribeSocket, ZMQ_SUBSCRIBE, NULL, 0);
 
     // Setup socket to respond to metrics requests
@@ -90,13 +90,13 @@ void GravityPublishManager::start()
     zmq_connect(metricsPublishSocket, GRAVITY_METRICS_PUB);
     zmq_setsockopt(metricsPublishSocket, ZMQ_SUBSCRIBE, NULL, 0);
 
-	// Configure polling on our sockets
-	zmq_pollitem_t pollItemResponse;
-	pollItemResponse.socket = gravityNodeResponseSocket;
-	pollItemResponse.events = ZMQ_POLLIN;
-	pollItemResponse.fd = 0;
-	pollItemResponse.revents = 0;
-	pollItems.push_back(pollItemResponse);
+    // Configure polling on our sockets
+    zmq_pollitem_t pollItemResponse;
+    pollItemResponse.socket = gravityNodeResponseSocket;
+    pollItemResponse.events = ZMQ_POLLIN;
+    pollItemResponse.fd = 0;
+    pollItemResponse.revents = 0;
+    pollItems.push_back(pollItemResponse);
 
     zmq_pollitem_t pollItemSubscribe;
     pollItemSubscribe.socket = gravityNodeSubscribeSocket;
@@ -121,78 +121,78 @@ void GravityPublishManager::start()
     metricsPollItem.revents = 0;
     pollItems.push_back(metricsPollItem);
 
-	ready();
+    ready();
 
-	// Process forever...
-	while (true)
-	{
-		// Start polling socket(s), blocking while we wait
-		int rc = zmq_poll(&pollItems[0], pollItems.size(), -1); // 0 --> return immediately, -1 --> blocks
-		if (rc == -1)
-		{
-                    // Interrupted
-                    if (errno == EINTR)
-                    {
-                        continue;
-                    }
-                    // Error
-                    break;
-		}
+    // Process forever...
+    while (true)
+    {
+        // Start polling socket(s), blocking while we wait
+        int rc = zmq_poll(&pollItems[0], pollItems.size(), -1);  // 0 --> return immediately, -1 --> blocks
+        if (rc == -1)
+        {
+            // Interrupted
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            // Error
+            break;
+        }
 
-		// Process new requests from the gravity node
-		if (pollItems[0].revents & ZMQ_POLLIN)
-		{
-			// Get new GravityNode request
-			string command = readStringMessage(gravityNodeResponseSocket);
-			logger->trace("GravityPublishManager, pollItems[0], command = {}", command);
+        // Process new requests from the gravity node
+        if (pollItems[0].revents & ZMQ_POLLIN)
+        {
+            // Get new GravityNode request
+            string command = readStringMessage(gravityNodeResponseSocket);
+            logger->trace("GravityPublishManager, pollItems[0], command = {}", command);
 
-			// message from gravity node on this socket
-			if (command == "register")
-			{
-				registerDataProduct();
-			}
-			else if (command == "unregister")
-			{
-			    unregisterDataProduct();
-			}
-			else if (command == "set_hwm")
-			{
-				setHWM();
-			}
-			else if (command == "set_tcp_keepalive")
-			{
-				setKeepAlive();
-			}
-			else if (command == "subscribersExist")
-			{
-				subscribersExist();
-			}
-			else
-			{
-				logger->warn("GravityPublishManager received unknown command '{}' from GravityNode", command);
-			}
-		}
+            // message from gravity node on this socket
+            if (command == "register")
+            {
+                registerDataProduct();
+            }
+            else if (command == "unregister")
+            {
+                unregisterDataProduct();
+            }
+            else if (command == "set_hwm")
+            {
+                setHWM();
+            }
+            else if (command == "set_tcp_keepalive")
+            {
+                setKeepAlive();
+            }
+            else if (command == "subscribersExist")
+            {
+                subscribersExist();
+            }
+            else
+            {
+                logger->warn("GravityPublishManager received unknown command '{}' from GravityNode", command);
+            }
+        }
 
-		if (pollItems[1].revents & ZMQ_POLLIN)
-		{
+        if (pollItems[1].revents & ZMQ_POLLIN)
+        {
             // Get new GravityNode request
             string command = readStringMessage(gravityNodeSubscribeSocket);
             logger->trace("GravityPublishManager, pollItems[1], command = {}", command);
 
-			// message from gravity node should be either a publish or kill request
-			if (command == "publish")
-			{
-				publish(pollItems[1].socket);
-			}
-			else if (command == "kill")
-			{
-				break;
-			}
-			else
-			{
+            // message from gravity node should be either a publish or kill request
+            if (command == "publish")
+            {
+                publish(pollItems[1].socket);
+            }
+            else if (command == "kill")
+            {
+                break;
+            }
+            else
+            {
                 logger->error("Received unknown publish command {}", command);
-			}
-		}
+            }
+        }
 
         if (pollItems[2].revents & ZMQ_POLLIN)
         {
@@ -246,107 +246,113 @@ void GravityPublishManager::start()
             }
         }
 
-		// Check for publish updates
-		for (unsigned int i = 4; i < pollItems.size(); i++)
-		{
-			if (pollItems[i].revents & ZMQ_POLLIN)
-			{
-				// Read whether it's a new subscription from socket
-				zmq_msg_init(&event);
-				zmq_recvmsg(pollItems[i].socket, &event, 0);
-				bool newsub = *((char*)zmq_msg_data(&event)) == 1;  //This message is coming from ZMQ.  The subscriber doesn't send messages on a subscribed socket.
-				zmq_msg_close(&event);
+        // Check for publish updates
+        for (unsigned int i = 4; i < pollItems.size(); i++)
+        {
+            if (pollItems[i].revents & ZMQ_POLLIN)
+            {
+                // Read whether it's a new subscription from socket
+                zmq_msg_init(&event);
+                zmq_recvmsg(pollItems[i].socket, &event, 0);
+                bool newsub =
+                    *((char*)zmq_msg_data(&event)) ==
+                    1;  //This message is coming from ZMQ.  The subscriber doesn't send messages on a subscribed socket.
+                zmq_msg_close(&event);
 
-				if (newsub)
-				{					
-				    std::shared_ptr<PublishDetails> pd = publishMapBySocket[pollItems[i].socket];
-                                    pd->hasSubscribers = true;
-				    // can't log here because the network logging uses this code - any logs here will result in an
-				    // infinite loop, or a deadlock.
-				    // This message can be useful though, so leaving it in, but commented out.
-				    //logger->debug("got a new subscriber for {}, resending {} values.", pd->dataProductID, pd->lastCachedValues.size());
+                if (newsub)
+                {
+                    std::shared_ptr<PublishDetails> pd = publishMapBySocket[pollItems[i].socket];
+                    pd->hasSubscribers = true;
+                    // can't log here because the network logging uses this code - any logs here will result in an
+                    // infinite loop, or a deadlock.
+                    // This message can be useful though, so leaving it in, but commented out.
+                    //logger->debug("got a new subscriber for {}, resending {} values.", pd->dataProductID, pd->lastCachedValues.size());
 
-				    list<std::shared_ptr<CacheValue> > values;
-				    for (map<string,std::shared_ptr<CacheValue> >::iterator iter = pd->lastCachedValues.begin(); iter != pd->lastCachedValues.end(); iter++)
-				        values.push_back(iter->second);
+                    list<std::shared_ptr<CacheValue> > values;
+                    for (map<string, std::shared_ptr<CacheValue> >::iterator iter = pd->lastCachedValues.begin();
+                         iter != pd->lastCachedValues.end(); iter++)
+                        values.push_back(iter->second);
 
-					
-				    // we shouldn't be doing this often, so just sort these when we need it.
+                    // we shouldn't be doing this often, so just sort these when we need it.
                     values.sort(sortCacheValues);
-				    for (list<std::shared_ptr<CacheValue> >::iterator iter = values.begin(); iter != values.end(); iter++)
-					{
-						//we have a new subscriber and are going to send it the last cached data product value. 
-						char* bytes = (*iter)->value;
-						int size = (*iter)->size;
-						//Deserialize cache bytes to a data product and mark cached
-						GravityDataProduct dataProduct(bytes, size);
-						dataProduct.setIsCachedDataproduct(true);
-						int newSize = dataProduct.getSize();
-						//Serialize back to send over socket
-						char* newBytes = new char[newSize];
-						dataProduct.serializeToArray(newBytes);		
-						// See comment above re the use of log statements in this section of code
-						//logger->trace("Publishing data product {}..., Which is cached? {}", dataProduct.getDataProductID(),dataProduct.isCachedDataproduct() ? "true" : "false");
-				        publish(pd->socket, (*iter)->filterText, newBytes, newSize);
-				        delete[] newBytes;
-					}
-				} else {
-				    std::shared_ptr<PublishDetails> pd = publishMapBySocket[pollItems[i].socket];
-                                    pd->hasSubscribers = false;
-    				    // See comment above re the use of log statements in this section of code
-				    //logger->debug("no more subscribers for {} ", pd->dataProductID);
-				}
-			}
-		}
-	}
+                    for (list<std::shared_ptr<CacheValue> >::iterator iter = values.begin(); iter != values.end();
+                         iter++)
+                    {
+                        //we have a new subscriber and are going to send it the last cached data product value.
+                        char* bytes = (*iter)->value;
+                        int size = (*iter)->size;
+                        //Deserialize cache bytes to a data product and mark cached
+                        GravityDataProduct dataProduct(bytes, size);
+                        dataProduct.setIsCachedDataproduct(true);
+                        int newSize = dataProduct.getSize();
+                        //Serialize back to send over socket
+                        char* newBytes = new char[newSize];
+                        dataProduct.serializeToArray(newBytes);
+                        // See comment above re the use of log statements in this section of code
+                        //logger->trace("Publishing data product {}..., Which is cached? {}", dataProduct.getDataProductID(),dataProduct.isCachedDataproduct() ? "true" : "false");
+                        publish(pd->socket, (*iter)->filterText, newBytes, newSize);
+                        delete[] newBytes;
+                    }
+                }
+                else
+                {
+                    std::shared_ptr<PublishDetails> pd = publishMapBySocket[pollItems[i].socket];
+                    pd->hasSubscribers = false;
+                    // See comment above re the use of log statements in this section of code
+                    //logger->debug("no more subscribers for {} ", pd->dataProductID);
+                }
+            }
+        }
+    }
 
-	// Clean up any pub sockets
-	for (map<void*,std::shared_ptr<PublishDetails> >::iterator iter = publishMapBySocket.begin(); iter != publishMapBySocket.end(); iter++)
-	{
-	    std::shared_ptr<PublishDetails> pubDetails = publishMapBySocket[iter->second->socket];
-		zmq_close(pubDetails->pollItem.socket);
-        for (map<string,std::shared_ptr<CacheValue> >::iterator valIter = pubDetails->lastCachedValues.begin(); valIter != pubDetails->lastCachedValues.end(); valIter++)
-            delete [] valIter->second->value;
+    // Clean up any pub sockets
+    for (map<void*, std::shared_ptr<PublishDetails> >::iterator iter = publishMapBySocket.begin();
+         iter != publishMapBySocket.end(); iter++)
+    {
+        std::shared_ptr<PublishDetails> pubDetails = publishMapBySocket[iter->second->socket];
+        zmq_close(pubDetails->pollItem.socket);
+        for (map<string, std::shared_ptr<CacheValue> >::iterator valIter = pubDetails->lastCachedValues.begin();
+             valIter != pubDetails->lastCachedValues.end(); valIter++)
+            delete[] valIter->second->value;
         pubDetails->lastCachedValues.clear();
-	}
+    }
 
-	publishMapBySocket.clear();
-	publishMapByID.clear();
+    publishMapBySocket.clear();
+    publishMapByID.clear();
 
     zmq_close(gravityNodeResponseSocket);
-	zmq_close(gravityNodeSubscribeSocket);
+    zmq_close(gravityNodeSubscribeSocket);
     zmq_close(gravityMetricsSocket);
     zmq_close(metricsPublishSocket);
 }
 
 void GravityPublishManager::ready()
 {
-	// Create the request socket
-	void* initSocket = zmq_socket(context, ZMQ_REQ);
+    // Create the request socket
+    void* initSocket = zmq_socket(context, ZMQ_REQ);
 
-	// Connect to service
-	zmq_connect(initSocket, "inproc://gravity_init");
+    // Connect to service
+    zmq_connect(initSocket, "inproc://gravity_init");
 
-	// Send request to service provider
-	sendStringMessage(initSocket, "GravityPublishManager", ZMQ_DONTWAIT);
+    // Send request to service provider
+    sendStringMessage(initSocket, "GravityPublishManager", ZMQ_DONTWAIT);
 
-	zmq_close(initSocket);
+    zmq_close(initSocket);
 }
 
 void GravityPublishManager::registerDataProduct()
 {
+    // Read the data product id for this request
+    string dataProductID = readStringMessage(gravityNodeResponseSocket);
 
-	// Read the data product id for this request
-	string dataProductID = readStringMessage(gravityNodeResponseSocket);
+    //Read flag to cache last sent data product or not
+    bool cacheLastValue = readIntMessage(gravityNodeResponseSocket);
 
-	//Read flag to cache last sent data product or not
-	bool cacheLastValue = readIntMessage(gravityNodeResponseSocket);
-
-	// Read the publish transport type
-	string transportType = readStringMessage(gravityNodeResponseSocket);
+    // Read the publish transport type
+    string transportType = readStringMessage(gravityNodeResponseSocket);
 
     int minPort = 0, maxPort = 0;
-    if(transportType == "tcp")
+    if (transportType == "tcp")
     {
         minPort = readIntMessage(gravityNodeResponseSocket);
         maxPort = readIntMessage(gravityNodeResponseSocket);
@@ -364,23 +370,23 @@ void GravityPublishManager::registerDataProduct()
     int verbose = 1;
     zmq_setsockopt(pubSocket, ZMQ_XPUB_VERBOSE, &verbose, sizeof(verbose));
 
-	// Set high water mark
-	zmq_setsockopt(pubSocket, ZMQ_SNDHWM, &publishHWM, sizeof(publishHWM));
-	
-	if (transportType == "tcp" && tcpKeepAliveEnabled)
-	{
-		// Enable keepalive 
-		int enable = 1;
-		zmq_setsockopt(pubSocket, ZMQ_TCP_KEEPALIVE, &enable, sizeof(enable));
-		
-		// Set TCP keep-alive as configured by user settings
-		zmq_setsockopt(pubSocket, ZMQ_TCP_KEEPALIVE_IDLE, &tcpKeepAliveTime, sizeof(tcpKeepAliveTime));
-		zmq_setsockopt(pubSocket, ZMQ_TCP_KEEPALIVE_CNT, &tcpKeepAliveProbes, sizeof(tcpKeepAliveProbes));
-		zmq_setsockopt(pubSocket, ZMQ_TCP_KEEPALIVE_INTVL, &tcpKeepAliveIntvl, sizeof(tcpKeepAliveIntvl));
-	}
+    // Set high water mark
+    zmq_setsockopt(pubSocket, ZMQ_SNDHWM, &publishHWM, sizeof(publishHWM));
+
+    if (transportType == "tcp" && tcpKeepAliveEnabled)
+    {
+        // Enable keepalive
+        int enable = 1;
+        zmq_setsockopt(pubSocket, ZMQ_TCP_KEEPALIVE, &enable, sizeof(enable));
+
+        // Set TCP keep-alive as configured by user settings
+        zmq_setsockopt(pubSocket, ZMQ_TCP_KEEPALIVE_IDLE, &tcpKeepAliveTime, sizeof(tcpKeepAliveTime));
+        zmq_setsockopt(pubSocket, ZMQ_TCP_KEEPALIVE_CNT, &tcpKeepAliveProbes, sizeof(tcpKeepAliveProbes));
+        zmq_setsockopt(pubSocket, ZMQ_TCP_KEEPALIVE_INTVL, &tcpKeepAliveIntvl, sizeof(tcpKeepAliveIntvl));
+    }
 
     string connectionURL;
-    if(transportType == "tcp")
+    if (transportType == "tcp")
     {
         int port = bindFirstAvailablePort(pubSocket, endpoint, minPort, maxPort);
         if (port < 0)
@@ -411,22 +417,22 @@ void GravityPublishManager::registerDataProduct()
 
     sendStringMessage(gravityNodeResponseSocket, connectionURL, ZMQ_DONTWAIT);
 
-	// Create poll item for response to this request
-	zmq_pollitem_t pollItem;
-	pollItem.socket = pubSocket;
-	pollItem.events = ZMQ_POLLIN;
-	pollItem.fd = 0;
-	pollItem.revents = 0;
-	pollItems.push_back(pollItem);
+    // Create poll item for response to this request
+    zmq_pollitem_t pollItem;
+    pollItem.socket = pubSocket;
+    pollItem.events = ZMQ_POLLIN;
+    pollItem.fd = 0;
+    pollItem.revents = 0;
+    pollItems.push_back(pollItem);
 
     // Track dataProductID->socket mapping
-	std::shared_ptr<PublishDetails> publishDetails = std::shared_ptr<PublishDetails>(new PublishDetails);
+    std::shared_ptr<PublishDetails> publishDetails = std::shared_ptr<PublishDetails>(new PublishDetails);
     publishDetails->url = connectionURL;
     publishDetails->dataProductID = dataProductID;
     publishDetails->socket = pubSocket;
-	publishDetails->pollItem = pollItem;
-	publishDetails->cacheLastValue = cacheLastValue;
-	publishDetails->hasSubscribers = false;
+    publishDetails->pollItem = pollItem;
+    publishDetails->cacheLastValue = cacheLastValue;
+    publishDetails->hasSubscribers = false;
 
     publishMapByID[dataProductID] = publishDetails;
     publishMapBySocket[pubSocket] = publishDetails;
@@ -434,68 +440,69 @@ void GravityPublishManager::registerDataProduct()
 
 void GravityPublishManager::unregisterDataProduct()
 {
-	// Read the data product id for this request
-	string dataProductID = readStringMessage(gravityNodeResponseSocket);
+    // Read the data product id for this request
+    string dataProductID = readStringMessage(gravityNodeResponseSocket);
 
-	// Go ahead and respond since there's nothing to wait for
-	sendStringMessage(gravityNodeResponseSocket, "", ZMQ_DONTWAIT);
+    // Go ahead and respond since there's nothing to wait for
+    sendStringMessage(gravityNodeResponseSocket, "", ZMQ_DONTWAIT);
 
     // Remove this data product from our metrics data
     metricsData.remove(dataProductID);
 
-	// If data product ID exists, clean up and remove socket. Otherwise, likely a duplicate unregister request
-	if (publishMapByID.count(dataProductID))
-	{
-	    std::shared_ptr<PublishDetails> publishDetails = publishMapByID[dataProductID];
-		void* socket = publishDetails->pollItem.socket;
-		publishMapBySocket.erase(socket);
-		publishMapByID.erase(dataProductID);
-		zmq_unbind(socket, publishDetails->url.c_str());
-		zmq_close(socket);
+    // If data product ID exists, clean up and remove socket. Otherwise, likely a duplicate unregister request
+    if (publishMapByID.count(dataProductID))
+    {
+        std::shared_ptr<PublishDetails> publishDetails = publishMapByID[dataProductID];
+        void* socket = publishDetails->pollItem.socket;
+        publishMapBySocket.erase(socket);
+        publishMapByID.erase(dataProductID);
+        zmq_unbind(socket, publishDetails->url.c_str());
+        zmq_close(socket);
 
-		// delete any cached values.
-        for (map<string,std::shared_ptr<CacheValue> >::iterator iter = publishDetails->lastCachedValues.begin(); iter != publishDetails->lastCachedValues.end(); iter++)
-		    delete [] iter->second->value;
+        // delete any cached values.
+        for (map<string, std::shared_ptr<CacheValue> >::iterator iter = publishDetails->lastCachedValues.begin();
+             iter != publishDetails->lastCachedValues.end(); iter++)
+            delete[] iter->second->value;
         publishDetails->lastCachedValues.clear();
         publishDetails->hasSubscribers = false;
 
-		// Remove from poll items
-		vector<zmq_pollitem_t>::iterator iter = pollItems.begin();
-		while (iter != pollItems.end())
-		{
-			if (iter->socket == socket)
-			{
-				iter = pollItems.erase(iter);
-			}
-			else
-			{
-				iter++;
-			}
-		}
-	}
+        // Remove from poll items
+        vector<zmq_pollitem_t>::iterator iter = pollItems.begin();
+        while (iter != pollItems.end())
+        {
+            if (iter->socket == socket)
+            {
+                iter = pollItems.erase(iter);
+            }
+            else
+            {
+                iter++;
+            }
+        }
+    }
 }
 
 void GravityPublishManager::setHWM()
 {
-	// Read the high water mark setting
-	publishHWM = readIntMessage(gravityNodeResponseSocket);
+    // Read the high water mark setting
+    publishHWM = readIntMessage(gravityNodeResponseSocket);
 
-	// Send ACK
-	sendStringMessage(gravityNodeResponseSocket, "ACK", ZMQ_DONTWAIT);
+    // Send ACK
+    sendStringMessage(gravityNodeResponseSocket, "ACK", ZMQ_DONTWAIT);
 }
 
 void GravityPublishManager::setKeepAlive()
 {
-	// TCP KeepAlive is being enabled
-	tcpKeepAliveEnabled = true;
-	
-	// Get TCP keep-alive settings
-	tcpKeepAliveTime = readIntMessage(gravityNodeResponseSocket);
-	tcpKeepAliveProbes = readIntMessage(gravityNodeResponseSocket);
-	tcpKeepAliveIntvl = readIntMessage(gravityNodeResponseSocket);
-	
-	// Send ACK
-	sendStringMessage(gravityNodeResponseSocket, "ACK", ZMQ_DONTWAIT);
+    // TCP KeepAlive is being enabled
+    tcpKeepAliveEnabled = true;
+
+    // Get TCP keep-alive settings
+    tcpKeepAliveTime = readIntMessage(gravityNodeResponseSocket);
+    tcpKeepAliveProbes = readIntMessage(gravityNodeResponseSocket);
+    tcpKeepAliveIntvl = readIntMessage(gravityNodeResponseSocket);
+
+    // Send ACK
+    sendStringMessage(gravityNodeResponseSocket, "ACK", ZMQ_DONTWAIT);
 }
 
 void GravityPublishManager::publish(void* requestSocket)
@@ -503,7 +510,7 @@ void GravityPublishManager::publish(void* requestSocket)
     // Read the filter text
     string dataProductId = readStringMessage(requestSocket);
     uint64_t timestamp = readUint64Message(requestSocket);
-    string filterText    = readStringMessage(requestSocket);
+    string filterText = readStringMessage(requestSocket);
 
     // Read the data product
     zmq_msg_t msg;
@@ -511,11 +518,10 @@ void GravityPublishManager::publish(void* requestSocket)
     zmq_recvmsg(requestSocket, &msg, -1);
     size_t gdbSize = zmq_msg_size(&msg);
     // make a copy to hold for new subscribers below
-    char *bytes = new char[gdbSize];
+    char* bytes = new char[gdbSize];
     memcpy(bytes, zmq_msg_data(&msg), gdbSize);
     zmq_msg_close(&msg);
 
-	
     std::shared_ptr<PublishDetails> publishDetails = publishMapByID[dataProductId];
     if (!publishDetails)
     {
@@ -524,28 +530,32 @@ void GravityPublishManager::publish(void* requestSocket)
     }
 
     // delete any old data and ...
-    if (publishDetails->lastCachedValues.count(filterText) > 0) {
-        delete [] publishDetails->lastCachedValues[filterText]->value;
+    if (publishDetails->lastCachedValues.count(filterText) > 0)
+    {
+        delete[] publishDetails->lastCachedValues[filterText]->value;
     }
 
-	//cache new data unless publisher specified not to
-	if(publishDetails->cacheLastValue){
-		logger->trace("Cache last data product value for {}", dataProductId);
-		// ... save new data for late subscribers
-		std::shared_ptr<CacheValue> val = std::shared_ptr<CacheValue>(new CacheValue);
-		val->filterText = filterText;
-		val->value = bytes;
-		val->size = gdbSize;
-		val->timestamp = timestamp;
-		publishDetails->lastCachedValues[filterText] = val;
-	
-	}else{
-		logger->trace("We are not caching data products");
-	}
+    //cache new data unless publisher specified not to
+    if (publishDetails->cacheLastValue)
+    {
+        logger->trace("Cache last data product value for {}", dataProductId);
+        // ... save new data for late subscribers
+        std::shared_ptr<CacheValue> val = std::shared_ptr<CacheValue>(new CacheValue);
+        val->filterText = filterText;
+        val->value = bytes;
+        val->size = gdbSize;
+        val->timestamp = timestamp;
+        publishDetails->lastCachedValues[filterText] = val;
+    }
+    else
+    {
+        logger->trace("We are not caching data products");
+    }
     publish(publishDetails->socket, filterText, bytes, gdbSize);
 
-    if (!publishDetails->cacheLastValue){
-        delete [] bytes;
+    if (!publishDetails->cacheLastValue)
+    {
+        delete[] bytes;
     }
 
     if (metricsEnabled)
@@ -555,9 +565,8 @@ void GravityPublishManager::publish(void* requestSocket)
     }
 }
 
-void GravityPublishManager::publish(void* socket, const string &filterText, const void *bytes, int size)
+void GravityPublishManager::publish(void* socket, const string& filterText, const void* bytes, int size)
 {
-
     // Create message & send filter text
     sendStringMessage(socket, filterText, ZMQ_SNDMORE);
 
@@ -570,7 +579,6 @@ void GravityPublishManager::publish(void* socket, const string &filterText, cons
 
     // Clean up
     zmq_msg_close(&data);
-
 }
 
 void GravityPublishManager::subscribersExist()
@@ -580,12 +588,14 @@ void GravityPublishManager::subscribersExist()
     string ret;
     if (!publishDetails)
     {
-        ret = "Unknown data product id: "+dataProductID ;  // Note: this string is used in GravityNode to set the error code
-    } else {
+        ret = "Unknown data product id: " +
+              dataProductID;  // Note: this string is used in GravityNode to set the error code
+    }
+    else
+    {
         ret = publishDetails->hasSubscribers ? "Y" : "N";
     }
     sendStringMessage(gravityNodeResponseSocket, ret, ZMQ_DONTWAIT);
 }
-
 
 } /* namespace gravity */

--- a/src/api/cpp/GravityPublishManager.h
+++ b/src/api/cpp/GravityPublishManager.h
@@ -42,7 +42,7 @@
 
 #define PUB_MGR_REQ_URL "inproc://gravity_publish_manager_request"
 #define PUB_MGR_PUB_URL "inproc://gravity_publish_manager_publish"
-#define PUB_MGR_HB_URL  "inproc://gravity_heartbeat_publish"
+#define PUB_MGR_HB_URL "inproc://gravity_heartbeat_publish"
 
 namespace gravity
 {
@@ -50,7 +50,7 @@ namespace gravity
 typedef struct CacheValue
 {
     std::string filterText;
-    char *value;
+    char* value;
     int size;
     uint64_t timestamp;
 } CacheValue;
@@ -59,8 +59,8 @@ typedef struct PublishDetails
 {
     std::string url;
     std::string dataProductID;
-	bool cacheLastValue;
-	std::map<std::string,std::shared_ptr<CacheValue> > lastCachedValues;
+    bool cacheLastValue;
+    std::map<std::string, std::shared_ptr<CacheValue> > lastCachedValues;
     zmq_pollitem_t pollItem;
     void* socket;
     bool hasSubscribers;
@@ -73,52 +73,52 @@ typedef struct PublishDetails
 class GravityPublishManager
 {
 private:
-	void* context;
+    void* context;
     void* gravityMetricsSocket;
     void* metricsPublishSocket;
-	void* gravityNodeResponseSocket;
+    void* gravityNodeResponseSocket;
     void* gravityNodeSubscribeSocket;
-    std::map<void*,std::shared_ptr<PublishDetails> > publishMapBySocket;
-    std::map<std::string,std::shared_ptr<PublishDetails> > publishMapByID;
+    std::map<void*, std::shared_ptr<PublishDetails> > publishMapBySocket;
+    std::map<std::string, std::shared_ptr<PublishDetails> > publishMapByID;
     std::vector<zmq_pollitem_t> pollItems;
 
-	void setHWM();
-	void setKeepAlive();
-	void subscribersExist();
-	void ready();
-	void registerDataProduct();
-	void unregisterDataProduct();
-	void publish(void* requestSocket);
-    void publish(void* socket, const std::string &filterText, const void *data, int size);
+    void setHWM();
+    void setKeepAlive();
+    void subscribersExist();
+    void ready();
+    void registerDataProduct();
+    void unregisterDataProduct();
+    void publish(void* requestSocket);
+    void publish(void* socket, const std::string& filterText, const void* data, int size);
 
-	int publishHWM;
+    int publishHWM;
     bool metricsEnabled;
     GravityMetrics metricsData;
-	
-	std::shared_ptr<spdlog::logger> logger;
-	
-	bool tcpKeepAliveEnabled;
-	int tcpKeepAliveTime;
-	int tcpKeepAliveProbes;
-	int tcpKeepAliveIntvl;
-	
+
+    std::shared_ptr<spdlog::logger> logger;
+
+    bool tcpKeepAliveEnabled;
+    int tcpKeepAliveTime;
+    int tcpKeepAliveProbes;
+    int tcpKeepAliveIntvl;
+
 public:
-	/**
+    /**
 	 * Constructor GravityPublishManager
 	 * \param context The zmq context in which the inproc socket will be established with the GravityNode
 	 */
-	GravityPublishManager(void* context);
+    GravityPublishManager(void* context);
 
-	/**
+    /**
 	 * Default destructor
 	 */
-	virtual ~GravityPublishManager();
+    virtual ~GravityPublishManager();
 
-	/**
+    /**
 	 * Starts the GravityPublishManager which will run forever, sending updates to new subscribers.
 	 * Should be executed from GravityNode in its own thread with a shared zmq context.
 	 */
-	void start();
+    void start();
 };
 
 } /* namespace gravity */

--- a/src/api/cpp/GravityRequestManager.cpp
+++ b/src/api/cpp/GravityRequestManager.cpp
@@ -38,62 +38,64 @@ using namespace std;
 
 GravityRequestManager::GravityRequestManager(void* context)
 {
-	// This is the zmq context used to the comms socket
-	this->context = context;
-	logger = spdlog::get("GravityLogger");
+    // This is the zmq context used to the comms socket
+    this->context = context;
+    logger = spdlog::get("GravityLogger");
 }
 
 GravityRequestManager::~GravityRequestManager() {}
 
 void GravityRequestManager::start()
 {
-	// Set up the inproc socket to subscribe to request messages from the GravityNode
-	gravityNodeSocket = zmq_socket(context, ZMQ_SUB);
-	zmq_connect(gravityNodeSocket, "inproc://gravity_request_manager");
-	zmq_setsockopt(gravityNodeSocket, ZMQ_SUBSCRIBE, NULL, 0);
+    // Set up the inproc socket to subscribe to request messages from the GravityNode
+    gravityNodeSocket = zmq_socket(context, ZMQ_SUB);
+    zmq_connect(gravityNodeSocket, "inproc://gravity_request_manager");
+    zmq_setsockopt(gravityNodeSocket, ZMQ_SUBSCRIBE, NULL, 0);
 
-	gravityResponseSocket = zmq_socket(context, ZMQ_REP);
-	zmq_connect(gravityResponseSocket, "inproc://gravity_request_rep");
+    gravityResponseSocket = zmq_socket(context, ZMQ_REP);
+    zmq_connect(gravityResponseSocket, "inproc://gravity_request_rep");
 
-	// Always have at least the gravity node to poll
-	zmq_pollitem_t pollItem;
-	pollItem.socket = gravityNodeSocket;
-	pollItem.events = ZMQ_POLLIN;
-	pollItem.fd = 0;
-	pollItem.revents = 0;
-	pollItems.push_back(pollItem);
+    // Always have at least the gravity node to poll
+    zmq_pollitem_t pollItem;
+    pollItem.socket = gravityNodeSocket;
+    pollItem.events = ZMQ_POLLIN;
+    pollItem.fd = 0;
+    pollItem.revents = 0;
+    pollItems.push_back(pollItem);
 
-	// And the rep socket
-	zmq_pollitem_t pollItemRep;
-	pollItemRep.socket = gravityResponseSocket;
-	pollItemRep.events = ZMQ_POLLIN;
-	pollItemRep.fd = 0;
-	pollItemRep.revents = 0;
-	pollItems.push_back(pollItemRep);
+    // And the rep socket
+    zmq_pollitem_t pollItemRep;
+    pollItemRep.socket = gravityResponseSocket;
+    pollItemRep.events = ZMQ_POLLIN;
+    pollItemRep.fd = 0;
+    pollItemRep.revents = 0;
+    pollItems.push_back(pollItemRep);
 
-	ready();
+    ready();
 
-	// Process forever...
-	zmq_msg_t message;
-	while (true)
-	{
-	    // before we poll, determine when the next timeout is (if any)
-	    // and handle any expired requests.
-	    int64_t nextTimeout = -1;
-	    for (map<void*,std::shared_ptr<RequestDetails> >::iterator iter = requestMap.begin(); iter != requestMap.end(); )
-	    {
-	        int64_t t = iter->second->timeoutTimeMilliseconds;
-	        if (t > 0)
-	        {
-	            // signed int64 is easily large enough to hold milli or microseconds since 1970
-	            int64_t currentTime = (int64_t) (getCurrentTime() / 1e3);
-	            if (t <= currentTime)
-	            {
-	                std::shared_ptr<RequestDetails> reqDetails = iter->second;
+    // Process forever...
+    zmq_msg_t message;
+    while (true)
+    {
+        // before we poll, determine when the next timeout is (if any)
+        // and handle any expired requests.
+        int64_t nextTimeout = -1;
+        for (map<void*, std::shared_ptr<RequestDetails> >::iterator iter = requestMap.begin();
+             iter != requestMap.end();)
+        {
+            int64_t t = iter->second->timeoutTimeMilliseconds;
+            if (t > 0)
+            {
+                // signed int64 is easily large enough to hold milli or microseconds since 1970
+                int64_t currentTime = (int64_t)(getCurrentTime() / 1e3);
+                if (t <= currentTime)
+                {
+                    std::shared_ptr<RequestDetails> reqDetails = iter->second;
                     reqDetails->requestor->requestTimeout(reqDetails->serviceID, reqDetails->requestID);
                     void* socket = iter->first;
-                    vector<zmq_pollitem_t>::iterator pollItemIter = pollItems.begin() + 2;  // start after internal framework sockets
-                    while(pollItemIter != pollItems.end())
+                    vector<zmq_pollitem_t>::iterator pollItemIter =
+                        pollItems.begin() + 2;  // start after internal framework sockets
+                    while (pollItemIter != pollItems.end())
                     {
                         if (socket == pollItemIter->socket)
                         {
@@ -102,360 +104,368 @@ void GravityRequestManager::start()
                         }
                     }
                     zmq_close(socket);
-                    map<void*,std::shared_ptr<RequestDetails> >::iterator delIter = iter++;
-	                requestMap.erase(delIter);
-	            }
-	            else
-	            {
-	                if (nextTimeout < 0 || t < nextTimeout)
-	                {
-	                    nextTimeout = t - currentTime;
-	                }
-	                iter++;
-	            }
-	        }
-	        else
-	        {
-	            iter++;
-	        }
-	    }
+                    map<void*, std::shared_ptr<RequestDetails> >::iterator delIter = iter++;
+                    requestMap.erase(delIter);
+                }
+                else
+                {
+                    if (nextTimeout < 0 || t < nextTimeout)
+                    {
+                        nextTimeout = t - currentTime;
+                    }
+                    iter++;
+                }
+            }
+            else
+            {
+                iter++;
+            }
+        }
 
-		// Start polling socket(s), blocking while we wait
-		int rc = zmq_poll(&pollItems[0], (int) pollItems.size(), (long) nextTimeout); // 0 --> return immediately, -1 --> blocks
-		if (rc == -1)
-		{
-                    // Interrupted
-                    if (errno == EINTR)
-                        continue;
-                    // Error
-                    break;
-		}
+        // Start polling socket(s), blocking while we wait
+        int rc = zmq_poll(&pollItems[0], (int)pollItems.size(),
+                          (long)nextTimeout);  // 0 --> return immediately, -1 --> blocks
+        if (rc == -1)
+        {
+            // Interrupted
+            if (errno == EINTR) continue;
+            // Error
+            break;
+        }
 
-		// Process new subscription requests from the gravity node
-		if (pollItems[0].revents & ZMQ_POLLIN)
-		{
-			// Get new GravityNode request
-			string command = readStringMessage(pollItems[0].socket);
+        // Process new subscription requests from the gravity node
+        if (pollItems[0].revents & ZMQ_POLLIN)
+        {
+            // Get new GravityNode request
+            string command = readStringMessage(pollItems[0].socket);
 
-			// message from gravity node should be either a request or kill
-			if (command == "request")
-			{
-				processRequest();
-			}
-			else if (command == "kill")
-			{
-				break;
-			}
-			else if (command == "set_service_dir_url")
-			{
-				serviceDirectoryUrl = readStringMessage(gravityNodeSocket);
-			}
-			else
-			{
-				logger->warn("GravityRequestManager received unknown command '{}' from GravityNode", command);
-			}
-		}
+            // message from gravity node should be either a request or kill
+            if (command == "request")
+            {
+                processRequest();
+            }
+            else if (command == "kill")
+            {
+                break;
+            }
+            else if (command == "set_service_dir_url")
+            {
+                serviceDirectoryUrl = readStringMessage(gravityNodeSocket);
+            }
+            else
+            {
+                logger->warn("GravityRequestManager received unknown command '{}' from GravityNode", command);
+            }
+        }
 
-		if (pollItems[1].revents & ZMQ_POLLIN)
-		{
-			// Get new GravityNode request
-			string command = readStringMessage(pollItems[1].socket);
+        if (pollItems[1].revents & ZMQ_POLLIN)
+        {
+            // Get new GravityNode request
+            string command = readStringMessage(pollItems[1].socket);
 
-			if (command == "createFutureResponse")
-			{
-				createFutureResponse();
-			}
-			else if (command == "sendFutureResponse")
-			{
-				sendFutureResponse();
-			}
-		}
+            if (command == "createFutureResponse")
+            {
+                createFutureResponse();
+            }
+            else if (command == "sendFutureResponse")
+            {
+                sendFutureResponse();
+            }
+        }
 
-		// init an iterator past the first element so that we can check active requests
-		// We can't create the iterator untl here because ProcessRequest may add elements
-		// to pollItems which would invalidate the iterator.
+        // init an iterator past the first element so that we can check active requests
+        // We can't create the iterator untl here because ProcessRequest may add elements
+        // to pollItems which would invalidate the iterator.
         vector<zmq_pollitem_t>::iterator pollItemIter = pollItems.begin() + 2;
 
         // Check for responses
-		std::vector<zmq_pollitem_t> newPollItems;
-		while(pollItemIter != pollItems.end())
-		{
-			if (pollItemIter->revents & ZMQ_POLLIN)
-			{
-				zmq_msg_init(&message);
-				zmq_recvmsg(pollItemIter->socket, &message, 0);
-				// Create new GravityDataProduct from the incoming message
-				GravityDataProduct response(zmq_msg_data(&message), (int) zmq_msg_size(&message));
-				// Clean up message
-				zmq_msg_close(&message);
+        std::vector<zmq_pollitem_t> newPollItems;
+        while (pollItemIter != pollItems.end())
+        {
+            if (pollItemIter->revents & ZMQ_POLLIN)
+            {
+                zmq_msg_init(&message);
+                zmq_recvmsg(pollItemIter->socket, &message, 0);
+                // Create new GravityDataProduct from the incoming message
+                GravityDataProduct response(zmq_msg_data(&message), (int)zmq_msg_size(&message));
+                // Clean up message
+                zmq_msg_close(&message);
 
-				if (response.isFutureResponse())
-				{					
-					logger->trace("Received a future response placeholder (url = {})", response.getFutureSocketUrl());
-					// Create REQ socket to interact with future REP socket
-					void* socket = zmq_socket(context, ZMQ_REQ);
-					zmq_connect(socket, response.getFutureSocketUrl().c_str());					
+                if (response.isFutureResponse())
+                {
+                    logger->trace("Received a future response placeholder (url = {})", response.getFutureSocketUrl());
+                    // Create REQ socket to interact with future REP socket
+                    void* socket = zmq_socket(context, ZMQ_REQ);
+                    zmq_connect(socket, response.getFutureSocketUrl().c_str());
 
-					// Send request to future REP socket
-					sendStringMessage(socket, "FUTURE_REQUEST", ZMQ_DONTWAIT);
+                    // Send request to future REP socket
+                    sendStringMessage(socket, "FUTURE_REQUEST", ZMQ_DONTWAIT);
 
-					// Copy request details from original request socket to future request socket
-					requestMap[socket] = requestMap[pollItemIter->socket];					
+                    // Copy request details from original request socket to future request socket
+                    requestMap[socket] = requestMap[pollItemIter->socket];
 
-					// Add new poll item once we're done with this loop
-					zmq_pollitem_t pollItem;
-					pollItem.socket = socket;
-					pollItem.events = ZMQ_POLLIN;
-					pollItem.fd = 0;
-					pollItem.revents = 0;
-					newPollItems.push_back(pollItem);					
-				}
-				else
-				{
-					// Get request details
-					std::shared_ptr<RequestDetails> reqDetails = requestMap[pollItemIter->socket];
+                    // Add new poll item once we're done with this loop
+                    zmq_pollitem_t pollItem;
+                    pollItem.socket = socket;
+                    pollItem.events = ZMQ_POLLIN;
+                    pollItem.fd = 0;
+                    pollItem.revents = 0;
+                    newPollItems.push_back(pollItem);
+                }
+                else
+                {
+                    // Get request details
+                    std::shared_ptr<RequestDetails> reqDetails = requestMap[pollItemIter->socket];
 
-					// Verify the service provider
-					if (response.getRegistrationTime() != reqDetails->registrationTime)
-					{
-						logger->error("Received service ({}) response from invalid service [{} != {}]. Aborting request.",
-							reqDetails->serviceID, response.getRegistrationTime(), reqDetails->registrationTime);
+                    // Verify the service provider
+                    if (response.getRegistrationTime() != reqDetails->registrationTime)
+                    {
+                        logger->error(
+                            "Received service ({}) response from invalid service [{} != {}]. Aborting request.",
+                            reqDetails->serviceID, response.getRegistrationTime(), reqDetails->registrationTime);
 
-						// Send notification of stale data to ServiceDirectory
-						if (response.getRegistrationTime() > 0) {
-						    notifyServiceDirectoryOfStaleEntry(reqDetails->serviceID, reqDetails->url, reqDetails->registrationTime);
-						} else {
-						    logger->debug("Service response appears to be invalid, so not requesting deletion from ServiceDirectory.");
-						}
-					}
-					else
-					{
-						// Deliver to requestor
-						logger->trace("GravityRequestManager: call requestFilled()");
-						reqDetails->requestor->requestFilled(reqDetails->serviceID, reqDetails->requestID, response);
-					}
-				}
+                        // Send notification of stale data to ServiceDirectory
+                        if (response.getRegistrationTime() > 0)
+                        {
+                            notifyServiceDirectoryOfStaleEntry(reqDetails->serviceID, reqDetails->url,
+                                                               reqDetails->registrationTime);
+                        }
+                        else
+                        {
+                            logger->debug(
+                                "Service response appears to be invalid, so not requesting deletion from "
+                                "ServiceDirectory.");
+                        }
+                    }
+                    else
+                    {
+                        // Deliver to requestor
+                        logger->trace("GravityRequestManager: call requestFilled()");
+                        reqDetails->requestor->requestFilled(reqDetails->serviceID, reqDetails->requestID, response);
+                    }
+                }
 
-				zmq_close(pollItemIter->socket);
-				requestMap.erase(pollItemIter->socket);	
-				pollItemIter = pollItems.erase(pollItemIter);
-			}
-			else
-			{
-			    pollItemIter++;
-			}
-		}
+                zmq_close(pollItemIter->socket);
+                requestMap.erase(pollItemIter->socket);
+                pollItemIter = pollItems.erase(pollItemIter);
+            }
+            else
+            {
+                pollItemIter++;
+            }
+        }
 
-		pollItems.insert(pollItems.end(), newPollItems.begin(), newPollItems.end());
-	}
+        pollItems.insert(pollItems.end(), newPollItems.begin(), newPollItems.end());
+    }
 
-	// Clean up all our open sockets
-	for (map<void*,std::shared_ptr<RequestDetails> >::iterator iter = requestMap.begin(); iter != requestMap.end(); iter++)
-	{
-		void* socket = iter->first;
-		zmq_close(socket);
-	}
-	zmq_close(gravityNodeSocket);
-	zmq_close(gravityResponseSocket);
+    // Clean up all our open sockets
+    for (map<void*, std::shared_ptr<RequestDetails> >::iterator iter = requestMap.begin(); iter != requestMap.end();
+         iter++)
+    {
+        void* socket = iter->first;
+        zmq_close(socket);
+    }
+    zmq_close(gravityNodeSocket);
+    zmq_close(gravityResponseSocket);
 }
 
 void GravityRequestManager::notifyServiceDirectoryOfStaleEntry(string serviceId, string url, uint32_t regTime)
 {
-	logger->debug("Notifying ServiceDirectory of stale service: [{} @ {}]", serviceId, url);
-	ServiceDirectoryUnregistrationPB unregistration;
-	unregistration.set_id(serviceId);
-	unregistration.set_url(url);
-	unregistration.set_registration_time(regTime);
-	unregistration.set_type(ServiceDirectoryUnregistrationPB::SERVICE);
+    logger->debug("Notifying ServiceDirectory of stale service: [{} @ {}]", serviceId, url);
+    ServiceDirectoryUnregistrationPB unregistration;
+    unregistration.set_id(serviceId);
+    unregistration.set_url(url);
+    unregistration.set_registration_time(regTime);
+    unregistration.set_type(ServiceDirectoryUnregistrationPB::SERVICE);
 
-	GravityDataProduct request("UnregistrationRequest");
-	request.setData(unregistration);
+    GravityDataProduct request("UnregistrationRequest");
+    request.setData(unregistration);
 
-	void* socket = zmq_socket(context, ZMQ_REQ); // Socket to connect to service provider
-	zmq_connect(socket, serviceDirectoryUrl.c_str());
-	int linger = -1;
-	zmq_setsockopt(socket, ZMQ_LINGER, &linger, sizeof(linger));
+    void* socket = zmq_socket(context, ZMQ_REQ);  // Socket to connect to service provider
+    zmq_connect(socket, serviceDirectoryUrl.c_str());
+    int linger = -1;
+    zmq_setsockopt(socket, ZMQ_LINGER, &linger, sizeof(linger));
 
-	// Send message to service provider
-	sendGravityDataProduct(socket, request, ZMQ_DONTWAIT);
+    // Send message to service provider
+    sendGravityDataProduct(socket, request, ZMQ_DONTWAIT);
 
-	zmq_close(socket);
+    zmq_close(socket);
 }
 
 void GravityRequestManager::ready()
 {
-	// Create the request socket
-	void* initSocket = zmq_socket(context, ZMQ_REQ);
+    // Create the request socket
+    void* initSocket = zmq_socket(context, ZMQ_REQ);
 
-	// Connect to service
-	zmq_connect(initSocket, "inproc://gravity_init");
+    // Connect to service
+    zmq_connect(initSocket, "inproc://gravity_init");
 
-	// Send request to service provider
-	sendStringMessage(initSocket, "GravityRequestManager", ZMQ_DONTWAIT);
+    // Send request to service provider
+    sendStringMessage(initSocket, "GravityRequestManager", ZMQ_DONTWAIT);
 
-	zmq_close(initSocket);
+    zmq_close(initSocket);
 }
 
 void GravityRequestManager::sendFutureResponse()
 {
-	int ret = GravityReturnCodes::SUCCESS;
-	string url = readStringMessage(gravityResponseSocket);
+    int ret = GravityReturnCodes::SUCCESS;
+    string url = readStringMessage(gravityResponseSocket);
 
-	zmq_msg_t message;
-	zmq_msg_init(&message);
+    zmq_msg_t message;
+    zmq_msg_init(&message);
     zmq_recvmsg(gravityResponseSocket, &message, 0);
     // Create new GravityDataProduct from the incoming message
-	GravityDataProduct response(zmq_msg_data(&message), (int) zmq_msg_size(&message));
+    GravityDataProduct response(zmq_msg_data(&message), (int)zmq_msg_size(&message));
     // Clean up message
     zmq_msg_close(&message);
 
-	if (futureResponseUrlToSocketMap.find(url) == futureResponseUrlToSocketMap.end())
-	{
-		logger->warn("Received a future response that is not associated with a REP url ('{}')", url);
-		ret = GravityReturnCodes::FAILURE;
-	}
-	else
-	{
-		void* responseSocket = futureResponseUrlToSocketMap[url];
-		
-		// Poll socket for pending request
-		zmq_pollitem_t pollItems[] = {{responseSocket, 0, ZMQ_POLLIN, 0}};
-		int rc = zmq_poll(pollItems, 1, 2000); // 2 second timeout - this really should be waiting for us
-		if (rc == -1)
-		{
-			ret = GravityReturnCodes::INTERRUPTED;
-		}
-		else if (rc == 0)
-		{
-			ret = GravityReturnCodes::REQUEST_TIMEOUT;
-		}
-		else if (pollItems[0].revents & ZMQ_POLLIN)
-		{
-			// Don't really care about the specifics of the request, just read and discard
-			zmq_msg_init(&message);
-			zmq_recvmsg(responseSocket, &message, 0);
-			zmq_msg_close(&message);
+    if (futureResponseUrlToSocketMap.find(url) == futureResponseUrlToSocketMap.end())
+    {
+        logger->warn("Received a future response that is not associated with a REP url ('{}')", url);
+        ret = GravityReturnCodes::FAILURE;
+    }
+    else
+    {
+        void* responseSocket = futureResponseUrlToSocketMap[url];
 
-			sendGravityDataProduct(responseSocket, response, ZMQ_DONTWAIT);
+        // Poll socket for pending request
+        zmq_pollitem_t pollItems[] = {{responseSocket, 0, ZMQ_POLLIN, 0}};
+        int rc = zmq_poll(pollItems, 1, 2000);  // 2 second timeout - this really should be waiting for us
+        if (rc == -1)
+        {
+            ret = GravityReturnCodes::INTERRUPTED;
+        }
+        else if (rc == 0)
+        {
+            ret = GravityReturnCodes::REQUEST_TIMEOUT;
+        }
+        else if (pollItems[0].revents & ZMQ_POLLIN)
+        {
+            // Don't really care about the specifics of the request, just read and discard
+            zmq_msg_init(&message);
+            zmq_recvmsg(responseSocket, &message, 0);
+            zmq_msg_close(&message);
 
-			// This brief sleep seems to be required to avoid zeromq bug
-			gravity::sleep(100);
-		}
+            sendGravityDataProduct(responseSocket, response, ZMQ_DONTWAIT);
 
-		// Return result
-		sendIntMessage(gravityResponseSocket, ret, ZMQ_DONTWAIT);
+            // This brief sleep seems to be required to avoid zeromq bug
+            gravity::sleep(100);
+        }
 
-		// Clean up the future response socket
-		zmq_close(responseSocket);
-		futureResponseUrlToSocketMap.erase(url);		
-	}
+        // Return result
+        sendIntMessage(gravityResponseSocket, ret, ZMQ_DONTWAIT);
+
+        // Clean up the future response socket
+        zmq_close(responseSocket);
+        futureResponseUrlToSocketMap.erase(url);
+    }
 }
 
 void GravityRequestManager::createFutureResponse()
 {
-	// Read our IP address
-	string ip = readStringMessage(gravityResponseSocket);
+    // Read our IP address
+    string ip = readStringMessage(gravityResponseSocket);
 
-	// Read port range
-	int minPort = readIntMessage(gravityResponseSocket);
-	int maxPort = readIntMessage(gravityResponseSocket);
+    // Read port range
+    int minPort = readIntMessage(gravityResponseSocket);
+    int maxPort = readIntMessage(gravityResponseSocket);
 
-	// Create the response socket
-	void* responseSocket = zmq_socket(context, ZMQ_REP);
+    // Create the response socket
+    void* responseSocket = zmq_socket(context, ZMQ_REP);
 
-	// Bind socket and create URL
-	string url = "";
-	int port = bindFirstAvailablePort(responseSocket, ip, minPort, maxPort);
+    // Bind socket and create URL
+    string url = "";
+    int port = bindFirstAvailablePort(responseSocket, ip, minPort, maxPort);
     if (port < 0)
     {
         logger->error("Could not find available port for FutureResponse");
         zmq_close(responseSocket);
     }
-	else
-	{
-		stringstream ss;
-		ss << "tcp://" << ip << ":" << port;
-		url = ss.str();
+    else
+    {
+        stringstream ss;
+        ss << "tcp://" << ip << ":" << port;
+        url = ss.str();
 
-		futureResponseUrlToSocketMap[url] = responseSocket;
-	}
+        futureResponseUrlToSocketMap[url] = responseSocket;
+    }
 
-	logger->trace("GravityRequestManager::createFutureResponse(): URL = '{}'", url);
+    logger->trace("GravityRequestManager::createFutureResponse(): URL = '{}'", url);
 
-	sendStringMessage(gravityResponseSocket, url, ZMQ_DONTWAIT);
+    sendStringMessage(gravityResponseSocket, url, ZMQ_DONTWAIT);
 }
 
 void GravityRequestManager::processRequest()
 {
-	// Read the service id for this request
-	string serviceID = readStringMessage(gravityNodeSocket);
+    // Read the service id for this request
+    string serviceID = readStringMessage(gravityNodeSocket);
 
-	// Read the service url
-	string url = readStringMessage(gravityNodeSocket);
+    // Read the service url
+    string url = readStringMessage(gravityNodeSocket);
 
-	// Read the request ID
-	string requestID = readStringMessage(gravityNodeSocket);
+    // Read the request ID
+    string requestID = readStringMessage(gravityNodeSocket);
 
-	int timeout_milliseconds = readIntMessage(gravityNodeSocket);
-	int64_t timeoutTimeMilliseconds = -1;
-	// calculate an actual time in milliseconds
-	if (timeout_milliseconds > 0)
-	{
-	    timeoutTimeMilliseconds = (int64_t) (getCurrentTime() / 1e3 + timeout_milliseconds);
-	}
+    int timeout_milliseconds = readIntMessage(gravityNodeSocket);
+    int64_t timeoutTimeMilliseconds = -1;
+    // calculate an actual time in milliseconds
+    if (timeout_milliseconds > 0)
+    {
+        timeoutTimeMilliseconds = (int64_t)(getCurrentTime() / 1e3 + timeout_milliseconds);
+    }
 
-	uint32_t regTime = readUint32Message(gravityNodeSocket);
+    uint32_t regTime = readUint32Message(gravityNodeSocket);
 
-	// Read the data product
-	zmq_msg_t msg;
-	zmq_msg_init(&msg);
-	zmq_recvmsg(gravityNodeSocket, &msg, -1);
-	GravityDataProduct dataProduct(zmq_msg_data(&msg), (int) zmq_msg_size(&msg));
-	zmq_msg_close(&msg);
-	dataProduct.setRegistrationTime(regTime);
+    // Read the data product
+    zmq_msg_t msg;
+    zmq_msg_init(&msg);
+    zmq_recvmsg(gravityNodeSocket, &msg, -1);
+    GravityDataProduct dataProduct(zmq_msg_data(&msg), (int)zmq_msg_size(&msg));
+    zmq_msg_close(&msg);
+    dataProduct.setRegistrationTime(regTime);
 
-	// Read the data product
-	zmq_msg_init(&msg);
-	zmq_recvmsg(gravityNodeSocket, &msg, -1);
-	GravityRequestor* requestor;
-	memcpy(&requestor, zmq_msg_data(&msg), zmq_msg_size(&msg));
-	zmq_msg_close(&msg);
+    // Read the data product
+    zmq_msg_init(&msg);
+    zmq_recvmsg(gravityNodeSocket, &msg, -1);
+    GravityRequestor* requestor;
+    memcpy(&requestor, zmq_msg_data(&msg), zmq_msg_size(&msg));
+    zmq_msg_close(&msg);
 
-	std::shared_ptr<RequestDetails> reqDetails;
+    std::shared_ptr<RequestDetails> reqDetails;
 
-	// Create the request socket
-	void* reqSocket = zmq_socket(context, ZMQ_REQ);
+    // Create the request socket
+    void* reqSocket = zmq_socket(context, ZMQ_REQ);
 
-	// Connect to service
-	zmq_connect(reqSocket, url.c_str());
+    // Connect to service
+    zmq_connect(reqSocket, url.c_str());
     int linger = 0;
     zmq_setsockopt(reqSocket, ZMQ_LINGER, &linger, sizeof(linger));
 
-	// Send data product
-	zmq_msg_t data;
-	zmq_msg_init_size(&data, dataProduct.getSize());
-	dataProduct.serializeToArray(zmq_msg_data(&data));
-	zmq_sendmsg(reqSocket, &data, ZMQ_DONTWAIT);
-	zmq_msg_close(&data);
+    // Send data product
+    zmq_msg_t data;
+    zmq_msg_init_size(&data, dataProduct.getSize());
+    dataProduct.serializeToArray(zmq_msg_data(&data));
+    zmq_sendmsg(reqSocket, &data, ZMQ_DONTWAIT);
+    zmq_msg_close(&data);
 
-	// Create poll item for response to this request
-	zmq_pollitem_t pollItem;
-	pollItem.socket = reqSocket;
-	pollItem.events = ZMQ_POLLIN;
-	pollItem.fd = 0;
-	pollItem.revents = 0;
-	pollItems.push_back(pollItem);
+    // Create poll item for response to this request
+    zmq_pollitem_t pollItem;
+    pollItem.socket = reqSocket;
+    pollItem.events = ZMQ_POLLIN;
+    pollItem.fd = 0;
+    pollItem.revents = 0;
+    pollItems.push_back(pollItem);
 
-	// Create request details
-	reqDetails.reset(new RequestDetails());
-	reqDetails->serviceID = serviceID;
-	reqDetails->requestID = requestID;
-	reqDetails->requestor = requestor;
-	reqDetails->timeoutTimeMilliseconds = timeoutTimeMilliseconds;
-	reqDetails->registrationTime = regTime;
-	reqDetails->url = url;
-	
-	requestMap[reqSocket] = reqDetails;
+    // Create request details
+    reqDetails.reset(new RequestDetails());
+    reqDetails->serviceID = serviceID;
+    reqDetails->requestID = requestID;
+    reqDetails->requestor = requestor;
+    reqDetails->timeoutTimeMilliseconds = timeoutTimeMilliseconds;
+    reqDetails->registrationTime = regTime;
+    reqDetails->url = url;
+
+    requestMap[reqSocket] = reqDetails;
 }
 
 } /* namespace gravity */

--- a/src/api/cpp/GravityRequestManager.h
+++ b/src/api/cpp/GravityRequestManager.h
@@ -36,50 +36,50 @@ namespace gravity
 
 typedef struct RequestDetails
 {
-	std::string serviceID;
-	std::string requestID;
-	int64_t timeoutTimeMilliseconds;
-	GravityRequestor* requestor;
-	uint32_t registrationTime;
-	std::string url;
+    std::string serviceID;
+    std::string requestID;
+    int64_t timeoutTimeMilliseconds;
+    GravityRequestor* requestor;
+    uint32_t registrationTime;
+    std::string url;
 } RequestDetails;
 
 class GravityRequestManager
 {
 private:
-	void* context;
-	void* gravityNodeSocket;
-	void* gravityResponseSocket;
-	std::map<void*,std::shared_ptr<RequestDetails> > requestMap;
-	std::vector<zmq_pollitem_t> pollItems;
-	std::map<std::string,void*> futureResponseUrlToSocketMap;
-	void processRequest();
-	void createFutureResponse();
-	void sendFutureResponse();
-	void ready();
+    void* context;
+    void* gravityNodeSocket;
+    void* gravityResponseSocket;
+    std::map<void*, std::shared_ptr<RequestDetails> > requestMap;
+    std::vector<zmq_pollitem_t> pollItems;
+    std::map<std::string, void*> futureResponseUrlToSocketMap;
+    void processRequest();
+    void createFutureResponse();
+    void sendFutureResponse();
+    void ready();
 
-	std::string serviceDirectoryUrl;
-	void notifyServiceDirectoryOfStaleEntry(std::string serviceId, std::string url, uint32_t regTime);
-	
-	std::shared_ptr<spdlog::logger> logger;
-	
+    std::string serviceDirectoryUrl;
+    void notifyServiceDirectoryOfStaleEntry(std::string serviceId, std::string url, uint32_t regTime);
+
+    std::shared_ptr<spdlog::logger> logger;
+
 public:
-	/**
+    /**
 	 * Constructor GravityRequestManager
 	 * \param context The zmq context in which the socket will be established with the service provider
 	 */
-	GravityRequestManager(void* context);
+    GravityRequestManager(void* context);
 
-	/**
+    /**
 	 * Default destructor
 	 */
-	virtual ~GravityRequestManager();
+    virtual ~GravityRequestManager();
 
-	/**
+    /**
 	 * Starts the GravityRequestManager which will manage the request/response communication with
 	 * the service provider
 	 */
-	void start();
+    void start();
 };
 
 } /* namespace gravity */

--- a/src/api/cpp/GravityRequestor.cpp
+++ b/src/api/cpp/GravityRequestor.cpp
@@ -27,7 +27,8 @@
 #include "GravityLogger.h"
 #include "spdlog/spdlog.h"
 
-namespace gravity {
+namespace gravity
+{
 
 using namespace std;
 
@@ -38,8 +39,4 @@ GRAVITY_API void GravityRequestor::requestTimeout(std::string serviceID, std::st
     spdlog::get("GravityLogger")->warn("Request timed out: service id = {}, request id = {}", serviceID, requestID);
 }
 
-}
-
-
-
-
+}  // namespace gravity

--- a/src/api/cpp/GravityRequestor.h
+++ b/src/api/cpp/GravityRequestor.h
@@ -48,7 +48,8 @@ public:
      * \param requestID ID of the request that was made
      * \param response GravityDataProduct containing the data of the response
      */
-    GRAVITY_API virtual void requestFilled(std::string serviceID, std::string requestID, const GravityDataProduct& response) = 0;
+    GRAVITY_API virtual void requestFilled(std::string serviceID, std::string requestID,
+                                           const GravityDataProduct& response) = 0;
 
     /**
      * Called when the response to a request has timed out. 
@@ -59,6 +60,5 @@ public:
 };
 
 } /* namespace gravity */
-
 
 #endif /* GRAVITYREQUESTOR_H_ */

--- a/src/api/cpp/GravitySemaphore.h
+++ b/src/api/cpp/GravitySemaphore.h
@@ -30,15 +30,16 @@ namespace gravity
 class Semaphore
 {
 public:
-	GRAVITY_API Semaphore();
-	GRAVITY_API Semaphore(int count);
-	GRAVITY_API void Lock();
-	GRAVITY_API void Unlock();
-	GRAVITY_API ~Semaphore();
+    GRAVITY_API Semaphore();
+    GRAVITY_API Semaphore(int count);
+    GRAVITY_API void Lock();
+    GRAVITY_API void Unlock();
+    GRAVITY_API ~Semaphore();
+
 private:
-	sem_t semaphore;
+    sem_t semaphore;
 };
 
-}
+}  // namespace gravity
 
-#endif //ZMQ_SEMEPHORE_H__
+#endif  //ZMQ_SEMEPHORE_H__

--- a/src/api/cpp/GravityServiceManager.h
+++ b/src/api/cpp/GravityServiceManager.h
@@ -38,7 +38,7 @@ namespace gravity
 
 typedef struct ServiceDetails
 {
-	std::string serviceID;
+    std::string serviceID;
     std::string url;
     zmq_pollitem_t pollItem;
     GravityServiceProvider* server;
@@ -47,32 +47,33 @@ typedef struct ServiceDetails
 class GravityServiceManager
 {
 private:
-	void* context;
-	void* gravityNodeSocket;
-	std::map<void*,std::shared_ptr<ServiceDetails> > serviceMapBySocket;
-	std::map<std::string, std::shared_ptr<ServiceDetails> > serviceMapByServiceID;
-	std::map<std::string, uint32_t> serviceRegistrationTimeMap;
-	std::vector<zmq_pollitem_t> pollItems;
-	void addService();
-	void removeService();
-	void ready();
-	std::shared_ptr<spdlog::logger> logger;
+    void* context;
+    void* gravityNodeSocket;
+    std::map<void*, std::shared_ptr<ServiceDetails> > serviceMapBySocket;
+    std::map<std::string, std::shared_ptr<ServiceDetails> > serviceMapByServiceID;
+    std::map<std::string, uint32_t> serviceRegistrationTimeMap;
+    std::vector<zmq_pollitem_t> pollItems;
+    void addService();
+    void removeService();
+    void ready();
+    std::shared_ptr<spdlog::logger> logger;
+
 public:
-	/**
+    /**
 	 * Constructor GravityServiceManager
 	 * \param context The zmq context used for connections
 	 */
-	GravityServiceManager(void* context);
+    GravityServiceManager(void* context);
 
-	/**
+    /**
 	 * Default destructor
 	 */
-	virtual ~GravityServiceManager();
+    virtual ~GravityServiceManager();
 
-	/**
+    /**
 	 * Starts the GravityServiceManager which will manage the communication with the service client
 	 */
-	void start();
+    void start();
 };
 
 } /* namespace gravity */

--- a/src/api/cpp/GravityServiceProvider.cpp
+++ b/src/api/cpp/GravityServiceProvider.cpp
@@ -26,14 +26,11 @@
 #include "GravityServiceProvider.h"
 #include "Utility.h"
 
-namespace gravity {
+namespace gravity
+{
 
 using namespace std;
 
 GravityServiceProvider::~GravityServiceProvider() {}
 
-}
-
-
-
-
+}  // namespace gravity

--- a/src/api/cpp/GravityServiceProvider.h
+++ b/src/api/cpp/GravityServiceProvider.h
@@ -48,10 +48,10 @@ public:
      * \param dataProduct GravityDataProduct with request data
      * \returns GravityDataProduct with the response
      */
-    virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID, const GravityDataProduct& dataProduct) = 0;
+    virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID,
+                                                        const GravityDataProduct& dataProduct) = 0;
 };
 
 } /* namespace gravity */
-
 
 #endif /* GRAVITYSERVICEPROVIDER_H_ */

--- a/src/api/cpp/GravitySubscriber.cpp
+++ b/src/api/cpp/GravitySubscriber.cpp
@@ -27,13 +27,10 @@
 
 #include <memory>
 
-namespace gravity {
+namespace gravity
+{
 
 GravitySubscriber::~GravitySubscriber() {}
 //TODO: REMOVE IMPLEMENTATION
-void GravitySubscriber::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts) {}
-}
-
-
-
-
+void GravitySubscriber::subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts) {}
+}  // namespace gravity

--- a/src/api/cpp/GravitySubscriber.h
+++ b/src/api/cpp/GravitySubscriber.h
@@ -46,7 +46,8 @@ public:
      * Called on implementing object when a registered subscription is filled with 1 or more GravityDataProducts
      * \param dataProducts the data products that fill the registered subscription
      */
-    GRAVITY_API virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts) = 0;
+    GRAVITY_API virtual void subscriptionFilled(
+        const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts) = 0;
 };
 
 } /* namespace gravity */

--- a/src/api/cpp/GravitySubscriptionManager.cpp
+++ b/src/api/cpp/GravitySubscriptionManager.cpp
@@ -38,51 +38,50 @@ namespace gravity
 
 using namespace std;
 
-bool sortCacheValues (const std::shared_ptr<GravityDataProduct> &i, const std::shared_ptr<GravityDataProduct> &j)
+bool sortCacheValues(const std::shared_ptr<GravityDataProduct>& i, const std::shared_ptr<GravityDataProduct>& j)
 {
     return i->getGravityTimestamp() < j->getGravityTimestamp();
 }
 
-
 GravitySubscriptionManager::GravitySubscriptionManager(void* context)
 {
-	// This is the zmq context that is shared with the GravityNode. Must use
-	// a shared context to establish an inproc socket.
-	this->context = context;
+    // This is the zmq context that is shared with the GravityNode. Must use
+    // a shared context to establish an inproc socket.
+    this->context = context;
 
     // Default to no metrics
     metricsEnabled = false;
 
-	// Default high water mark
-	subscribeHWM = 1000;
-	
-	// Get logger
-	logger = spdlog::get("GravityLogger");
+    // Default high water mark
+    subscribeHWM = 1000;
+
+    // Get logger
+    logger = spdlog::get("GravityLogger");
 }
 
 GravitySubscriptionManager::~GravitySubscriptionManager() {}
 
 void GravitySubscriptionManager::start()
 {
-	vector<pair<std::shared_ptr<SubscriptionDetails>, void*> > deleteList;
+    vector<pair<std::shared_ptr<SubscriptionDetails>, void*> > deleteList;
 
     // Set up the inproc socket to subscribe to subscribe and unsubscribe messages from
-	// the GravityNode
-	gravityNodeSocket = zmq_socket(context, ZMQ_SUB);
-	zmq_connect(gravityNodeSocket, "inproc://gravity_subscription_manager");
-	zmq_setsockopt(gravityNodeSocket, ZMQ_SUBSCRIBE, NULL, 0);
+    // the GravityNode
+    gravityNodeSocket = zmq_socket(context, ZMQ_SUB);
+    zmq_connect(gravityNodeSocket, "inproc://gravity_subscription_manager");
+    zmq_setsockopt(gravityNodeSocket, ZMQ_SUBSCRIBE, NULL, 0);
 
     // Setup socket to reponsd to metrics requests
     gravityMetricsSocket = zmq_socket(context, ZMQ_REP);
     zmq_bind(gravityMetricsSocket, GRAVITY_SUB_METRICS_REQ);
 
-	// Poll the gravity node
-	zmq_pollitem_t pollItem;
-	pollItem.socket = gravityNodeSocket;
-	pollItem.events = ZMQ_POLLIN;
-	pollItem.fd = 0;
-	pollItem.revents = 0;
-	pollItems.push_back(pollItem);
+    // Poll the gravity node
+    zmq_pollitem_t pollItem;
+    pollItem.socket = gravityNodeSocket;
+    pollItem.events = ZMQ_POLLIN;
+    pollItem.fd = 0;
+    pollItem.revents = 0;
+    pollItems.push_back(pollItem);
 
     // Poll the metrics request socket
     zmq_pollitem_t metricsRequestPollItem;
@@ -92,128 +91,130 @@ void GravitySubscriptionManager::start()
     metricsRequestPollItem.revents = 0;
     pollItems.push_back(metricsRequestPollItem);
 
-	void* configureSocket=zmq_socket(context,ZMQ_SUB);
-	zmq_connect(configureSocket,"inproc://gravity_subscription_manager_configure");
-	zmq_setsockopt(configureSocket, ZMQ_SUBSCRIBE, NULL, 0);
+    void* configureSocket = zmq_socket(context, ZMQ_SUB);
+    zmq_connect(configureSocket, "inproc://gravity_subscription_manager_configure");
+    zmq_setsockopt(configureSocket, ZMQ_SUBSCRIBE, NULL, 0);
 
-	// Always have at least the gravity node to poll
-	zmq_pollitem_t configItem;
-	configItem.socket = configureSocket;
-	configItem.events = ZMQ_POLLIN;
-	configItem.fd = 0;
-	configItem.revents = 0;
+    // Always have at least the gravity node to poll
+    zmq_pollitem_t configItem;
+    configItem.socket = configureSocket;
+    configItem.events = ZMQ_POLLIN;
+    configItem.fd = 0;
+    configItem.revents = 0;
 
-	ready();
+    ready();
 
-	//receive Gravity node parameters
-	bool configured = false;
-	while(!configured)
-	{
-		// Start polling socket(s), blocking while we wait
-		int rc = zmq_poll(&configItem, 1, -1); // 0 --> return immediately, -1 --> blocks
-		if (rc == -1)
-		{
-                    // Interrupted
-                    if (errno == EINTR)
-                        continue;
-                    // Error
-                    break;
-		}
+    //receive Gravity node parameters
+    bool configured = false;
+    while (!configured)
+    {
+        // Start polling socket(s), blocking while we wait
+        int rc = zmq_poll(&configItem, 1, -1);  // 0 --> return immediately, -1 --> blocks
+        if (rc == -1)
+        {
+            // Interrupted
+            if (errno == EINTR) continue;
+            // Error
+            break;
+        }
 
-		// Process new subscription requests from the gravity node
-		if (configItem.revents & ZMQ_POLLIN)
-		{
-			string command = readStringMessage(configureSocket);
-			if(command == "configure")
-			{
-				//receive Gravity node details
-				domain = readStringMessage(configureSocket);
-				componentID = readStringMessage(configureSocket);
-				ipAddress = readStringMessage(configureSocket);
+        // Process new subscription requests from the gravity node
+        if (configItem.revents & ZMQ_POLLIN)
+        {
+            string command = readStringMessage(configureSocket);
+            if (command == "configure")
+            {
+                //receive Gravity node details
+                domain = readStringMessage(configureSocket);
+                componentID = readStringMessage(configureSocket);
+                ipAddress = readStringMessage(configureSocket);
 
-				configured=true;
-			}
-		}
-	}
+                configured = true;
+            }
+        }
+    }
 
-	zmq_close(configureSocket);
+    zmq_close(configureSocket);
 
-	// Process forever...
-	while (true)
-	{
-		calculateTimeout();
-		int rc = zmq_poll(&pollItems[0], pollItems.size(), pollTimeout); // 0 --> return immediately, -1 --> blocks
-                if (rc == -1)
-                {
-                    // Interrupted
-                    if (errno == EINTR)
-                    {
-                        continue;
-                    }
-                    // Error
-                    logger->debug("zmq_poll error, exiting (errno = {})", errno);
-                    break;
-                }
+    // Process forever...
+    while (true)
+    {
+        calculateTimeout();
+        int rc = zmq_poll(&pollItems[0], pollItems.size(), pollTimeout);  // 0 --> return immediately, -1 --> blocks
+        if (rc == -1)
+        {
+            // Interrupted
+            if (errno == EINTR)
+            {
+                continue;
+            }
+            // Error
+            logger->debug("zmq_poll error, exiting (errno = {})", errno);
+            break;
+        }
 
-		// If timeout occured
-		if(rc == 0)
-		{
-			if (currTimeoutMonitor != NULL)
-			{				
-				//calculate time since last subscription
-				uint64_t currTime =  getCurrentTime()/1000;
-				int timeSinceLast = (currTimeoutMonitor->lastReceived)!=-1l?(int)(currTime-currTimeoutMonitor->lastReceived):-1;				
-				(currTimeoutMonitor->monitor)->subscriptionTimeout(currMonitorDetails->dataProductID, timeSinceLast, currMonitorDetails->filter, currMonitorDetails->domain);
-				//reset timeout for the current monitor
-				currTimeoutMonitor->endTime = currTimeoutMonitor->endTime + currTimeoutMonitor->timeout;
-				logger->trace("Subscription Timeout ({})",currMonitorDetails->dataProductID);
-			}
-			continue;
-		}
+        // If timeout occured
+        if (rc == 0)
+        {
+            if (currTimeoutMonitor != NULL)
+            {
+                //calculate time since last subscription
+                uint64_t currTime = getCurrentTime() / 1000;
+                int timeSinceLast =
+                    (currTimeoutMonitor->lastReceived) != -1l ? (int)(currTime - currTimeoutMonitor->lastReceived) : -1;
+                (currTimeoutMonitor->monitor)
+                    ->subscriptionTimeout(currMonitorDetails->dataProductID, timeSinceLast, currMonitorDetails->filter,
+                                          currMonitorDetails->domain);
+                //reset timeout for the current monitor
+                currTimeoutMonitor->endTime = currTimeoutMonitor->endTime + currTimeoutMonitor->timeout;
+                logger->trace("Subscription Timeout ({})", currMonitorDetails->dataProductID);
+            }
+            continue;
+        }
 
-		// Process new subscription requests from the gravity node
-		if (pollItems[0].revents & ZMQ_POLLIN)
-		{
-			// Get new GravityNode request
-			string command = readStringMessage(gravityNodeSocket);
+        // Process new subscription requests from the gravity node
+        if (pollItems[0].revents & ZMQ_POLLIN)
+        {
+            // Get new GravityNode request
+            string command = readStringMessage(gravityNodeSocket);
 
-			logger->trace("Received command [{}]", command);
+            logger->trace("Received command [{}]", command);
 
-			// message from gravity node should be either a subscribe or unsubscribe request
-			if (command == "subscribe")
-			{
-				logger->trace("About to add subscription");
-				addSubscription();
-			}
-			else if (command == "unsubscribe")
-			{
-				removeSubscription();
-			}
-			else if (command == "kill")
-			{
-				break;
-			}
-			else if (command == "set_hwm")
-			{
-				setHWM();
-			}
-			else if (command == "set_monitor")
-			{
-				setTimeoutMonitor();
-			}
-			else if (command == "clear_monitor")
-			{		
-				clearTimeoutMonitor();
-			}
-			else if (command == "set_service_dir_url")
-			{
-				serviceDirectoryUrl = readStringMessage(gravityNodeSocket);
-			}
-			else
-			{
-				logger->warn("GravitySubscriptionManager received unknown command '{}' from GravityNode", command);
-			}
-		}
+            // message from gravity node should be either a subscribe or unsubscribe request
+            if (command == "subscribe")
+            {
+                logger->trace("About to add subscription");
+                addSubscription();
+            }
+            else if (command == "unsubscribe")
+            {
+                removeSubscription();
+            }
+            else if (command == "kill")
+            {
+                break;
+            }
+            else if (command == "set_hwm")
+            {
+                setHWM();
+            }
+            else if (command == "set_monitor")
+            {
+                setTimeoutMonitor();
+            }
+            else if (command == "clear_monitor")
+            {
+                clearTimeoutMonitor();
+            }
+            else if (command == "set_service_dir_url")
+            {
+                serviceDirectoryUrl = readStringMessage(gravityNodeSocket);
+            }
+            else
+            {
+                logger->warn("GravitySubscriptionManager received unknown command '{}' from GravityNode", command);
+            }
+        }
 
         if (pollItems[1].revents & ZMQ_POLLIN)
         {
@@ -255,52 +256,55 @@ void GravitySubscriptionManager::start()
             }
         }
 
-		// Check for subscription updates
-		for (unsigned int index = 2; index < pollItems.size(); index++)
-		{
-			string url = "<PUBLISHER UPDATES>";
-			if (subscriptionSocketMap.find(pollItems[index].socket) != subscriptionSocketMap.end())
-			{
-				url = subscriptionSocketMap[pollItems[index].socket]->socketToUrlMap[pollItems[index].socket];
-			}
-	        logger->trace("Checking poll item: index = {}, size = {}, url={}", index, pollItems.size(), url);
-			if (pollItems[index].revents & ZMQ_POLLIN)
-			{
-			    // if it's a regular subscription poll item
-			    if (subscriptionSocketMap.count(pollItems[index].socket) > 0)
-			    {
+        // Check for subscription updates
+        for (unsigned int index = 2; index < pollItems.size(); index++)
+        {
+            string url = "<PUBLISHER UPDATES>";
+            if (subscriptionSocketMap.find(pollItems[index].socket) != subscriptionSocketMap.end())
+            {
+                url = subscriptionSocketMap[pollItems[index].socket]->socketToUrlMap[pollItems[index].socket];
+            }
+            logger->trace("Checking poll item: index = {}, size = {}, url={}", index, pollItems.size(), url);
+            if (pollItems[index].revents & ZMQ_POLLIN)
+            {
+                // if it's a regular subscription poll item
+                if (subscriptionSocketMap.count(pollItems[index].socket) > 0)
+                {
                     // Deliver to subscriber(s)
-			        std::shared_ptr<SubscriptionDetails> subDetails = subscriptionSocketMap[pollItems[index].socket];
+                    std::shared_ptr<SubscriptionDetails> subDetails = subscriptionSocketMap[pollItems[index].socket];
 
-                    vector< std::shared_ptr<GravityDataProduct> > dataProducts;
+                    vector<std::shared_ptr<GravityDataProduct> > dataProducts;
                     while (true)
                     {
                         string filterText;
                         std::shared_ptr<GravityDataProduct> dataProduct;
-                        if (readSubscription(pollItems[index].socket, filterText, dataProduct) < 0)
+                        if (readSubscription(pollItems[index].socket, filterText, dataProduct) < 0) break;
+
+                        // Verify publisher
+                        if (socketVerificationMap[pollItems[index].socket] != dataProduct->getRegistrationTime())
+                        {
+                            // Published data does not match publisher
+                            logger->critical(
+                                "Received data product ({}) from publisher different from registered with "
+                                "ServiceDirectory [{} != {}]",
+                                dataProduct->getDataProductID(), socketVerificationMap[pollItems[index].socket],
+                                dataProduct->getRegistrationTime());
+
+                            // Notify Service Directory of stale entry
+                            notifyServiceDirectoryOfStaleEntry(subDetails->dataProductID, subDetails->domain, url,
+                                                               socketVerificationMap[pollItems[index].socket]);
+
+                            // Unsubscribe
+                            //unsubscribeFromPollItem(pollItems[index], filterText);
+
+                            // Add this socket to the to be deleted list
+                            deleteList.push_back(std::make_pair(subDetails, pollItems[index].socket));
+
                             break;
+                        }
 
-						// Verify publisher
-						if (socketVerificationMap[pollItems[index].socket] != dataProduct->getRegistrationTime())
-						{
-							// Published data does not match publisher
-							logger->critical("Received data product ({}) from publisher different from registered with ServiceDirectory [{} != {}]",
-											dataProduct->getDataProductID(), socketVerificationMap[pollItems[index].socket], 
-											dataProduct->getRegistrationTime());								
-							
-							// Notify Service Directory of stale entry
-							notifyServiceDirectoryOfStaleEntry(subDetails->dataProductID, subDetails->domain, url, socketVerificationMap[pollItems[index].socket]);
-
-							// Unsubscribe
-							//unsubscribeFromPollItem(pollItems[index], filterText);
-
-							// Add this socket to the to be deleted list
-							deleteList.push_back(std::make_pair(subDetails, pollItems[index].socket));
-
-							break;
-						}
-
-                        std::shared_ptr<GravityDataProduct> lastCachedValue = lastCachedValueMap[pollItems[index].socket];
+                        std::shared_ptr<GravityDataProduct> lastCachedValue =
+                            lastCachedValueMap[pollItems[index].socket];
 
                         // if it's been relayed, it will come in on a different socket than the original.  Look at all cached values
                         // to try to filter out duplicates.
@@ -309,13 +313,14 @@ void GravitySubscriptionManager::start()
                         bool cachedRelay = false;
                         if (!lastCachedValue && dataProduct->isRelayedDataproduct())
                         {
-                            for (map<void*, std::shared_ptr<GravityDataProduct> >::const_iterator mapIter = lastCachedValueMap.begin();
-                                    mapIter != lastCachedValueMap.end(); mapIter++)
+                            for (map<void*, std::shared_ptr<GravityDataProduct> >::const_iterator mapIter =
+                                     lastCachedValueMap.begin();
+                                 mapIter != lastCachedValueMap.end(); mapIter++)
                             {
                                 if (mapIter->second &&
-                                        mapIter->second->getGravityTimestamp() == dataProduct->getGravityTimestamp() &&
-                                        mapIter->second->getComponentId() == dataProduct->getComponentId() &&
-                                        *(mapIter->second) == *dataProduct) // only compares product id and data
+                                    mapIter->second->getGravityTimestamp() == dataProduct->getGravityTimestamp() &&
+                                    mapIter->second->getComponentId() == dataProduct->getComponentId() &&
+                                    *(mapIter->second) == *dataProduct)  // only compares product id and data
                                 {
                                     cachedRelay = true;
                                     break;
@@ -325,56 +330,60 @@ void GravitySubscriptionManager::start()
 
                         // This may be a resend of previous value if a new subscriber was added, so make sure this is new data
                         if (!cachedRelay &&
-                              (!lastCachedValue ||
-                               lastCachedValue->getGravityTimestamp() < dataProduct->getGravityTimestamp() ||
-                               // or if timestamps are the same, but GDP's are different
-                               (lastCachedValue->getGravityTimestamp() == dataProduct->getGravityTimestamp() && !(*lastCachedValue == *dataProduct))))
+                            (!lastCachedValue ||
+                             lastCachedValue->getGravityTimestamp() < dataProduct->getGravityTimestamp() ||
+                             // or if timestamps are the same, but GDP's are different
+                             (lastCachedValue->getGravityTimestamp() == dataProduct->getGravityTimestamp() &&
+                              !(*lastCachedValue == *dataProduct))))
                         {
+                            // Grab current time now for stamping received_timestamp on received data products
+                            dataProduct->setReceivedTimestamp(getCurrentTime());
 
-							// Grab current time now for stamping received_timestamp on received data products
-							dataProduct->setReceivedTimestamp(getCurrentTime());
-																												
-							if(dataProduct->isCachedDataproduct() && subDetails->receiveCachedDataProducts == false){
-								// if it's cached and we're not receiving cached, do nothing
-								logger->trace("Ignoring cached data product");
-							}
-							else
-							{														
-								// Add data product to vector to be provided to the subscriber								
-								logger->trace(dataProduct->isCachedDataproduct() ? "Accepting cached data product" : "Accepting new data product");
-								dataProducts.push_back(dataProduct);
-							}
-								// Save most recent value so we can provide it to new subscribers, and to perform check above.
-								lastCachedValueMap[pollItems[index].socket] = dataProduct;
-							
+                            if (dataProduct->isCachedDataproduct() && subDetails->receiveCachedDataProducts == false)
+                            {
+                                // if it's cached and we're not receiving cached, do nothing
+                                logger->trace("Ignoring cached data product");
+                            }
+                            else
+                            {
+                                // Add data product to vector to be provided to the subscriber
+                                logger->trace(dataProduct->isCachedDataproduct() ? "Accepting cached data product"
+                                                                                 : "Accepting new data product");
+                                dataProducts.push_back(dataProduct);
+                            }
+                            // Save most recent value so we can provide it to new subscribers, and to perform check above.
+                            lastCachedValueMap[pollItems[index].socket] = dataProduct;
                         }
-                    }                
+                    }
 
                     // Loop through all subscribers and deliver the messages
-					if(dataProducts.size() != 0)
-					{
-						logger->trace("received {} gdp's, about to send to {} subscribers", dataProducts.size(), subDetails->subscribers.size());
+                    if (dataProducts.size() != 0)
+                    {
+                        logger->trace("received {} gdp's, about to send to {} subscribers", dataProducts.size(),
+                                      subDetails->subscribers.size());
 
-						for (set<GravitySubscriber*>::iterator iter = subDetails->subscribers.begin(); iter != subDetails->subscribers.end(); iter++)
-						{
-							(*iter)->subscriptionFilled(dataProducts);
-						}
-						uint64_t currTime = getCurrentTime()/1000;
-						for (set<std::shared_ptr<TimeoutMonitor> >::iterator iter = subDetails->monitors.begin(); iter != subDetails->monitors.end(); iter++)
-						{						
-							(*iter)->lastReceived = (int64_t) currTime;
-							(*iter)->endTime = currTime + (*iter)->timeout;
-						}
+                        for (set<GravitySubscriber*>::iterator iter = subDetails->subscribers.begin();
+                             iter != subDetails->subscribers.end(); iter++)
+                        {
+                            (*iter)->subscriptionFilled(dataProducts);
+                        }
+                        uint64_t currTime = getCurrentTime() / 1000;
+                        for (set<std::shared_ptr<TimeoutMonitor> >::iterator iter = subDetails->monitors.begin();
+                             iter != subDetails->monitors.end(); iter++)
+                        {
+                            (*iter)->lastReceived = (int64_t)currTime;
+                            (*iter)->endTime = currTime + (*iter)->timeout;
+                        }
 
                         if (metricsEnabled)
                         {
                             collectMetrics(dataProducts);
                         }
-					}
+                    }
                 }
-			    else // it's a publisher update list from the SD
-			    {
-			        std::shared_ptr<GravityDataProduct> dataProduct;
+                else  // it's a publisher update list from the SD
+                {
+                    std::shared_ptr<GravityDataProduct> dataProduct;
                     string dataProductID;
                     readSubscription(pollItems[index].socket, dataProductID, dataProduct);
                     if (dataProductID.empty())
@@ -384,79 +393,84 @@ void GravitySubscriptionManager::start()
                     }
                     ComponentDataLookupResponsePB update;
                     dataProduct->populateMessage(update);
-					string domain = update.domain_id();
-                    logger->trace("Found update to publishers list for data product {} (domain:{})", dataProductID, domain);
+                    string domain = update.domain_id();
+                    logger->trace("Found update to publishers list for data product {} (domain:{})", dataProductID,
+                                  domain);
 
-					// Create the domain/data key for tracking subscriptions
-					DomainDataKey key(domain, dataProductID);
-					logger->trace("subscriptionMap.count(key) = {}", subscriptionMap.count(key));
+                    // Create the domain/data key for tracking subscriptions
+                    DomainDataKey key(domain, dataProductID);
+                    logger->trace("subscriptionMap.count(key) = {}", subscriptionMap.count(key));
 
-					list<PublisherInfoPB> allPublishers, trimmedPublishers;
+                    list<PublisherInfoPB> allPublishers, trimmedPublishers;
                     for (int i = 0; i < update.publishers_size(); i++)
                     {
-                    	allPublishers.push_back(update.publishers(i));
+                        allPublishers.push_back(update.publishers(i));
                     }
-					trimPublishers(allPublishers, trimmedPublishers);
+                    trimPublishers(allPublishers, trimmedPublishers);
 
                     if (subscriptionMap.count(key) != 0)
                     {
-						// Loop over our existing subscriptions (filters) for domain/data of the updated publisher list
-                        for (map<string, std::shared_ptr<SubscriptionDetails> >::iterator iter = subscriptionMap[key].begin();
-                             iter != subscriptionMap[key].end();
-                             iter++)
+                        // Loop over our existing subscriptions (filters) for domain/data of the updated publisher list
+                        for (map<string, std::shared_ptr<SubscriptionDetails> >::iterator iter =
+                                 subscriptionMap[key].begin();
+                             iter != subscriptionMap[key].end(); iter++)
                         {
-							// Details of the existing subscription
-							string filter = iter->first;
-							std::shared_ptr<SubscriptionDetails> subDetails = iter->second;
+                            // Details of the existing subscription
+                            string filter = iter->first;
+                            std::shared_ptr<SubscriptionDetails> subDetails = iter->second;
 
-							// Loop over publishers list provided by SD
+                            // Loop over publishers list provided by SD
                             for (list<PublisherInfoPB>::const_iterator trimmedIter = trimmedPublishers.begin();
-                            		trimmedIter != trimmedPublishers.end(); trimmedIter++)
+                                 trimmedIter != trimmedPublishers.end(); trimmedIter++)
                             {
                                 // If we don't already have this publisher url, add it OR if it is an updated publisher url based on a new registration timestamp
-								if (subDetails->pollItemMap.count(trimmedIter->url()) == 0 ||
-									socketVerificationMap[subDetails->pollItemMap[trimmedIter->url()].socket] != trimmedIter->registration_time())
-                                {                                    
-									if (socketVerificationMap[subDetails->pollItemMap[trimmedIter->url()].socket] != trimmedIter->registration_time())
-									{
-										logger->trace("Updated url: {}", trimmedIter->url());
-										// This is an updated publisher location. Remove the old one.
-										deleteList.push_back(std::make_pair(subDetails, subDetails->pollItemMap[trimmedIter->url()].socket));
-									}
-									else
-									{
-										logger->trace("New url: {}", trimmedIter->url());
-									}
+                                if (subDetails->pollItemMap.count(trimmedIter->url()) == 0 ||
+                                    socketVerificationMap[subDetails->pollItemMap[trimmedIter->url()].socket] !=
+                                        trimmedIter->registration_time())
+                                {
+                                    if (socketVerificationMap[subDetails->pollItemMap[trimmedIter->url()].socket] !=
+                                        trimmedIter->registration_time())
+                                    {
+                                        logger->trace("Updated url: {}", trimmedIter->url());
+                                        // This is an updated publisher location. Remove the old one.
+                                        deleteList.push_back(std::make_pair(
+                                            subDetails, subDetails->pollItemMap[trimmedIter->url()].socket));
+                                    }
+                                    else
+                                    {
+                                        logger->trace("New url: {}", trimmedIter->url());
+                                    }
 
                                     zmq_pollitem_t pollItem;
-                                    void *subSocket = setupSubscription(trimmedIter->url(), filter, pollItem);
+                                    void* subSocket = setupSubscription(trimmedIter->url(), filter, pollItem);
 
                                     // Track by socket for quick lookup as data arrives
-									subscriptionSocketMap[subSocket] = subDetails;
+                                    subscriptionSocketMap[subSocket] = subDetails;
 
                                     // Add url & poll item to subscription details
-									subDetails->pollItemMap[trimmedIter->url()] = pollItem;
+                                    subDetails->pollItemMap[trimmedIter->url()] = pollItem;
 
-									// Add lookup from socket to url
-									subDetails->socketToUrlMap[subSocket] = trimmedIter->url();									
-                                }								
+                                    // Add lookup from socket to url
+                                    subDetails->socketToUrlMap[subSocket] = trimmedIter->url();
+                                }
                                 else
                                 {
                                     logger->trace("Skipping. Already have this publisher url: {}", trimmedIter->url());
                                 }
 
-								// Insert/Update map to manage publisher verification
-								socketVerificationMap[iter->second->pollItemMap[trimmedIter->url()].socket] = trimmedIter->registration_time();
+                                // Insert/Update map to manage publisher verification
+                                socketVerificationMap[iter->second->pollItemMap[trimmedIter->url()].socket] =
+                                    trimmedIter->registration_time();
                             }
 
                             // loop through the existing urls/sockets to see if any have disappeared.
-							map<string, zmq_pollitem_t>::iterator socketIter = subDetails->pollItemMap.begin();
-							while (socketIter != subDetails->pollItemMap.end())
+                            map<string, zmq_pollitem_t>::iterator socketIter = subDetails->pollItemMap.begin();
+                            while (socketIter != subDetails->pollItemMap.end())
                             {
                                 bool found = false;
                                 // there doesn't seem to be a good way to check containment in a protobuf set...
                                 for (list<PublisherInfoPB>::const_iterator trimmedIter = trimmedPublishers.begin();
-                                		trimmedIter != trimmedPublishers.end(); trimmedIter++)
+                                     trimmedIter != trimmedPublishers.end(); trimmedIter++)
                                 {
                                     if (socketIter->first == trimmedIter->url())
                                     {
@@ -465,55 +479,56 @@ void GravitySubscriptionManager::start()
                                     }
                                 }
 
-                                if (!found) 
-								{
+                                if (!found)
+                                {
                                     logger->debug("url {} is gone, adding to delete list", socketIter->first);
-									deleteList.push_back(std::make_pair(iter->second, socketIter->second.socket));
-                                } 								
-								++socketIter;
+                                    deleteList.push_back(std::make_pair(iter->second, socketIter->second.socket));
+                                }
+                                ++socketIter;
                             }
                         }
                     }
-			    }
-			}
-		}
+                }
+            }
+        }
 
-		
-		for (vector<pair<std::shared_ptr<SubscriptionDetails>, void*> >::iterator iter = deleteList.begin(); iter != deleteList.end(); iter++)
-		{
-			std::shared_ptr<SubscriptionDetails> subDetails = iter->first;
-			void* socket = iter->second;
-			string url = subDetails->socketToUrlMap[socket];
-			subscriptionSocketMap.erase(socket);
-			socketVerificationMap.erase(socket);
-			lastCachedValueMap.erase(socket);
-			
-			// Unsubscribe
-			logger->trace("Unsubscribing: {}:{}:{} @ {}", subDetails->domain, subDetails->dataProductID, subDetails->filter, url);
-			zmq_setsockopt(socket, ZMQ_UNSUBSCRIBE, subDetails->filter.c_str(), subDetails->filter.length());			
-			
-			// Close the socket
-			zmq_close(socket);
+        for (vector<pair<std::shared_ptr<SubscriptionDetails>, void*> >::iterator iter = deleteList.begin();
+             iter != deleteList.end(); iter++)
+        {
+            std::shared_ptr<SubscriptionDetails> subDetails = iter->first;
+            void* socket = iter->second;
+            string url = subDetails->socketToUrlMap[socket];
+            subscriptionSocketMap.erase(socket);
+            socketVerificationMap.erase(socket);
+            lastCachedValueMap.erase(socket);
 
-			// If the socket for this url hasn't been updated, remove it
-			if (subDetails->pollItemMap[url].socket == socket)
-			{
-				subDetails->pollItemMap.erase(url);
-			}
-			subDetails->socketToUrlMap.erase(socket);
-			
-			for (vector<zmq_pollitem_t>::iterator pollIter = pollItems.begin(); pollIter != pollItems.end(); ++pollIter)
-			{
-				if (socket == pollIter->socket)
-				{
-					pollItems.erase(pollIter);
-					logger->debug("delete socket from pollitems, size is now {}", pollItems.size());
-					break;
-				}
-			}
+            // Unsubscribe
+            logger->trace("Unsubscribing: {}:{}:{} @ {}", subDetails->domain, subDetails->dataProductID,
+                          subDetails->filter, url);
+            zmq_setsockopt(socket, ZMQ_UNSUBSCRIBE, subDetails->filter.c_str(), subDetails->filter.length());
 
-			// Check if we're out of subscriptions for this domain/data/filter
-			/*
+            // Close the socket
+            zmq_close(socket);
+
+            // If the socket for this url hasn't been updated, remove it
+            if (subDetails->pollItemMap[url].socket == socket)
+            {
+                subDetails->pollItemMap.erase(url);
+            }
+            subDetails->socketToUrlMap.erase(socket);
+
+            for (vector<zmq_pollitem_t>::iterator pollIter = pollItems.begin(); pollIter != pollItems.end(); ++pollIter)
+            {
+                if (socket == pollIter->socket)
+                {
+                    pollItems.erase(pollIter);
+                    logger->debug("delete socket from pollitems, size is now {}", pollItems.size());
+                    break;
+                }
+            }
+
+            // Check if we're out of subscriptions for this domain/data/filter
+            /*
 			if (subDetails->pollItemMap.empty())
 			{
 				// Clean up update publisher subscription
@@ -541,46 +556,50 @@ void GravitySubscriptionManager::start()
 				}
 			}
 			*/
-		}
-		deleteList.clear();
-	}
+        }
+        deleteList.clear();
+    }
 
-	// Clean up all our open sockets
-	for (map<DomainDataKey, map<std::string, std::shared_ptr<SubscriptionDetails> > >::iterator iter = subscriptionMap.begin();
-	     iter != subscriptionMap.end(); iter++)
-	{
-	    for (map<std::string, std::shared_ptr<SubscriptionDetails> >::iterator detIter = iter->second.begin(); detIter != iter->second.end(); detIter++)
-	    {
-	        for (std::map<std::string, zmq_pollitem_t>::iterator piIter = detIter->second->pollItemMap.begin(); piIter != detIter->second->pollItemMap.end(); piIter++)
-	        {
-	            zmq_close(piIter->second.socket);
-	        }
-	        zmq_close(detIter->second->publisherUpdatePollItem.socket);
-	    }
-	}
+    // Clean up all our open sockets
+    for (map<DomainDataKey, map<std::string, std::shared_ptr<SubscriptionDetails> > >::iterator iter =
+             subscriptionMap.begin();
+         iter != subscriptionMap.end(); iter++)
+    {
+        for (map<std::string, std::shared_ptr<SubscriptionDetails> >::iterator detIter = iter->second.begin();
+             detIter != iter->second.end(); detIter++)
+        {
+            for (std::map<std::string, zmq_pollitem_t>::iterator piIter = detIter->second->pollItemMap.begin();
+                 piIter != detIter->second->pollItemMap.end(); piIter++)
+            {
+                zmq_close(piIter->second.socket);
+            }
+            zmq_close(detIter->second->publisherUpdatePollItem.socket);
+        }
+    }
 
-	subscriptionMap.clear();
-	subscriptionSocketMap.clear();
-	socketVerificationMap.clear();
-	zmq_close(gravityNodeSocket);
+    subscriptionMap.clear();
+    subscriptionSocketMap.clear();
+    socketVerificationMap.clear();
+    zmq_close(gravityNodeSocket);
     zmq_close(gravityMetricsSocket);
 }
 
 void GravitySubscriptionManager::ready()
 {
-	// Create the request socket
-	void* initSocket = zmq_socket(context, ZMQ_REQ);
+    // Create the request socket
+    void* initSocket = zmq_socket(context, ZMQ_REQ);
 
-	// Connect to service
-	zmq_connect(initSocket, "inproc://gravity_init");
+    // Connect to service
+    zmq_connect(initSocket, "inproc://gravity_init");
 
-	// Send request to service provider
-	sendStringMessage(initSocket, "GravitySubscriptionManager", ZMQ_DONTWAIT);
+    // Send request to service provider
+    sendStringMessage(initSocket, "GravitySubscriptionManager", ZMQ_DONTWAIT);
 
-	zmq_close(initSocket);
+    zmq_close(initSocket);
 }
 
-int GravitySubscriptionManager::readSubscription(void *socket, string &filterText, std::shared_ptr<GravityDataProduct> &dataProduct)
+int GravitySubscriptionManager::readSubscription(void* socket, string& filterText,
+                                                 std::shared_ptr<GravityDataProduct>& dataProduct)
 {
     // Messages
     zmq_msg_t filter, message;
@@ -596,7 +615,7 @@ int GravitySubscriptionManager::readSubscription(void *socket, string &filterTex
         return ret;
     }
     int size = zmq_msg_size(&filter);
-    char* s = (char*)malloc(size+1);
+    char* s = (char*)malloc(size + 1);
     memcpy(s, zmq_msg_data(&filter), size);
     s[size] = 0;
     filterText = string(s, size);
@@ -606,31 +625,32 @@ int GravitySubscriptionManager::readSubscription(void *socket, string &filterTex
     zmq_msg_init(&message);
     zmq_recvmsg(socket, &message, 0);
     // Create new GravityDataProduct from the incoming message
-    dataProduct = std::shared_ptr<GravityDataProduct>(new GravityDataProduct(zmq_msg_data(&message), zmq_msg_size(&message)));
+    dataProduct =
+        std::shared_ptr<GravityDataProduct>(new GravityDataProduct(zmq_msg_data(&message), zmq_msg_size(&message)));
     // Clean up message
     zmq_msg_close(&message);
 
     return ret;
 }
 
-void *GravitySubscriptionManager::setupSubscription(const string &url, const string &filter, zmq_pollitem_t &pollItem)
+void* GravitySubscriptionManager::setupSubscription(const string& url, const string& filter, zmq_pollitem_t& pollItem)
 {
-	logger->trace("Setting up subscription for {}", url);
+    logger->trace("Setting up subscription for {}", url);
     // Create the socket
     void* subSocket = zmq_socket(context, ZMQ_SUB);
-	logger->trace("Created socket");
+    logger->trace("Created socket");
 
-	// Configure high water mark
-	zmq_setsockopt(subSocket, ZMQ_RCVHWM, &subscribeHWM, sizeof(subscribeHWM));    
-	logger->trace("Configured hwm");
+    // Configure high water mark
+    zmq_setsockopt(subSocket, ZMQ_RCVHWM, &subscribeHWM, sizeof(subscribeHWM));
+    logger->trace("Configured hwm");
 
     // Configure filter
     zmq_setsockopt(subSocket, ZMQ_SUBSCRIBE, filter.c_str(), filter.length());
-	logger->trace("Configured filter");
+    logger->trace("Configured filter");
 
-	// Connect to publisher
+    // Connect to publisher
     zmq_connect(subSocket, url.c_str());
-	logger->trace("connected to publisher");
+    logger->trace("connected to publisher");
 
     // set up the poll item for this subscription
     pollItem.socket = subSocket;
@@ -638,12 +658,12 @@ void *GravitySubscriptionManager::setupSubscription(const string &url, const str
     pollItem.fd = 0;
     pollItem.revents = 0;
     pollItems.push_back(pollItem);
-	logger->trace("Added to pollItem");
+    logger->trace("Added to pollItem");
 
     return subSocket;
 }
 
-void GravitySubscriptionManager::removePollItem(zmq_pollitem_t &pollItem)
+void GravitySubscriptionManager::removePollItem(zmq_pollitem_t& pollItem)
 {
     // Remove from poll items
     vector<zmq_pollitem_t>::iterator pollIter = pollItems.begin();
@@ -662,25 +682,25 @@ void GravitySubscriptionManager::removePollItem(zmq_pollitem_t &pollItem)
 
 void GravitySubscriptionManager::setHWM()
 {
-	// Read the high water mark setting
-	subscribeHWM = readIntMessage(gravityNodeSocket);
+    // Read the high water mark setting
+    subscribeHWM = readIntMessage(gravityNodeSocket);
 }
 
 void GravitySubscriptionManager::addSubscription()
 {
-	logger->trace("Adding subscription");
-	// Read the data product id for this subscription
-	string dataProductID = readStringMessage(gravityNodeSocket);
-	logger->trace("dataProductID = '{}'", dataProductID);
+    logger->trace("Adding subscription");
+    // Read the data product id for this subscription
+    string dataProductID = readStringMessage(gravityNodeSocket);
+    logger->trace("dataProductID = '{}'", dataProductID);
 
-	bool receiveLastCachedValue = readIntMessage(gravityNodeSocket);
-	logger->trace("receiveLastCachedValue = {}", receiveLastCachedValue);
+    bool receiveLastCachedValue = readIntMessage(gravityNodeSocket);
+    logger->trace("receiveLastCachedValue = {}", receiveLastCachedValue);
 
-	// Read all the publisher infos
-	uint32_t numPubInfoPBs = readUint32Message(gravityNodeSocket);
-	list<PublisherInfoPB> pubInfoPBs;
-	for (uint32_t i = 0; i < numPubInfoPBs; i++)
-	{
+    // Read all the publisher infos
+    uint32_t numPubInfoPBs = readUint32Message(gravityNodeSocket);
+    list<PublisherInfoPB> pubInfoPBs;
+    for (uint32_t i = 0; i < numPubInfoPBs; i++)
+    {
         zmq_msg_t msg;
         zmq_msg_init(&msg);
         zmq_recvmsg(gravityNodeSocket, &msg, -1);
@@ -688,434 +708,443 @@ void GravitySubscriptionManager::addSubscription()
         pb.ParseFromArray(zmq_msg_data(&msg), zmq_msg_size(&msg));
         zmq_msg_close(&msg);
         pubInfoPBs.push_back(pb);
-        if (pb.has_url())
-            logger->trace("url = '{}'", pb.url());
-	}
+        if (pb.has_url()) logger->trace("url = '{}'", pb.url());
+    }
 
-	// Read the subscription filter
-	string filter = readStringMessage(gravityNodeSocket);
-	logger->trace("filter = {}s'", filter);
+    // Read the subscription filter
+    string filter = readStringMessage(gravityNodeSocket);
+    logger->trace("filter = {}s'", filter);
 
-	// Read the domain
-	string domain = readStringMessage(gravityNodeSocket);
-	logger->trace("domain = '{}'", domain);
+    // Read the domain
+    string domain = readStringMessage(gravityNodeSocket);
+    logger->trace("domain = '{}'", domain);
 
     // Read the url for to subscribe to for publisher updates
     string publisherUpdateUrl = readStringMessage(gravityNodeSocket);
-	logger->trace("publisherUpdateUrl = '{}'", publisherUpdateUrl);
+    logger->trace("publisherUpdateUrl = '{}'", publisherUpdateUrl);
 
-	// Read the subscriber
-	zmq_msg_t msg;
-	zmq_msg_init(&msg);
-	zmq_recvmsg(gravityNodeSocket, &msg, -1);
-	GravitySubscriber* subscriber;
-	memcpy(&subscriber, zmq_msg_data(&msg), zmq_msg_size(&msg));
-	zmq_msg_close(&msg);
+    // Read the subscriber
+    zmq_msg_t msg;
+    zmq_msg_init(&msg);
+    zmq_recvmsg(gravityNodeSocket, &msg, -1);
+    GravitySubscriber* subscriber;
+    memcpy(&subscriber, zmq_msg_data(&msg), zmq_msg_size(&msg));
+    zmq_msg_close(&msg);
 
-	logger->trace("Set up GravitySubscriber");
+    logger->trace("Set up GravitySubscriber");
 
-	// Create the domain/data key for tracking subscriptions
-	DomainDataKey key(domain, dataProductID);
+    // Create the domain/data key for tracking subscriptions
+    DomainDataKey key(domain, dataProductID);
 
-	// Create new SubscriptionDetails
-	std::shared_ptr<SubscriptionDetails> subDetails;
+    // Create new SubscriptionDetails
+    std::shared_ptr<SubscriptionDetails> subDetails;
 
-	if (subscriptionMap.count(key) == 0)
-	{
-	    map<string, std::shared_ptr<SubscriptionDetails> > filterMap;
-	    subscriptionMap[key] = filterMap;
-	}
-	
-	if (subscriptionMap[key].count(filter) > 0)
-	{
-		logger->trace("Already have details for this");
-		// Already have a details for this
-		subDetails = subscriptionMap[key][filter];
-	}
-	else
-	{
-		logger->trace("Populate new subDetails");
-	    subDetails.reset(new SubscriptionDetails());
+    if (subscriptionMap.count(key) == 0)
+    {
+        map<string, std::shared_ptr<SubscriptionDetails> > filterMap;
+        subscriptionMap[key] = filterMap;
+    }
+
+    if (subscriptionMap[key].count(filter) > 0)
+    {
+        logger->trace("Already have details for this");
+        // Already have a details for this
+        subDetails = subscriptionMap[key][filter];
+    }
+    else
+    {
+        logger->trace("Populate new subDetails");
+        subDetails.reset(new SubscriptionDetails());
         subDetails->dataProductID = dataProductID;
-		subDetails->domain = domain;
+        subDetails->domain = domain;
         subDetails->filter = filter;
-		subDetails->receiveCachedDataProducts = receiveLastCachedValue;
+        subDetails->receiveCachedDataProducts = receiveLastCachedValue;
 
-		zmq_pollitem_t pollItem;
-		setupSubscription(publisherUpdateUrl, dataProductID, pollItem);
-		subDetails->publisherUpdatePollItem = pollItem;
+        zmq_pollitem_t pollItem;
+        setupSubscription(publisherUpdateUrl, dataProductID, pollItem);
+        subDetails->publisherUpdatePollItem = pollItem;
 
-	    subscriptionMap[key][filter] = subDetails;
-	}
+        subscriptionMap[key][filter] = subDetails;
+    }
 
-	list<PublisherInfoPB> trimmedPublishers;
-	trimPublishers(pubInfoPBs, trimmedPublishers);
-	for (list<PublisherInfoPB>::iterator iter = trimmedPublishers.begin(); iter != trimmedPublishers.end(); iter++)
-	{
-		// if we have a url and we haven't seen it before, subscribe to it
-		if (iter->has_url() && subDetails->pollItemMap.count(iter->url()) == 0)
-		{
-			logger->trace("Subscribe to new url");
-			zmq_pollitem_t pollItem;
-			void *subSocket = setupSubscription(iter->url(), filter, pollItem);
+    list<PublisherInfoPB> trimmedPublishers;
+    trimPublishers(pubInfoPBs, trimmedPublishers);
+    for (list<PublisherInfoPB>::iterator iter = trimmedPublishers.begin(); iter != trimmedPublishers.end(); iter++)
+    {
+        // if we have a url and we haven't seen it before, subscribe to it
+        if (iter->has_url() && subDetails->pollItemMap.count(iter->url()) == 0)
+        {
+            logger->trace("Subscribe to new url");
+            zmq_pollitem_t pollItem;
+            void* subSocket = setupSubscription(iter->url(), filter, pollItem);
 
-			// Create subscription details
-			subDetails->pollItemMap[iter->url()] = pollItem;
+            // Create subscription details
+            subDetails->pollItemMap[iter->url()] = pollItem;
 
-			// Add lookup from socket to URL
-			subDetails->socketToUrlMap[subSocket] = iter->url();
+            // Add lookup from socket to URL
+            subDetails->socketToUrlMap[subSocket] = iter->url();
 
-			// and by socket for quick lookup as data arrives
-			subscriptionSocketMap[subSocket] = subDetails;
+            // and by socket for quick lookup as data arrives
+            subscriptionSocketMap[subSocket] = subDetails;
 
-			// Map to manage publisher verification
-			socketVerificationMap[subSocket] = iter->registration_time();
-		}
-	}
-	
-	// if a monitor was registered before the subscription, reset the timeouts
-	if(subDetails->subscribers.empty() && !subDetails->monitors.empty())
-	{
-		uint64_t currTime = getCurrentTime()/1000;
-		for(set<std::shared_ptr<TimeoutMonitor> >::iterator monitorIter = subDetails->monitors.begin(); monitorIter != subDetails->monitors.end(); monitorIter++)
-		{
-			(*monitorIter)->endTime = currTime + (*monitorIter)->timeout;
-		}
-	}
+            // Map to manage publisher verification
+            socketVerificationMap[subSocket] = iter->registration_time();
+        }
+    }
+
+    // if a monitor was registered before the subscription, reset the timeouts
+    if (subDetails->subscribers.empty() && !subDetails->monitors.empty())
+    {
+        uint64_t currTime = getCurrentTime() / 1000;
+        for (set<std::shared_ptr<TimeoutMonitor> >::iterator monitorIter = subDetails->monitors.begin();
+             monitorIter != subDetails->monitors.end(); monitorIter++)
+        {
+            (*monitorIter)->endTime = currTime + (*monitorIter)->timeout;
+        }
+    }
 
     // Add new subscriber if it isn't already in the list
     if (subDetails->subscribers.find(subscriber) == subDetails->subscribers.end())
     {
-		logger->trace("Adding new subscriber to list");
+        logger->trace("Adding new subscriber to list");
         subDetails->subscribers.insert(subscriber);
 
         // If we've already received data on this subscription, send the most recent
         // value to the new subscriber, unless the subscriber doesn't want the lastCachedValue
-		if (receiveLastCachedValue)
-		{
-			logger->trace("Sending cached value to subscriber");
-			vector<std::shared_ptr<GravityDataProduct> > dataProducts;
-			for (map<string, zmq_pollitem_t>::iterator iter = subDetails->pollItemMap.begin(); iter != subDetails->pollItemMap.end(); iter++)
-			{
-				if (lastCachedValueMap[iter->second.socket])
-				{
-					dataProducts.push_back(lastCachedValueMap[iter->second.socket]);
-				}
-			}
-			if (dataProducts.size() > 0)
-			{
-				logger->debug("sending data ({}) to late subscriber", dataProductID);
-				sort(dataProducts.begin(), dataProducts.end(), sortCacheValues);
-				subscriber->subscriptionFilled(dataProducts);
-			}			
-		}else
-		{
-			logger->trace("Not sending cached value to subscriber");
-		}
-    }else
-	{
-		logger->trace("Subscriber already in list");
-	}
+        if (receiveLastCachedValue)
+        {
+            logger->trace("Sending cached value to subscriber");
+            vector<std::shared_ptr<GravityDataProduct> > dataProducts;
+            for (map<string, zmq_pollitem_t>::iterator iter = subDetails->pollItemMap.begin();
+                 iter != subDetails->pollItemMap.end(); iter++)
+            {
+                if (lastCachedValueMap[iter->second.socket])
+                {
+                    dataProducts.push_back(lastCachedValueMap[iter->second.socket]);
+                }
+            }
+            if (dataProducts.size() > 0)
+            {
+                logger->debug("sending data ({}) to late subscriber", dataProductID);
+                sort(dataProducts.begin(), dataProducts.end(), sortCacheValues);
+                subscriber->subscriptionFilled(dataProducts);
+            }
+        }
+        else
+        {
+            logger->trace("Not sending cached value to subscriber");
+        }
+    }
+    else
+    {
+        logger->trace("Subscriber already in list");
+    }
 }
 
 void GravitySubscriptionManager::removeSubscription()
 {
-	// Read data product id
-	string dataProductID = readStringMessage(gravityNodeSocket);
+    // Read data product id
+    string dataProductID = readStringMessage(gravityNodeSocket);
 
     // Remove this data product from our metrics
     metricsData.remove(dataProductID);
 
-	// Read the subscription filter
-	string filter = readStringMessage(gravityNodeSocket);
+    // Read the subscription filter
+    string filter = readStringMessage(gravityNodeSocket);
 
-	// Read the domain
-	string domain = readStringMessage(gravityNodeSocket);
+    // Read the domain
+    string domain = readStringMessage(gravityNodeSocket);
 
-	logger->trace("unsubscribe from data product: {}:{}:{}", domain, dataProductID, filter);
+    logger->trace("unsubscribe from data product: {}:{}:{}", domain, dataProductID, filter);
 
-	// Read the subscriber
-	zmq_msg_t msg;
-	zmq_msg_init(&msg);
-	zmq_recvmsg(gravityNodeSocket, &msg, -1);
-	GravitySubscriber* subscriber;
-	memcpy(&subscriber, zmq_msg_data(&msg), zmq_msg_size(&msg));
-	zmq_msg_close(&msg);
+    // Read the subscriber
+    zmq_msg_t msg;
+    zmq_msg_init(&msg);
+    zmq_recvmsg(gravityNodeSocket, &msg, -1);
+    GravitySubscriber* subscriber;
+    memcpy(&subscriber, zmq_msg_data(&msg), zmq_msg_size(&msg));
+    zmq_msg_close(&msg);
 
-	// Create the domain/data key for tracking subscriptions
-	DomainDataKey key(domain, dataProductID);
+    // Create the domain/data key for tracking subscriptions
+    DomainDataKey key(domain, dataProductID);
 
-	if (subscriptionMap.count(key) > 0 && subscriptionMap[key].count(filter) > 0)
-	{
-		logger->trace("Found at least one subscriber");
-		// Get subscription details
-	    std::shared_ptr<SubscriptionDetails> subDetails = subscriptionMap[key][filter];
+    if (subscriptionMap.count(key) > 0 && subscriptionMap[key].count(filter) > 0)
+    {
+        logger->trace("Found at least one subscriber");
+        // Get subscription details
+        std::shared_ptr<SubscriptionDetails> subDetails = subscriptionMap[key][filter];
 
-		// Find & remove subscriber from our list of subscribers for this data product
-		set<GravitySubscriber*>::iterator iter = subDetails->subscribers.begin();
-		while (iter != subDetails->subscribers.end())
-		{
-			// Pointer to same subscriber?
-			if (*iter == subscriber)
-			{
-				logger->trace("Found and removed subscriber");
-				subDetails->subscribers.erase(iter);
-				break;
-			}
-			else
-			{
-				iter++;
-			}
-		}
+        // Find & remove subscriber from our list of subscribers for this data product
+        set<GravitySubscriber*>::iterator iter = subDetails->subscribers.begin();
+        while (iter != subDetails->subscribers.end())
+        {
+            // Pointer to same subscriber?
+            if (*iter == subscriber)
+            {
+                logger->trace("Found and removed subscriber");
+                subDetails->subscribers.erase(iter);
+                break;
+            }
+            else
+            {
+                iter++;
+            }
+        }
 
-		// If no more subscribers, close the subscription sockets and clear the details
-		if (subDetails->subscribers.empty())
-		{
-			logger->trace("No more subscribers");
-			//if no more monitor references
-			if(subDetails->monitors.empty())
-			{
-				logger->trace("No more monitors");
+        // If no more subscribers, close the subscription sockets and clear the details
+        if (subDetails->subscribers.empty())
+        {
+            logger->trace("No more subscribers");
+            //if no more monitor references
+            if (subDetails->monitors.empty())
+            {
+                logger->trace("No more monitors");
 
-				// Remove details from main map
-				subscriptionMap[key].erase(filter);
-				if (subscriptionMap[key].size() == 0)
-				{
-					subscriptionMap.erase(key);
-				}
+                // Remove details from main map
+                subscriptionMap[key].erase(filter);
+                if (subscriptionMap[key].size() == 0)
+                {
+                    subscriptionMap.erase(key);
+                }
 
-				// If we no longer have subscriptions for this domain/dataProductID combo, then stop
-				// subscribing for updates from the SD on this as well				
-				logger->trace("Removing subscription to {}", gravity::constants::REGISTERED_PUBLISHERS_DPID);
-				removePollItem(subDetails->publisherUpdatePollItem);
-				zmq_setsockopt(subDetails->publisherUpdatePollItem.socket, ZMQ_UNSUBSCRIBE, dataProductID.c_str(), dataProductID.length());
-				zmq_close(subDetails->publisherUpdatePollItem.socket);
-			}
+                // If we no longer have subscriptions for this domain/dataProductID combo, then stop
+                // subscribing for updates from the SD on this as well
+                logger->trace("Removing subscription to {}", gravity::constants::REGISTERED_PUBLISHERS_DPID);
+                removePollItem(subDetails->publisherUpdatePollItem);
+                zmq_setsockopt(subDetails->publisherUpdatePollItem.socket, ZMQ_UNSUBSCRIBE, dataProductID.c_str(),
+                               dataProductID.length());
+                zmq_close(subDetails->publisherUpdatePollItem.socket);
+            }
 
-			for (map<string, zmq_pollitem_t>::iterator iter = subDetails->pollItemMap.begin(); iter != subDetails->pollItemMap.end(); iter++)
-			{
-				unsubscribeFromPollItem(iter->second, filter);
+            for (map<string, zmq_pollitem_t>::iterator iter = subDetails->pollItemMap.begin();
+                 iter != subDetails->pollItemMap.end(); iter++)
+            {
+                unsubscribeFromPollItem(iter->second, filter);
 
-				// Remove from poll items
-				removePollItem(iter->second);
+                // Remove from poll items
+                removePollItem(iter->second);
 
-				// Clear cached values
-				lastCachedValueMap.erase(iter->second.socket);
-			}				
-		}
-	}
+                // Clear cached values
+                lastCachedValueMap.erase(iter->second.socket);
+            }
+        }
+    }
 }
 
 void GravitySubscriptionManager::setTimeoutMonitor()
 {
-	string dataProductID = readStringMessage(gravityNodeSocket);
+    string dataProductID = readStringMessage(gravityNodeSocket);
 
-	zmq_msg_t msg;
-	zmq_msg_init(&msg);
-	zmq_recvmsg(gravityNodeSocket, &msg, -1);
-	GravitySubscriptionMonitor* monitor;
-	memcpy(&monitor, zmq_msg_data(&msg), zmq_msg_size(&msg));
-	zmq_msg_close(&msg);
+    zmq_msg_t msg;
+    zmq_msg_init(&msg);
+    zmq_recvmsg(gravityNodeSocket, &msg, -1);
+    GravitySubscriptionMonitor* monitor;
+    memcpy(&monitor, zmq_msg_data(&msg), zmq_msg_size(&msg));
+    zmq_msg_close(&msg);
 
-	int timeout = readIntMessage(gravityNodeSocket);
-	
-	string filter = readStringMessage(gravityNodeSocket);
-	string domain = readStringMessage(gravityNodeSocket);
-	
-	DomainDataKey key(domain, dataProductID);
-		
-	std::shared_ptr<SubscriptionDetails> subDetails;
-	if (subscriptionMap[key].count(filter) > 0)
-	{
-		// Already have a details for this
-		subDetails = subscriptionMap[key][filter];
-	}
-	else
-	{
-		subDetails.reset(new SubscriptionDetails());
-		subDetails->dataProductID = dataProductID;
-		subDetails->domain = domain;
-		subDetails->filter = filter;
-		map<string, std::shared_ptr<SubscriptionDetails> > filterMap;
-	    subscriptionMap[key] = filterMap;
-		subscriptionMap[key][filter] = subDetails;
-	}
-		
-	uint64_t currTime = getCurrentTime()/1000;
+    int timeout = readIntMessage(gravityNodeSocket);
 
-	for(std::set<std::shared_ptr<TimeoutMonitor> >::iterator iter = subDetails->monitors.begin();iter != subDetails->monitors.end();iter++)
-	{
-		// if a reference to this monitor already exists
-		if((*iter)->monitor == monitor)
-		{
-			(*iter)->timeout=timeout;			
-			(*iter)->endTime=currTime+timeout;
-			return;
-		}
+    string filter = readStringMessage(gravityNodeSocket);
+    string domain = readStringMessage(gravityNodeSocket);
 
-	}
+    DomainDataKey key(domain, dataProductID);
 
-	// create and add new monitor
-	std::shared_ptr<TimeoutMonitor> tm;
-	tm.reset(new TimeoutMonitor());
+    std::shared_ptr<SubscriptionDetails> subDetails;
+    if (subscriptionMap[key].count(filter) > 0)
+    {
+        // Already have a details for this
+        subDetails = subscriptionMap[key][filter];
+    }
+    else
+    {
+        subDetails.reset(new SubscriptionDetails());
+        subDetails->dataProductID = dataProductID;
+        subDetails->domain = domain;
+        subDetails->filter = filter;
+        map<string, std::shared_ptr<SubscriptionDetails> > filterMap;
+        subscriptionMap[key] = filterMap;
+        subscriptionMap[key][filter] = subDetails;
+    }
 
-	tm->monitor = monitor;
-	tm->timeout=timeout;
-	tm->endTime= currTime + timeout;
-	tm->lastReceived=-1l;		
-		
-	subDetails->monitors.insert(tm);
+    uint64_t currTime = getCurrentTime() / 1000;
 
+    for (std::set<std::shared_ptr<TimeoutMonitor> >::iterator iter = subDetails->monitors.begin();
+         iter != subDetails->monitors.end(); iter++)
+    {
+        // if a reference to this monitor already exists
+        if ((*iter)->monitor == monitor)
+        {
+            (*iter)->timeout = timeout;
+            (*iter)->endTime = currTime + timeout;
+            return;
+        }
+    }
+
+    // create and add new monitor
+    std::shared_ptr<TimeoutMonitor> tm;
+    tm.reset(new TimeoutMonitor());
+
+    tm->monitor = monitor;
+    tm->timeout = timeout;
+    tm->endTime = currTime + timeout;
+    tm->lastReceived = -1l;
+
+    subDetails->monitors.insert(tm);
 }
 
 void GravitySubscriptionManager::clearTimeoutMonitor()
 {
-	string dataProductID = readStringMessage(gravityNodeSocket);
+    string dataProductID = readStringMessage(gravityNodeSocket);
 
-	zmq_msg_t msg;
-	zmq_msg_init(&msg);
-	zmq_recvmsg(gravityNodeSocket, &msg, -1);
-	GravitySubscriptionMonitor* monitor;
-	memcpy(&monitor, zmq_msg_data(&msg), zmq_msg_size(&msg));
-	zmq_msg_close(&msg);
+    zmq_msg_t msg;
+    zmq_msg_init(&msg);
+    zmq_recvmsg(gravityNodeSocket, &msg, -1);
+    GravitySubscriptionMonitor* monitor;
+    memcpy(&monitor, zmq_msg_data(&msg), zmq_msg_size(&msg));
+    zmq_msg_close(&msg);
 
-	string filter = readStringMessage(gravityNodeSocket);
-	string domain = readStringMessage(gravityNodeSocket);
+    string filter = readStringMessage(gravityNodeSocket);
+    string domain = readStringMessage(gravityNodeSocket);
 
-	DomainDataKey key(domain, dataProductID);		
-		
-	if (subscriptionMap.count(key) > 0 && subscriptionMap[key].count(filter) > 0)
-	{
-	    std::shared_ptr<SubscriptionDetails> subDetails = subscriptionMap[key][filter];
+    DomainDataKey key(domain, dataProductID);
 
-		// Find & remove all matching monitors
-		set<std::shared_ptr<TimeoutMonitor> >::iterator iter = subDetails->monitors.begin();
-		while (iter != subDetails->monitors.end())
-		{
-			if ((*iter)->monitor == monitor)
-			{		
-				//Is This necessary?
-				if((*iter) == currTimeoutMonitor)
-				{
-					currTimeoutMonitor.reset();
-					pollTimeout=-1;
-				}
-				subDetails->monitors.erase(iter);
-				break;
-			}
-			
-			iter++;			
-		}
+    if (subscriptionMap.count(key) > 0 && subscriptionMap[key].count(filter) > 0)
+    {
+        std::shared_ptr<SubscriptionDetails> subDetails = subscriptionMap[key][filter];
 
-		//if no more references to this subscription, remove from map
-		if(subDetails->monitors.empty() && subDetails->subscribers.empty())
-		{
-			// Remove from details main map
-			subscriptionMap[key].erase(filter);
-			if (subscriptionMap[key].size() == 0)
-			{
-				subscriptionMap.erase(key);
-			}
-			// If we no longer have subscriptions for this domain/dataProductID combo, then stop
-			// subscribing for updates from the SD on this as well
-			removePollItem(subDetails->publisherUpdatePollItem);
-			zmq_setsockopt(subDetails->publisherUpdatePollItem.socket, ZMQ_UNSUBSCRIBE, dataProductID.c_str(), dataProductID.length());
-			zmq_close(subDetails->publisherUpdatePollItem.socket);
-		}
-	}
+        // Find & remove all matching monitors
+        set<std::shared_ptr<TimeoutMonitor> >::iterator iter = subDetails->monitors.begin();
+        while (iter != subDetails->monitors.end())
+        {
+            if ((*iter)->monitor == monitor)
+            {
+                //Is This necessary?
+                if ((*iter) == currTimeoutMonitor)
+                {
+                    currTimeoutMonitor.reset();
+                    pollTimeout = -1;
+                }
+                subDetails->monitors.erase(iter);
+                break;
+            }
+
+            iter++;
+        }
+
+        //if no more references to this subscription, remove from map
+        if (subDetails->monitors.empty() && subDetails->subscribers.empty())
+        {
+            // Remove from details main map
+            subscriptionMap[key].erase(filter);
+            if (subscriptionMap[key].size() == 0)
+            {
+                subscriptionMap.erase(key);
+            }
+            // If we no longer have subscriptions for this domain/dataProductID combo, then stop
+            // subscribing for updates from the SD on this as well
+            removePollItem(subDetails->publisherUpdatePollItem);
+            zmq_setsockopt(subDetails->publisherUpdatePollItem.socket, ZMQ_UNSUBSCRIBE, dataProductID.c_str(),
+                           dataProductID.length());
+            zmq_close(subDetails->publisherUpdatePollItem.socket);
+        }
+    }
 }
 
 void GravitySubscriptionManager::unsubscribeFromPollItem(zmq_pollitem_t pollItem, string filterText)
 {
-	// Clean-up/Subscribe from this subscription
-	subscriptionSocketMap.erase(pollItem.socket);
-	socketVerificationMap.erase(pollItem.socket);
+    // Clean-up/Subscribe from this subscription
+    subscriptionSocketMap.erase(pollItem.socket);
+    socketVerificationMap.erase(pollItem.socket);
 
-	// Unsubscribe
-	zmq_setsockopt(pollItem.socket, ZMQ_UNSUBSCRIBE, filterText.c_str(), filterText.length());
+    // Unsubscribe
+    zmq_setsockopt(pollItem.socket, ZMQ_UNSUBSCRIBE, filterText.c_str(), filterText.length());
 
-	// Close the socket
-	zmq_close(pollItem.socket);
+    // Close the socket
+    zmq_close(pollItem.socket);
 }
-	
+
 void GravitySubscriptionManager::calculateTimeout()
 {
-	int minTime = -1;
-	currTimeoutMonitor.reset();
-	currMonitorDetails.reset();
-	map<DomainDataKey, map<std::string, std::shared_ptr<SubscriptionDetails> > >::iterator dpIter = subscriptionMap.begin();
-	//go through all domain-dataproduct keys
-	while (dpIter != subscriptionMap.end())
-	{
-		map<string, std::shared_ptr<SubscriptionDetails> >::iterator filterIter = dpIter->second.begin();
-		while(filterIter != dpIter->second.end())
-		{
-		    std::shared_ptr<SubscriptionDetails> subDetails = filterIter->second;
-			for(set<std::shared_ptr<TimeoutMonitor> >::iterator monitorIter = subDetails->monitors.begin(); monitorIter != subDetails->monitors.end(); monitorIter++)
-			{
-				// check if this is an active subscription with a valid timeout
-				if(subDetails->subscribers.size() > 0 && (*monitorIter)->timeout>=0)
-				{
+    int minTime = -1;
+    currTimeoutMonitor.reset();
+    currMonitorDetails.reset();
+    map<DomainDataKey, map<std::string, std::shared_ptr<SubscriptionDetails> > >::iterator dpIter =
+        subscriptionMap.begin();
+    //go through all domain-dataproduct keys
+    while (dpIter != subscriptionMap.end())
+    {
+        map<string, std::shared_ptr<SubscriptionDetails> >::iterator filterIter = dpIter->second.begin();
+        while (filterIter != dpIter->second.end())
+        {
+            std::shared_ptr<SubscriptionDetails> subDetails = filterIter->second;
+            for (set<std::shared_ptr<TimeoutMonitor> >::iterator monitorIter = subDetails->monitors.begin();
+                 monitorIter != subDetails->monitors.end(); monitorIter++)
+            {
+                // check if this is an active subscription with a valid timeout
+                if (subDetails->subscribers.size() > 0 && (*monitorIter)->timeout >= 0)
+                {
+                    uint64_t currTime = getCurrentTime() / 1000;
+                    // calculate how much time is left until this monitor times out
+                    int64_t timeRemaining = (*monitorIter)->endTime - currTime;
 
-					uint64_t currTime = getCurrentTime()/1000;
-					// calculate how much time is left until this monitor times out
-					int64_t timeRemaining =(*monitorIter)->endTime-currTime;
+                    //a subscription timed out during processing
+                    if (timeRemaining <= 0)
+                    {
+                        int timeSinceLast =
+                            (*monitorIter)->lastReceived > 0 ? (int)(currTime - (*monitorIter)->lastReceived) : -1l;
+                        //make call to monitor
+                        (*monitorIter)
+                            ->monitor->subscriptionTimeout(subDetails->dataProductID, timeSinceLast, subDetails->filter,
+                                                           subDetails->domain);
+                        //reset next timeout
+                        (*monitorIter)->endTime = (*monitorIter)->endTime + (*monitorIter)->timeout;
 
-					//a subscription timed out during processing
-					if(timeRemaining <= 0)
-					{						
-						int timeSinceLast = (*monitorIter)->lastReceived>0?(int)(currTime-(*monitorIter)->lastReceived):-1l;
-						//make call to monitor
-						(*monitorIter)->monitor->subscriptionTimeout(subDetails->dataProductID,timeSinceLast,
-								subDetails->filter,subDetails->domain);
-						//reset next timeout
-						(*monitorIter)->endTime = (*monitorIter)->endTime + (*monitorIter)->timeout;
-						
-						logger->trace("Subscription Timeout ({})",subDetails->dataProductID);	
+                        logger->trace("Subscription Timeout ({})", subDetails->dataProductID);
 
-						if((*monitorIter)->timeout < minTime || minTime == -1)
-						{
-							minTime = (int) (*monitorIter)->timeout;
-						}
-					}
-					else if(timeRemaining < (int64_t) minTime || minTime == -1)
-					{
-						//set current timeout details
-						minTime = (int) timeRemaining;
-						currTimeoutMonitor = *monitorIter;
-						currMonitorDetails = subDetails;					
-					}
-				}
-			}
-			filterIter++;
-		}		
-		dpIter++;
-	}	
-	pollTimeout=minTime;
+                        if ((*monitorIter)->timeout < minTime || minTime == -1)
+                        {
+                            minTime = (int)(*monitorIter)->timeout;
+                        }
+                    }
+                    else if (timeRemaining < (int64_t)minTime || minTime == -1)
+                    {
+                        //set current timeout details
+                        minTime = (int)timeRemaining;
+                        currTimeoutMonitor = *monitorIter;
+                        currMonitorDetails = subDetails;
+                    }
+                }
+            }
+            filterIter++;
+        }
+        dpIter++;
+    }
+    pollTimeout = minTime;
 }
 
-void GravitySubscriptionManager::notifyServiceDirectoryOfStaleEntry(string dataProductId, string domain, string url, uint32_t regTime)
+void GravitySubscriptionManager::notifyServiceDirectoryOfStaleEntry(string dataProductId, string domain, string url,
+                                                                    uint32_t regTime)
 {
-	logger->debug("Notifying ServiceDirectory of stale publisher: [{} @ {}]", dataProductId, url);
-	ServiceDirectoryUnregistrationPB unregistration;
-	unregistration.set_id(dataProductId);
-	unregistration.set_url(url);
-	unregistration.set_domain(domain);
-	unregistration.set_registration_time(regTime);
-	unregistration.set_type(ServiceDirectoryUnregistrationPB::DATA);
+    logger->debug("Notifying ServiceDirectory of stale publisher: [{} @ {}]", dataProductId, url);
+    ServiceDirectoryUnregistrationPB unregistration;
+    unregistration.set_id(dataProductId);
+    unregistration.set_url(url);
+    unregistration.set_domain(domain);
+    unregistration.set_registration_time(regTime);
+    unregistration.set_type(ServiceDirectoryUnregistrationPB::DATA);
 
-	GravityDataProduct request("UnregistrationRequest");
-	request.setData(unregistration);
+    GravityDataProduct request("UnregistrationRequest");
+    request.setData(unregistration);
 
-	void* socket = zmq_socket(context, ZMQ_REQ); // Socket to connect to service provider
-	zmq_connect(socket, serviceDirectoryUrl.c_str());
-	int linger = -1;
-	zmq_setsockopt(socket, ZMQ_LINGER, &linger, sizeof(linger));
+    void* socket = zmq_socket(context, ZMQ_REQ);  // Socket to connect to service provider
+    zmq_connect(socket, serviceDirectoryUrl.c_str());
+    int linger = -1;
+    zmq_setsockopt(socket, ZMQ_LINGER, &linger, sizeof(linger));
 
-	// Send message to service provider
-	sendGravityDataProduct(socket, request, ZMQ_DONTWAIT);
+    // Send message to service provider
+    sendGravityDataProduct(socket, request, ZMQ_DONTWAIT);
 
-	zmq_close(socket);
+    zmq_close(socket);
 }
 
 void GravitySubscriptionManager::collectMetrics(vector<std::shared_ptr<GravityDataProduct> > dataProducts)
@@ -1133,34 +1162,34 @@ void GravitySubscriptionManager::collectMetrics(vector<std::shared_ptr<GravityDa
 /**
  * This assumes publishers are already for the same data product id and domain
  */
-void GravitySubscriptionManager::trimPublishers(const std::list<gravity::PublisherInfoPB>& fullList, std::list<gravity::PublisherInfoPB>& trimmedList)
+void GravitySubscriptionManager::trimPublishers(const std::list<gravity::PublisherInfoPB>& fullList,
+                                                std::list<gravity::PublisherInfoPB>& trimmedList)
 {
-	bool iAmRelay = false;
-	for (list<PublisherInfoPB>::const_iterator iter = fullList.begin(); iter != fullList.end(); iter++)
-	{
-		// if this is a valid publisher and we are a relay, then don't want to subscribe to one
-		if (iter->has_url() && iter->isrelay() && iter->componentid() == componentID)
-		{
-			iAmRelay = true;
-		}
-	}
+    bool iAmRelay = false;
+    for (list<PublisherInfoPB>::const_iterator iter = fullList.begin(); iter != fullList.end(); iter++)
+    {
+        // if this is a valid publisher and we are a relay, then don't want to subscribe to one
+        if (iter->has_url() && iter->isrelay() && iter->componentid() == componentID)
+        {
+            iAmRelay = true;
+        }
+    }
 
-	trimmedList.clear();
-	bool foundGlobalRelay = false;
-	for (list<PublisherInfoPB>::const_iterator iter = fullList.begin(); iter != fullList.end(); iter++)
-	{
-	    if (!iter->has_url())  // if invalid publisher - should never happen
-	    {
-	        logger->warn("Found publisher with no url??  Skipping...");
-	        continue;
-	    }
-	    else if (iAmRelay)
-		{
-			if (!iter->isrelay())
-				trimmedList.push_back(*iter);
-		}
-		else if (iter->isrelay())
-		{
+    trimmedList.clear();
+    bool foundGlobalRelay = false;
+    for (list<PublisherInfoPB>::const_iterator iter = fullList.begin(); iter != fullList.end(); iter++)
+    {
+        if (!iter->has_url())  // if invalid publisher - should never happen
+        {
+            logger->warn("Found publisher with no url??  Skipping...");
+            continue;
+        }
+        else if (iAmRelay)
+        {
+            if (!iter->isrelay()) trimmedList.push_back(*iter);
+        }
+        else if (iter->isrelay())
+        {
             if (iter->has_ipaddress())
             {
                 logger->trace("found valid relay with ip = {}, my ip = {}", iter->ipaddress(), ipAddress);
@@ -1170,7 +1199,7 @@ void GravitySubscriptionManager::trimPublishers(const std::list<gravity::Publish
                 logger->trace("Found valid global relay");
             }
             // if it's a relay for any IP or our IP
-            if(!iter->has_ipaddress() || iter->ipaddress() == ipAddress)
+            if (!iter->has_ipaddress() || iter->ipaddress() == ipAddress)
             {
                 trimmedList.clear();
                 trimmedList.push_back(*iter);
@@ -1181,19 +1210,19 @@ void GravitySubscriptionManager::trimPublishers(const std::list<gravity::Publish
                     // we have a local relay, so we're done here
                     break;
             }
-            else // ignore it
+            else  // ignore it
             {
                 continue;
             }
-		}
+        }
 
-		// The normal case
-		if (!iAmRelay && !foundGlobalRelay)
-		{
-			trimmedList.push_back(*iter);
-		}
-	}
-	logger->trace("added {} elements to trimmed pub list", trimmedList.size());
+        // The normal case
+        if (!iAmRelay && !foundGlobalRelay)
+        {
+            trimmedList.push_back(*iter);
+        }
+    }
+    logger->trace("added {} elements to trimmed pub list", trimmedList.size());
 }
 
 } /* namespace gravity */

--- a/src/api/cpp/GravitySubscriptionManager.h
+++ b/src/api/cpp/GravitySubscriptionManager.h
@@ -54,89 +54,91 @@ namespace gravity
 class GravitySubscriptionManager
 {
 private:
-	typedef struct TimeoutMonitor
-	{
-		GravitySubscriptionMonitor* monitor;
-		int timeout;
-		uint64_t endTime;
-		int64_t lastReceived;
-	} TimeoutMonitor;
+    typedef struct TimeoutMonitor
+    {
+        GravitySubscriptionMonitor *monitor;
+        int timeout;
+        uint64_t endTime;
+        int64_t lastReceived;
+    } TimeoutMonitor;
 
     typedef struct SubscriptionDetails
     {
         std::string domain;
         std::string dataProductID;
         std::string filter;
-		bool receiveCachedDataProducts;
+        bool receiveCachedDataProducts;
         std::map<std::string, zmq_pollitem_t> pollItemMap;
-		std::map<void*, std::string> socketToUrlMap;
-        std::set<GravitySubscriber*> subscribers;
-		std::set<std::shared_ptr<TimeoutMonitor> > monitors;
-		zmq_pollitem_t publisherUpdatePollItem;
-	} SubscriptionDetails;
+        std::map<void *, std::string> socketToUrlMap;
+        std::set<GravitySubscriber *> subscribers;
+        std::set<std::shared_ptr<TimeoutMonitor> > monitors;
+        zmq_pollitem_t publisherUpdatePollItem;
+    } SubscriptionDetails;
 
-	void* context;
-	void* gravityNodeSocket;
-    void* gravityMetricsSocket;
-	std::map<DomainDataKey, std::map<std::string, std::shared_ptr<SubscriptionDetails> > > subscriptionMap;
-    std::map<void*,std::shared_ptr<SubscriptionDetails> > subscriptionSocketMap;
-	std::map<void*,uint32_t> socketVerificationMap;
-	//std::map<DomainDataKey, std::map<std::string, zmq_pollitem_t> > publisherUpdateMap;
-    std::map<void*,std::shared_ptr<GravityDataProduct> > lastCachedValueMap;
-	std::vector<zmq_pollitem_t> pollItems;
+    void *context;
+    void *gravityNodeSocket;
+    void *gravityMetricsSocket;
+    std::map<DomainDataKey, std::map<std::string, std::shared_ptr<SubscriptionDetails> > > subscriptionMap;
+    std::map<void *, std::shared_ptr<SubscriptionDetails> > subscriptionSocketMap;
+    std::map<void *, uint32_t> socketVerificationMap;
+    //std::map<DomainDataKey, std::map<std::string, zmq_pollitem_t> > publisherUpdateMap;
+    std::map<void *, std::shared_ptr<GravityDataProduct> > lastCachedValueMap;
+    std::vector<zmq_pollitem_t> pollItems;
 
-	// Info for this node - not subscription specific
-	std::string domain;
-	std::string componentID;
-	std::string ipAddress;
+    // Info for this node - not subscription specific
+    std::string domain;
+    std::string componentID;
+    std::string ipAddress;
 
-	// Service Directory Location
-	std::string serviceDirectoryUrl;
+    // Service Directory Location
+    std::string serviceDirectoryUrl;
 
-	void setHWM();
-	void addSubscription();
-	void removeSubscription();
-	int readSubscription(void *socket, std::string &filterText, std::shared_ptr<GravityDataProduct> &dataProduct);
-	void *setupSubscription(const std::string &url, const std::string &filter, zmq_pollitem_t &pollItem);
-	void removePollItem(zmq_pollitem_t &pollItem);
-	void ready();
-	void setTimeoutMonitor();
-	void clearTimeoutMonitor();
-	void calculateTimeout();
-	void trimPublishers(const std::list<gravity::PublisherInfoPB>& fullList, std::list<gravity::PublisherInfoPB>& trimmedList);
-	void unsubscribeFromPollItem(zmq_pollitem_t pollItem, std::string filterText);
-	void notifyServiceDirectoryOfStaleEntry(std::string dataProductId, std::string domain, std::string url, uint32_t regTime);
+    void setHWM();
+    void addSubscription();
+    void removeSubscription();
+    int readSubscription(void *socket, std::string &filterText, std::shared_ptr<GravityDataProduct> &dataProduct);
+    void *setupSubscription(const std::string &url, const std::string &filter, zmq_pollitem_t &pollItem);
+    void removePollItem(zmq_pollitem_t &pollItem);
+    void ready();
+    void setTimeoutMonitor();
+    void clearTimeoutMonitor();
+    void calculateTimeout();
+    void trimPublishers(const std::list<gravity::PublisherInfoPB> &fullList,
+                        std::list<gravity::PublisherInfoPB> &trimmedList);
+    void unsubscribeFromPollItem(zmq_pollitem_t pollItem, std::string filterText);
+    void notifyServiceDirectoryOfStaleEntry(std::string dataProductId, std::string domain, std::string url,
+                                            uint32_t regTime);
 
-	int pollTimeout;
-	std::shared_ptr<TimeoutMonitor> currTimeoutMonitor;
-	std::shared_ptr<SubscriptionDetails> currMonitorDetails;
+    int pollTimeout;
+    std::shared_ptr<TimeoutMonitor> currTimeoutMonitor;
+    std::shared_ptr<SubscriptionDetails> currMonitorDetails;
 
-	int subscribeHWM;
+    int subscribeHWM;
     bool metricsEnabled;
     GravityMetrics metricsData;
     void collectMetrics(std::vector<std::shared_ptr<GravityDataProduct> > dataProducts);
-	
-	// Logger
-	std::shared_ptr<spdlog::logger> logger;
-	
+
+    // Logger
+    std::shared_ptr<spdlog::logger> logger;
+
 public:
-	/**
+    /**
 	 * Constructor GravitySubscriptionManager
 	 * \param context The zmq context in which the inproc socket will be established with the GravityNode
 	 */
-	GravitySubscriptionManager(void* context);
+    GravitySubscriptionManager(void *context);
 
-	/**
+    /**
 	 * Default destructor
 	 */
-	virtual ~GravitySubscriptionManager();
+    virtual ~GravitySubscriptionManager();
 
-	/**
+    /**
 	 * Starts the GravitySubscriptionManager which will run forever, managing subscriptions and
 	 * passing published data to the defined subscribers. Should be executed from GravityNode in
 	 * its own thread with a shared zmq context.
 	 */
-	void start();
+    void start();
 };
 
 } /* namespace gravity */

--- a/src/api/cpp/GravitySubscriptionMonitor.cpp
+++ b/src/api/cpp/GravitySubscriptionMonitor.cpp
@@ -25,13 +25,12 @@
 
 #include "GravitySubscriptionMonitor.h"
 
-namespace gravity {
-
+namespace gravity
+{
 
 GravitySubscriptionMonitor::~GravitySubscriptionMonitor() {}
-void GravitySubscriptionMonitor::subscriptionTimeout(std::string dataProductID, int milliSecondsSinceLast, std::string filter, std::string domain) {}
+void GravitySubscriptionMonitor::subscriptionTimeout(std::string dataProductID, int milliSecondsSinceLast,
+                                                     std::string filter, std::string domain)
+{
 }
-
-
-
-
+}  // namespace gravity

--- a/src/api/cpp/GravitySubscriptionMonitor.h
+++ b/src/api/cpp/GravitySubscriptionMonitor.h
@@ -49,7 +49,8 @@ public:
 	 * \param filter the name of the filter registered for this data product
 	 * \param domain the name of the domain for this data product
      */
-	GRAVITY_API virtual void subscriptionTimeout(std::string dataProductID, int milliSecondsSinceLast, std::string filter, std::string domain) = 0;
+    GRAVITY_API virtual void subscriptionTimeout(std::string dataProductID, int milliSecondsSinceLast,
+                                                 std::string filter, std::string domain) = 0;
 };
 
 } /* namespace gravity */

--- a/src/api/cpp/KeyValueParserWrap.h
+++ b/src/api/cpp/KeyValueParserWrap.h
@@ -34,38 +34,37 @@ public:
     /**
      * Constructor
      */
-    KeyValueConfigParser(const char* filename, const std::vector<const char *> &sections) :
-        spKeyValueHandle( keyvalue_open( filename, &sections[0] ), keyvalue_close ) {}
+    KeyValueConfigParser(const char *filename, const std::vector<const char *> &sections)
+        : spKeyValueHandle(keyvalue_open(filename, &sections[0]), keyvalue_close)
+    {
+    }
 
-     /**
+    /**
      * GetString: fetches a string given a key
      */
     std::string GetString(const std::string key, const std::string default_value = "")
     {
-    	std::string key_lower = gravity::StringCopyToLowerCase(key);
+        std::string key_lower = gravity::StringCopyToLowerCase(key);
         /* Returns "" if not found */
-        std::string value( keyvalue_getstring( spKeyValueHandle.get(), key.c_str() ) );
-    	if ( value.length() )
-            return value;
+        std::string value(keyvalue_getstring(spKeyValueHandle.get(), key.c_str()));
+        if (value.length()) return value;
         return default_value;
     }
 
-     /**
+    /**
      * GetKeys: fetches all the keys
      */
     std::vector<std::string> GetKeys()
     {
         std::vector<std::string> allkeys;
-        const char** keys = keyvalue_getkeys( spKeyValueHandle.get() );
-        for ( const char **_keys = keys; _keys && *_keys; _keys++ )
-            allkeys.push_back( *_keys );
-        if (keys)
-            free(keys);
+        const char **keys = keyvalue_getkeys(spKeyValueHandle.get());
+        for (const char **_keys = keys; _keys && *_keys; _keys++) allkeys.push_back(*_keys);
+        if (keys) free(keys);
         return allkeys;
     }
 
 protected:
-    std::shared_ptr< keyvalue_type_t > spKeyValueHandle;
+    std::shared_ptr<keyvalue_type_t> spKeyValueHandle;
 };
 
-#endif //_KEYVALUE_PARSERWRAP_H
+#endif  //_KEYVALUE_PARSERWRAP_H

--- a/src/api/cpp/PublishSink.h
+++ b/src/api/cpp/PublishSink.h
@@ -26,69 +26,67 @@
 
 namespace gravity
 {
-	
-template<typename Mutex>
+
+template <typename Mutex>
 class proxy_dist_sink : public spdlog::sinks::dist_sink<Mutex>
 {
     using BaseSink = spdlog::sinks::dist_sink<Mutex>;
 
 protected:
-    void sink_it_(const spdlog::details::log_msg &msg) override
+    void sink_it_(const spdlog::details::log_msg& msg) override
     {
-        if (BaseSink::should_log(msg.level)) 
-		{
+        if (BaseSink::should_log(msg.level))
+        {
             BaseSink::sink_it_(msg);
         }
     }
 };
-	
-template<typename Mutex>
+
+template <typename Mutex>
 class PublishSink : public spdlog::sinks::base_sink<Mutex>
 {
 private:
-	GravityNode* gn;
-	std::mutex lock;
-	bool init;
-	
-	bool checkInit()
-	{
-		std::lock_guard<std::mutex> guard(lock);
-		if (!init)
-		{
-			//GravityReturnCode ret  = gn->registerDataProduct(gravity::constants::GRAVITY_LOGGER_DPID, GravityTransportTypes::TCP);
-			GravityReturnCode ret  = gn->registerDataProductInternal(gravity::constants::GRAVITY_LOGGER_DPID, GravityTransportTypes::TCP, false, false, false, true);
-			init = ret == GravityReturnCodes::SUCCESS;
-		}
-		return init;
-	}
-	
+    GravityNode* gn;
+    std::mutex lock;
+    bool init;
+
+    bool checkInit()
+    {
+        std::lock_guard<std::mutex> guard(lock);
+        if (!init)
+        {
+            //GravityReturnCode ret  = gn->registerDataProduct(gravity::constants::GRAVITY_LOGGER_DPID, GravityTransportTypes::TCP);
+            GravityReturnCode ret = gn->registerDataProductInternal(
+                gravity::constants::GRAVITY_LOGGER_DPID, GravityTransportTypes::TCP, false, false, false, true);
+            init = ret == GravityReturnCodes::SUCCESS;
+        }
+        return init;
+    }
+
 public:
-	PublishSink(GravityNode* gn) : init(false)
-	{
-		this->gn = gn;
-	}
-	
+    PublishSink(GravityNode* gn) : init(false) { this->gn = gn; }
+
 protected:
     void sink_it_(const spdlog::details::log_msg& msg) override
     {
-		if (checkInit())
-		{
-			// Format message
-			spdlog::memory_buf_t formatted;
-			spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
+        if (checkInit())
+        {
+            // Format message
+            spdlog::memory_buf_t formatted;
+            spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
 
-			GravityDataProduct dp(gravity::constants::GRAVITY_LOGGER_DPID);
-			gravity::GravityLogMessagePB logMessage;
-			logMessage.set_level(spdlog::level::to_string_view(msg.level).data());
-			logMessage.set_message(fmt::to_string(formatted));
-			dp.setData(logMessage);
-			gn->publish(dp);
-		}
+            GravityDataProduct dp(gravity::constants::GRAVITY_LOGGER_DPID);
+            gravity::GravityLogMessagePB logMessage;
+            logMessage.set_level(spdlog::level::to_string_view(msg.level).data());
+            logMessage.set_message(fmt::to_string(formatted));
+            dp.setData(logMessage);
+            gn->publish(dp);
+        }
     }
 
-    void flush_() override 
+    void flush_() override
     {
-		// Nothing to do here
+        // Nothing to do here
     }
 };
-}
+}  // namespace gravity

--- a/src/api/cpp/Semaphore.cpp
+++ b/src/api/cpp/Semaphore.cpp
@@ -22,30 +22,16 @@
 
 using namespace std;
 
-namespace gravity {
-
-Semaphore::Semaphore()
+namespace gravity
 {
-	sem_init(&semaphore, 0, 1);
-}
 
-Semaphore::Semaphore(int count)
-{
-	sem_init(&semaphore, 0, count);
-}
+Semaphore::Semaphore() { sem_init(&semaphore, 0, 1); }
 
-void Semaphore::Lock()
-{
-	sem_wait(&semaphore);
-}
-void Semaphore::Unlock()
-{
-	sem_post(&semaphore);
-}
+Semaphore::Semaphore(int count) { sem_init(&semaphore, 0, count); }
 
-Semaphore::~Semaphore()
-{
-	sem_destroy(&semaphore);
-}
+void Semaphore::Lock() { sem_wait(&semaphore); }
+void Semaphore::Unlock() { sem_post(&semaphore); }
 
-}//namespace gravity
+Semaphore::~Semaphore() { sem_destroy(&semaphore); }
+
+}  //namespace gravity

--- a/src/api/cpp/SpdLog.cpp
+++ b/src/api/cpp/SpdLog.cpp
@@ -20,32 +20,14 @@
 
 using namespace gravity;
 
-void SpdLog::critical(const char* message)
-{
-	spdlog::critical(message);
-}
+void SpdLog::critical(const char* message) { spdlog::critical(message); }
 
-void SpdLog::error(const char* message)
-{
-	spdlog::error(message);
-}
+void SpdLog::error(const char* message) { spdlog::error(message); }
 
-void SpdLog::warn(const char* message)
-{
-	spdlog::warn(message);
-}
+void SpdLog::warn(const char* message) { spdlog::warn(message); }
 
-void SpdLog::info(const char* message)
-{
-	spdlog::info(message);
-}
+void SpdLog::info(const char* message) { spdlog::info(message); }
 
-void SpdLog::debug(const char* message)
-{
-	spdlog::debug(message);
-}
+void SpdLog::debug(const char* message) { spdlog::debug(message); }
 
-void SpdLog::trace(const char* message)
-{
-	spdlog::trace(message);
-}
+void SpdLog::trace(const char* message) { spdlog::trace(message); }

--- a/src/api/cpp/SpdLog.h
+++ b/src/api/cpp/SpdLog.h
@@ -21,7 +21,8 @@
 
 #include "GravityNode.h"
 
-namespace gravity {
+namespace gravity
+{
 
 #define SPD_LOG_OFF 6
 #define SPD_LOG_CRITICAL 5
@@ -42,8 +43,9 @@ public:
     /**
      * Log Levels
      */
-   enum LogLevel {
-        TRACE ,
+    enum LogLevel
+    {
+        TRACE,
         DEBUG,
         INFO,
         WARNING,
@@ -67,5 +69,5 @@ public:
     GRAVITY_API static void trace(const char* message);
 };
 
-} //Namespace
+}  // namespace gravity
 #endif

--- a/src/api/cpp/Utility.cpp
+++ b/src/api/cpp/Utility.cpp
@@ -26,11 +26,11 @@
 #include <Windows.h>
 #include <time.h>
 #include <algorithm>
-#if _MSC_VER < 1910 && !defined(_CRT_NO_TIME_T) 
+#if _MSC_VER < 1910 && !defined(_CRT_NO_TIME_T)
 struct timespec
 {
-	time_t tv_sec; // Seconds - >= 0
-	time_t tv_nsec; // Nanoseconds - [0, 999999999]
+    time_t tv_sec;   // Seconds - >= 0
+    time_t tv_nsec;  // Nanoseconds - [0, 999999999]
 };
 #endif
 #else
@@ -38,112 +38,102 @@ struct timespec
 #include <unistd.h>
 #endif
 
-namespace gravity {
+namespace gravity
+{
 
 // String Conversions
 GRAVITY_API std::string StringToLowerCase(std::string str)
 {
-	std::use_facet< std::ctype<char> >(std::locale("")).tolower(&str[0], &str[0] + str.length()); //Convert to lowercase.
-	return str;
+    std::use_facet<std::ctype<char> >(std::locale(""))
+        .tolower(&str[0], &str[0] + str.length());  //Convert to lowercase.
+    return str;
 }
 GRAVITY_API char* StringToLowerCase(char* str, int leng)
 {
-	std::use_facet< std::ctype<char> >(std::locale("")).tolower(&str[0], &str[0] + leng); //Convert to lowercase.
+    std::use_facet<std::ctype<char> >(std::locale("")).tolower(&str[0], &str[0] + leng);  //Convert to lowercase.
 
-	return str;
+    return str;
 }
 
-GRAVITY_API std::string StringCopyToLowerCase(const std::string &str)
+GRAVITY_API std::string StringCopyToLowerCase(const std::string& str)
 {
-	std::string copy = str;
-	return StringToLowerCase(copy);
+    std::string copy = str;
+    return StringToLowerCase(copy);
 }
 
 GRAVITY_API int StringToInt(std::string str, int default_value)
 {
-	int ret_val;
-	std::stringstream ss(str);
-	ss >> ret_val;
-	if(ss.fail())
-		ret_val = default_value;
-	return ret_val;
+    int ret_val;
+    std::stringstream ss(str);
+    ss >> ret_val;
+    if (ss.fail()) ret_val = default_value;
+    return ret_val;
 }
 
 GRAVITY_API double StringToDouble(std::string str, double default_value)
 {
-	double ret_val;
-	std::stringstream ss(str);
-	ss >> ret_val;
-	if(ss.fail())
-		ret_val = default_value;
-	return ret_val;
+    double ret_val;
+    std::stringstream ss(str);
+    ss >> ret_val;
+    if (ss.fail()) ret_val = default_value;
+    return ret_val;
 }
 
 //Trimming
-std::string& trim_right_inplace( //TODO confirm removal from GRAVITY_API
-  std::string&       s,
-  const std::string& delimiters = " \f\n\r\t\v" )
+std::string& trim_right_inplace(  //TODO confirm removal from GRAVITY_API
+    std::string& s, const std::string& delimiters = " \f\n\r\t\v")
 {
-  return s.erase( s.find_last_not_of( delimiters ) + 1 );
+    return s.erase(s.find_last_not_of(delimiters) + 1);
 }
 
-std::string& trim_left_inplace(//TODO confirm removal from GRAVITY_API
-  std::string&       s,
-  const std::string& delimiters = " \f\n\r\t\v" )
+std::string& trim_left_inplace(  //TODO confirm removal from GRAVITY_API
+    std::string& s, const std::string& delimiters = " \f\n\r\t\v")
 {
-  return s.erase( 0, s.find_first_not_of( delimiters ) );
+    return s.erase(0, s.find_first_not_of(delimiters));
 }
 
-GRAVITY_API std::string& trim(
-  std::string&       s,
-  const std::string& delimiters)
+GRAVITY_API std::string& trim(std::string& s, const std::string& delimiters)
 {
-  return trim_left_inplace( trim_right_inplace( s, delimiters ), delimiters );
+    return trim_left_inplace(trim_right_inplace(s, delimiters), delimiters);
 }
 
 GRAVITY_API void replaceAll(std::string& target, const std::string& oldValue, const std::string& newValue)
 {
     //necessary check - otherwise program crashes
-    if (oldValue.empty())
-      return;
+    if (oldValue.empty()) return;
     auto pos = target.find(oldValue);
-    while(pos != std::string::npos) {
-      target.replace(pos, oldValue.size(), newValue);
-      pos = target.find(oldValue);
+    while (pos != std::string::npos)
+    {
+        target.replace(pos, oldValue.size(), newValue);
+        pos = target.find(oldValue);
     }
 }
-
 
 // OS
 GRAVITY_API bool IsValidFilename(const std::string filename)
 {
-	char restrictedChars[] = "/\\?%*:|\"<>";
-	const size_t numRChars = 10;
-	size_t numDots = 0;
+    char restrictedChars[] = "/\\?%*:|\"<>";
+    const size_t numRChars = 10;
+    size_t numDots = 0;
 
-	for(size_t i = 0; i < filename.length(); i++)
-	{
-		if(filename[i] < 31)
-			return false;
+    for (size_t i = 0; i < filename.length(); i++)
+    {
+        if (filename[i] < 31) return false;
 
-		for(size_t r = 0; r < numRChars; r++)
-			if(filename[i] == restrictedChars[r])
-				return false;
+        for (size_t r = 0; r < numRChars; r++)
+            if (filename[i] == restrictedChars[r]) return false;
 
-		if(filename[i] == '.')
-			numDots++;
-	}
+        if (filename[i] == '.') numDots++;
+    }
 
-	//TODO: on windows check for specific restrictions (cannot be complete first segment before .):
-	//CON, PRN, AUX, CLOCK$, NUL, COM0, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT0, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9.
-	//And not the following for NTFS: $Mft, $MftMirr, $LogFile, $Volume, $AttrDef, $Bitmap, $Boot, $BadClus, $Secure, $Upcase, $Extend, $Quota, $ObjId and $Reparse
+    //TODO: on windows check for specific restrictions (cannot be complete first segment before .):
+    //CON, PRN, AUX, CLOCK$, NUL, COM0, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT0, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9.
+    //And not the following for NTFS: $Mft, $MftMirr, $LogFile, $Volume, $AttrDef, $Bitmap, $Boot, $BadClus, $Secure, $Upcase, $Extend, $Quota, $ObjId and $Reparse
 
-	if(numDots == filename.length())
-		return false;  //We can't be all dots.
+    if (numDots == filename.length()) return false;  //We can't be all dots.
 
-	return true;
+    return true;
 }
-
 
 //Replace the clock_gettime for Windows.
 #ifdef WIN32
@@ -171,26 +161,29 @@ getFILETIMEoffset()
 }
 
 //T. Ludwinski: changed timeval to timespec and microseconds to nanoseconds
-int
-clock_gettime(int X, struct timespec *tv)
+int clock_gettime(int X, struct timespec* tv)
 {
-    LARGE_INTEGER           t;
-    FILETIME            f;
-    double                  nanoseconds;
-    static LARGE_INTEGER    offset;
-    static double           frequencyToNanoseconds;
-    static int              initialized = 0;
-    static BOOL             usePerformanceCounter = 0;
-    static LARGE_INTEGER 	startTime;
+    LARGE_INTEGER t;
+    FILETIME f;
+    double nanoseconds;
+    static LARGE_INTEGER offset;
+    static double frequencyToNanoseconds;
+    static int initialized = 0;
+    static BOOL usePerformanceCounter = 0;
+    static LARGE_INTEGER startTime;
 
-    if (!initialized) {
+    if (!initialized)
+    {
         LARGE_INTEGER performanceFrequency;
         initialized = 1;
         usePerformanceCounter = QueryPerformanceFrequency(&performanceFrequency);
-        if (usePerformanceCounter) {
+        if (usePerformanceCounter)
+        {
             QueryPerformanceCounter(&offset);
             frequencyToNanoseconds = (double)performanceFrequency.QuadPart / 1000000000.;
-        } else {
+        }
+        else
+        {
             offset = getFILETIMEoffset();
             frequencyToNanoseconds = .01;
         }
@@ -200,11 +193,13 @@ clock_gettime(int X, struct timespec *tv)
         startTime.QuadPart <<= 32;
         startTime.QuadPart |= f.dwLowDateTime;
 
-        startTime.QuadPart -= 116444736000000000ULL; //Convert from Window time to UTC (100ns)
-        startTime.QuadPart = startTime.QuadPart * 100; //To nanoseconds
+        startTime.QuadPart -= 116444736000000000ULL;    //Convert from Window time to UTC (100ns)
+        startTime.QuadPart = startTime.QuadPart * 100;  //To nanoseconds
     }
-    if (usePerformanceCounter) QueryPerformanceCounter(&t);
-    else {
+    if (usePerformanceCounter)
+        QueryPerformanceCounter(&t);
+    else
+    {
         GetSystemTimeAsFileTime(&f);
         t.QuadPart = f.dwHighDateTime;
         t.QuadPart <<= 32;
@@ -214,7 +209,7 @@ clock_gettime(int X, struct timespec *tv)
     t.QuadPart -= offset.QuadPart;
     nanoseconds = (double)t.QuadPart / frequencyToNanoseconds;
     nanoseconds += startTime.QuadPart;
-    t.QuadPart = (LONGLONG) nanoseconds;
+    t.QuadPart = (LONGLONG)nanoseconds;
     tv->tv_sec = t.QuadPart / 1000000000LL;
     tv->tv_nsec = t.QuadPart % 1000000000LL;
     return (0);
@@ -225,19 +220,19 @@ GRAVITY_API uint64_t getCurrentTime()
 {
     timespec ts;
     clock_gettime(0, &ts);
-    return (uint64_t)ts.tv_sec * 1000000LL + (uint64_t)ts.tv_nsec / 1000LL; //in microseconds
+    return (uint64_t)ts.tv_sec * 1000000LL + (uint64_t)ts.tv_nsec / 1000LL;  //in microseconds
 }
 
 GRAVITY_API unsigned int sleep(int milliseconds)
 {
-	// If sleep time < 0, set it to 0
-	milliseconds = std::max(0, milliseconds);
+    // If sleep time < 0, set it to 0
+    milliseconds = std::max(0, milliseconds);
 #ifdef WIN32
-	Sleep(milliseconds);
-	return 0;
+    Sleep(milliseconds);
+    return 0;
 #else
-	return usleep(milliseconds*1000); //Maybe replace this guy with clock_nanosleep???
+    return usleep(milliseconds * 1000);  //Maybe replace this guy with clock_nanosleep???
 #endif
 }
 
-}
+}  // namespace gravity

--- a/src/api/cpp/Utility.h
+++ b/src/api/cpp/Utility.h
@@ -25,37 +25,38 @@
  * Mark functions that are part of the public API.
  */
 #ifdef _WIN32
-#    if _WIN32 != __MINGW32__
-#        ifdef GRAVITY_EXPORTS
-#            define GRAVITY_API __declspec(dllexport)
-#        else
-#            define GRAVITY_API __declspec(dllimport)
-#        endif
-#    else
-#        define GRAVITY_API
-#    endif
+#if _WIN32 != __MINGW32__
+#ifdef GRAVITY_EXPORTS
+#define GRAVITY_API __declspec(dllexport)
 #else
-#    define GRAVITY_API
+#define GRAVITY_API __declspec(dllimport)
+#endif
+#else
+#define GRAVITY_API
+#endif
+#else
+#define GRAVITY_API
 #endif
 
-namespace gravity {
+namespace gravity
+{
 
 /**
  * @name String conversion and helper functions
  * @{
- */ 
-GRAVITY_API std::string StringToLowerCase(std::string str); ///< Return lowercase string
-GRAVITY_API char* StringToLowerCase(char* str, int leng); ///< In-place modification and returns ptr to string
-GRAVITY_API std::string StringCopyToLowerCase(const std::string &str); ///< \TODO remove, same as StringToLowerCase
-GRAVITY_API int StringToInt(std::string str, int default_value); ///< Return an integer.
-GRAVITY_API double StringToDouble(std::string str, double default_value); ///< Return a double
+ */
+GRAVITY_API std::string StringToLowerCase(std::string str);  ///< Return lowercase string
+GRAVITY_API char* StringToLowerCase(char* str, int leng);    ///< In-place modification and returns ptr to string
+GRAVITY_API std::string StringCopyToLowerCase(const std::string& str);     ///< \TODO remove, same as StringToLowerCase
+GRAVITY_API int StringToInt(std::string str, int default_value);           ///< Return an integer.
+GRAVITY_API double StringToDouble(std::string str, double default_value);  ///< Return a double
 /**
  * Trim a string.
  * \param s string that will be modified
  * \param delimiters characters to remove from the right and left of the string
  * \return also return a reference to the modified string
  */
-GRAVITY_API std::string& trim(std::string& s, const std::string& delimiters = " \f\n\r\t\v" );
+GRAVITY_API std::string& trim(std::string& s, const std::string& delimiters = " \f\n\r\t\v");
 
 /**
  * Replace substrings in a string.
@@ -64,9 +65,9 @@ GRAVITY_API std::string& trim(std::string& s, const std::string& delimiters = " 
  * \param newValue replacement substring
  */
 GRAVITY_API void replaceAll(std::string& target, const std::string& oldValue, const std::string& newValue);
-/** @} */ //String conversion and helper functions
+/** @} */  //String conversion and helper functions
 
-GRAVITY_API bool IsValidFilename(const std::string filename); ///< Return if filename is valid, which is OS dependent
+GRAVITY_API bool IsValidFilename(const std::string filename);  ///< Return if filename is valid, which is OS dependent
 
 /**
  * @name Time functions
@@ -77,10 +78,10 @@ GRAVITY_API bool IsValidFilename(const std::string filename); ///< Return if fil
  * \TODO place an ifdef around this
  */
 GRAVITY_API uint64_t getCurrentTime();
-/** @} */ //Time functions
+/** @} */  //Time functions
 
 GRAVITY_API unsigned int sleep(int milliseconds);
 
-}
+}  // namespace gravity
 
-#endif //GRAVITY_UTILITY_H__
+#endif  //GRAVITY_UTILITY_H__

--- a/src/api/java/src/cpp/CPPGravityHeartbeatListener.cpp
+++ b/src/api/java/src/cpp/CPPGravityHeartbeatListener.cpp
@@ -16,23 +16,23 @@
  **
  */
 
-
-
 #include "CPPGravityHeartbeatListener.h"
 #include <iostream>
 
 using namespace gravity;
 using namespace std;
 
-CPPGravityHeartbeatListener::~CPPGravityHeartbeatListener()
-{}
+CPPGravityHeartbeatListener::~CPPGravityHeartbeatListener() {}
 
-void CPPGravityHeartbeatListener::MissedHeartbeat(std::string componentID, int64_t microsecond_to_last_heartbeat, int64_t& interval_in_microseconds)
+void CPPGravityHeartbeatListener::MissedHeartbeat(std::string componentID, int64_t microsecond_to_last_heartbeat,
+                                                  int64_t& interval_in_microseconds)
 {
     MissedHeartbeatJava(componentID, microsecond_to_last_heartbeat, interval_in_microseconds);
 }
 
-int64_t CPPGravityHeartbeatListener::MissedHeartbeatJava(const std::string componentID, int64_t microsecond_to_last_heartbeat, int64_t& interval_in_microseconds)
+int64_t CPPGravityHeartbeatListener::MissedHeartbeatJava(const std::string componentID,
+                                                         int64_t microsecond_to_last_heartbeat,
+                                                         int64_t& interval_in_microseconds)
 {
     return 0L;
 }
@@ -42,8 +42,8 @@ void CPPGravityHeartbeatListener::ReceivedHeartbeat(std::string componentID, int
     ReceivedHeartbeatJava(componentID, interval_in_microseconds);
 }
 
-int64_t CPPGravityHeartbeatListener::ReceivedHeartbeatJava(const std::string componentID, int64_t& interval_in_microseconds)
+int64_t CPPGravityHeartbeatListener::ReceivedHeartbeatJava(const std::string componentID,
+                                                           int64_t& interval_in_microseconds)
 {
     return 0L;
 }
-

--- a/src/api/java/src/cpp/CPPGravityHeartbeatListener.h
+++ b/src/api/java/src/cpp/CPPGravityHeartbeatListener.h
@@ -16,7 +16,6 @@
  **
  */
 
-
 #ifndef CPPGRAVITYHEARTBEATLISTENER_H_
 #define CPPGRAVITYHEARTBEATLISTENER_H_
 
@@ -31,14 +30,14 @@ namespace gravity
 class CPPGravityHeartbeatListener : public GravityHeartbeatListener
 {
 public:
-
     virtual ~CPPGravityHeartbeatListener();
-    virtual void MissedHeartbeat(std::string componentID, int64_t microsecond_to_last_heartbeat, int64_t& interval_in_microseconds);
-    virtual int64_t MissedHeartbeatJava(const std::string componentID, int64_t microsecond_to_last_heartbeat, int64_t& interval_in_microseconds);
+    virtual void MissedHeartbeat(std::string componentID, int64_t microsecond_to_last_heartbeat,
+                                 int64_t& interval_in_microseconds);
+    virtual int64_t MissedHeartbeatJava(const std::string componentID, int64_t microsecond_to_last_heartbeat,
+                                        int64_t& interval_in_microseconds);
     virtual void ReceivedHeartbeat(std::string componentID, int64_t& interval_in_microseconds);
     virtual int64_t ReceivedHeartbeatJava(const std::string componentID, int64_t& interval_in_microseconds);
 };
 
-}
+}  // namespace gravity
 #endif /* CPPGRAVITYHEARTBEATLISTENER_H_ */
-

--- a/src/api/java/src/cpp/CPPGravityLogger.cpp
+++ b/src/api/java/src/cpp/CPPGravityLogger.cpp
@@ -20,11 +20,6 @@
 
 using namespace gravity;
 
-CPPGravityLogger::~CPPGravityLogger()
-{}
+CPPGravityLogger::~CPPGravityLogger() {}
 
-void CPPGravityLogger::Log(int level, const char* messagestr)
-{
-}
-
-
+void CPPGravityLogger::Log(int level, const char* messagestr) {}

--- a/src/api/java/src/cpp/CPPGravityLogger.h
+++ b/src/api/java/src/cpp/CPPGravityLogger.h
@@ -16,7 +16,6 @@
  **
  */
 
-
 #ifndef CPPGRAVITYLOGGER_H_
 #define CPPGRAVITYLOGGER_H_
 
@@ -31,11 +30,9 @@ namespace gravity
 class CPPGravityLogger : public Logger
 {
 public:
-
     virtual ~CPPGravityLogger();
     virtual void Log(int level, const char* messagestr);
 };
 
-}
+}  // namespace gravity
 #endif /* CPPGRAVITYLOGGER_H_ */
-

--- a/src/api/java/src/cpp/CPPGravityRequestor.cpp
+++ b/src/api/java/src/cpp/CPPGravityRequestor.cpp
@@ -16,26 +16,24 @@
  **
  */
 
-
-
 #include "CPPGravityRequestor.h"
 #include <iostream>
 
 using namespace gravity;
 
-CPPGravityRequestor::~CPPGravityRequestor()
-{}
+CPPGravityRequestor::~CPPGravityRequestor() {}
 
-void CPPGravityRequestor::requestFilled(std::string serviceID, std::string requestID, const GravityDataProduct& response)
+void CPPGravityRequestor::requestFilled(std::string serviceID, std::string requestID,
+                                        const GravityDataProduct& response)
 {
     unsigned char* array = new unsigned char[response.getSize()];
     response.serializeToArray(array);
     requestFilled(serviceID, requestID, (char*)array, response.getSize());
-	delete[] array;
+    delete[] array;
 }
 
-char CPPGravityRequestor::requestFilled(const std::string& serviceID, const std::string& requestID, char* array, int length)
+char CPPGravityRequestor::requestFilled(const std::string& serviceID, const std::string& requestID, char* array,
+                                        int length)
 {
     return 0;
 }
-

--- a/src/api/java/src/cpp/CPPGravityRequestor.h
+++ b/src/api/java/src/cpp/CPPGravityRequestor.h
@@ -16,7 +16,6 @@
  **
  */
 
-
 #ifndef CPPGRAVITYREQUESTOR_H_
 #define CPPGRAVITYREQUESTOR_H_
 
@@ -31,12 +30,10 @@ namespace gravity
 class CPPGravityRequestor : public GravityRequestor
 {
 public:
-
     virtual ~CPPGravityRequestor();
     virtual void requestFilled(std::string serviceID, std::string requestID, const GravityDataProduct& response);
     virtual char requestFilled(const std::string& serviceID, const std::string& requestID, char* array, int length);
 };
 
-}
+}  // namespace gravity
 #endif /* CPPGRAVITYREQUESTOR_H_ */
-

--- a/src/api/java/src/cpp/CPPGravityServiceProvider.cpp
+++ b/src/api/java/src/cpp/CPPGravityServiceProvider.cpp
@@ -22,10 +22,10 @@
 
 using namespace gravity;
 
-CPPGravityServiceProvider::~CPPGravityServiceProvider()
-{}
+CPPGravityServiceProvider::~CPPGravityServiceProvider() {}
 
-std::shared_ptr<GravityDataProduct> CPPGravityServiceProvider::request(const std::string serviceID, const GravityDataProduct& dataProduct)
+std::shared_ptr<GravityDataProduct> CPPGravityServiceProvider::request(const std::string serviceID,
+                                                                       const GravityDataProduct& dataProduct)
 {
     unsigned char* array = new unsigned char[dataProduct.getSize()];
     dataProduct.serializeToArray(array);
@@ -34,9 +34,9 @@ std::shared_ptr<GravityDataProduct> CPPGravityServiceProvider::request(const std
     return ret;
 }
 
-std::shared_ptr<GravityDataProduct> CPPGravityServiceProvider::request(const std::string serviceID, char* array, int length)
+std::shared_ptr<GravityDataProduct> CPPGravityServiceProvider::request(const std::string serviceID, char* array,
+                                                                       int length)
 {
     std::shared_ptr<GravityDataProduct> ret(new GravityDataProduct("CPP RESPONSE"));
     return ret;
 }
-

--- a/src/api/java/src/cpp/CPPGravityServiceProvider.h
+++ b/src/api/java/src/cpp/CPPGravityServiceProvider.h
@@ -16,7 +16,6 @@
  **
  */
 
-
 #ifndef CPPGRAVITYSERVICEPROVIDER_H_
 #define CPPGRAVITYSERVICEPROVIDER_H_
 
@@ -31,12 +30,11 @@ namespace gravity
 class CPPGravityServiceProvider : public GravityServiceProvider
 {
 public:
-
     virtual ~CPPGravityServiceProvider();
-    virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID, const GravityDataProduct& dataProduct);
-    virtual std::shared_ptr<GravityDataProduct>  request(const std::string serviceID, char* array, int length);
+    virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID,
+                                                        const GravityDataProduct& dataProduct);
+    virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID, char* array, int length);
 };
 
-}
+}  // namespace gravity
 #endif /* CPPGRAVITYSERVICEPROVIDER_H_ */
-

--- a/src/api/java/src/cpp/CPPGravitySubscriber.cpp
+++ b/src/api/java/src/cpp/CPPGravitySubscriber.cpp
@@ -16,18 +16,15 @@
  **
  */
 
-
-
 #include "CPPGravitySubscriber.h"
 #include <iostream>
 #include <memory>
 
 using namespace gravity;
 
-CPPGravitySubscriber::~CPPGravitySubscriber()
-{}
+CPPGravitySubscriber::~CPPGravitySubscriber() {}
 
-void CPPGravitySubscriber::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void CPPGravitySubscriber::subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
     int* lengths = new int[dataProducts.size()];
     int arrayLength = 0;
@@ -44,12 +41,8 @@ void CPPGravitySubscriber::subscriptionFilled(const std::vector< std::shared_ptr
         offset += lengths[index];
     }
     subscriptionFilled((char*)array, arrayLength, lengths, dataProducts.size());
-	delete[] lengths;
-	delete[] array;
+    delete[] lengths;
+    delete[] array;
 }
 
-int CPPGravitySubscriber::subscriptionFilled(char* array, int arrayLength, int* lengths, int length)
-{
-    return 0;
-}
-
+int CPPGravitySubscriber::subscriptionFilled(char* array, int arrayLength, int* lengths, int length) { return 0; }

--- a/src/api/java/src/cpp/CPPGravitySubscriber.h
+++ b/src/api/java/src/cpp/CPPGravitySubscriber.h
@@ -16,7 +16,6 @@
  **
  */
 
-
 #ifndef CPPGRAVITYSUBSCRIBER_H_
 #define CPPGRAVITYSUBSCRIBER_H_
 
@@ -31,12 +30,10 @@ namespace gravity
 class CPPGravitySubscriber : public GravitySubscriber
 {
 public:
-
     virtual ~CPPGravitySubscriber();
-    virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
     virtual int subscriptionFilled(char* array, int arrayLength, int* lengths, int length);
 };
 
-}
+}  // namespace gravity
 #endif /* CPPGRAVITYSUBSCRIBER_H_ */
-

--- a/src/api/java/src/cpp/CPPGravitySubscriptionMonitor.cpp
+++ b/src/api/java/src/cpp/CPPGravitySubscriptionMonitor.cpp
@@ -21,13 +21,15 @@
 
 using namespace gravity;
 
-CPPGravitySubscriptionMonitor::~CPPGravitySubscriptionMonitor()
-{}
+CPPGravitySubscriptionMonitor::~CPPGravitySubscriptionMonitor() {}
 
-void CPPGravitySubscriptionMonitor::subscriptionTimeout(std::string dataProductID, int milliSecondsSinceLast, std::string filter, std::string domain)
+void CPPGravitySubscriptionMonitor::subscriptionTimeout(std::string dataProductID, int milliSecondsSinceLast,
+                                                        std::string filter, std::string domain)
 {
-	subscriptionTimeoutJava(dataProductID,milliSecondsSinceLast,filter,domain);
+    subscriptionTimeoutJava(dataProductID, milliSecondsSinceLast, filter, domain);
 }
 
-void CPPGravitySubscriptionMonitor::subscriptionTimeoutJava(const std::string& dataProductID, int milliSecondsSinceLast, const std::string& filter, const std::string& domain)
-{}
+void CPPGravitySubscriptionMonitor::subscriptionTimeoutJava(const std::string& dataProductID, int milliSecondsSinceLast,
+                                                            const std::string& filter, const std::string& domain)
+{
+}

--- a/src/api/java/src/cpp/CPPGravitySubscriptionMonitor.h
+++ b/src/api/java/src/cpp/CPPGravitySubscriptionMonitor.h
@@ -27,10 +27,12 @@ namespace gravity
 class CPPGravitySubscriptionMonitor : public GravitySubscriptionMonitor
 {
 public:
-	virtual ~CPPGravitySubscriptionMonitor();
-	virtual void subscriptionTimeout(std::string dataProductID, int milliSecondsSinceLast, std::string filter, std::string domain);
-	virtual void subscriptionTimeoutJava(const std::string& dataProductID, int milliSecondsSinceLast, const std::string& filter, const std::string& domain);
+    virtual ~CPPGravitySubscriptionMonitor();
+    virtual void subscriptionTimeout(std::string dataProductID, int milliSecondsSinceLast, std::string filter,
+                                     std::string domain);
+    virtual void subscriptionTimeoutJava(const std::string& dataProductID, int milliSecondsSinceLast,
+                                         const std::string& filter, const std::string& domain);
 };
-}
+}  // namespace gravity
 
 #endif /* CPPGRAVITYSUBSCRIPTIONMONITOR_H_ */

--- a/src/components/cpp/Archiver/FileArchiver.cpp
+++ b/src/components/cpp/Archiver/FileArchiver.cpp
@@ -29,82 +29,81 @@ using namespace std;
 
 int main(int argc, const char* argv[])
 {
-	gravity::FileArchiver archiver;
-	archiver.waitForExit();
+    gravity::FileArchiver archiver;
+    archiver.waitForExit();
 }
 
-namespace gravity {
+namespace gravity
+{
 
 const char* FileArchiver::ComponentName = "FileArchiver";
 
 FileArchiver::FileArchiver()
 {
-	// Initialize Gravity Node
-	gravityNode.init(FileArchiver::ComponentName);
-	
-	// Get logger
-	logger = spdlog::get("GravityLogger");
+    // Initialize Gravity Node
+    gravityNode.init(FileArchiver::ComponentName);
 
-	// Configure logger to log to console
-	//Log::initAndAddConsoleLogger(FileArchiver::ComponentName, Log::MESSAGE);
+    // Get logger
+    logger = spdlog::get("GravityLogger");
 
-	// Open archive file
-	string filename = gravityNode.getStringParam("ArchiveFilename", "archive.bin");
-	if (filename == "auto")
-	{
-		time_t now;
-		struct tm ts;
-		char fname[80];
-		time(&now);
-		ts = *localtime(&now);
-		strftime(fname, sizeof(fname), "archive_%Y%m%d_%H%M%S.bin", &ts);
-		//cout << "fname = '" << fname << "'" << endl;
-		archiveFile.open(fname, ios::out | ios::binary);
-	}
-	else
-	{
-		archiveFile.open(filename.c_str(), ios::out | ios::binary);
-	}
+    // Configure logger to log to console
+    //Log::initAndAddConsoleLogger(FileArchiver::ComponentName, Log::MESSAGE);
 
-	// Write value (1) to endian-ness check when read
-	int value = 1;
-        archiveFile.write((char*)&value, sizeof(value));
+    // Open archive file
+    string filename = gravityNode.getStringParam("ArchiveFilename", "archive.bin");
+    if (filename == "auto")
+    {
+        time_t now;
+        struct tm ts;
+        char fname[80];
+        time(&now);
+        ts = *localtime(&now);
+        strftime(fname, sizeof(fname), "archive_%Y%m%d_%H%M%S.bin", &ts);
+        //cout << "fname = '" << fname << "'" << endl;
+        archiveFile.open(fname, ios::out | ios::binary);
+    }
+    else
+    {
+        archiveFile.open(filename.c_str(), ios::out | ios::binary);
+    }
 
-	// Get list of data products to archive
-	string dpList = gravityNode.getStringParam("DataProductList", "");
+    // Write value (1) to endian-ness check when read
+    int value = 1;
+    archiveFile.write((char*)&value, sizeof(value));
 
-	// allow starting suspended
-	suspend = gravityNode.getBoolParam("StartSuspended", false);
+    // Get list of data products to archive
+    string dpList = gravityNode.getStringParam("DataProductList", "");
 
-	gravityNode.registerService("FileArchiverControlRequest", GravityTransportTypes::TCP, *this);
+    // allow starting suspended
+    suspend = gravityNode.getBoolParam("StartSuspended", false);
 
-	// Subscribe to each data product
-	vector<string> dps = split(dpList);
-	for (vector<string>::iterator iter = dps.begin(); iter != dps.end(); iter++)
-	{
-	    gravityNode.subscribe(*iter, *this);
-	}
+    gravityNode.registerService("FileArchiverControlRequest", GravityTransportTypes::TCP, *this);
+
+    // Subscribe to each data product
+    vector<string> dps = split(dpList);
+    for (vector<string>::iterator iter = dps.begin(); iter != dps.end(); iter++)
+    {
+        gravityNode.subscribe(*iter, *this);
+    }
 }
 
-FileArchiver::~FileArchiver()
-{
-}
+FileArchiver::~FileArchiver() {}
 
 vector<string> FileArchiver::split(string s)
 {
-	vector<string> tokens;
+    vector<string> tokens;
 
-	std::istringstream iss(s);
-	std::string tok;
-	while (getline(iss, tok, ','))
-	{
-		// trim any spaces from the ends
-		tok.erase(tok.find_last_not_of(" ") + 1);
-		tok.erase(0, tok.find_first_not_of(" "));
-		tokens.push_back(tok);
-	}
+    std::istringstream iss(s);
+    std::string tok;
+    while (getline(iss, tok, ','))
+    {
+        // trim any spaces from the ends
+        tok.erase(tok.find_last_not_of(" ") + 1);
+        tok.erase(0, tok.find_first_not_of(" "));
+        tokens.push_back(tok);
+    }
 
-	return tokens;
+    return tokens;
 }
 
 void FileArchiver::subscriptionFilled(const vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
@@ -130,7 +129,8 @@ void FileArchiver::subscriptionFilled(const vector<std::shared_ptr<GravityDataPr
     }
 }
 
-std::shared_ptr<GravityDataProduct> FileArchiver::request(const std::string serviceID, const GravityDataProduct& dataProduct)
+std::shared_ptr<GravityDataProduct> FileArchiver::request(const std::string serviceID,
+                                                          const GravityDataProduct& dataProduct)
 {
     logger->debug("Received service request of type '{}'", serviceID);
     FileArchiverControlResponsePB faResponse;
@@ -152,14 +152,12 @@ std::shared_ptr<GravityDataProduct> FileArchiver::request(const std::string serv
         }
     }
 
-    std::shared_ptr<GravityDataProduct> gdpResponse = std::shared_ptr<GravityDataProduct>(new GravityDataProduct("FileArchiverControlResponse"));
+    std::shared_ptr<GravityDataProduct> gdpResponse =
+        std::shared_ptr<GravityDataProduct>(new GravityDataProduct("FileArchiverControlResponse"));
     gdpResponse->setData(faResponse);
     return gdpResponse;
 }
 
-void FileArchiver::waitForExit()
-{
-	gravityNode.waitForExit();
-}
+void FileArchiver::waitForExit() { gravityNode.waitForExit(); }
 
 } /* namespace gravity */

--- a/src/components/cpp/Archiver/FileArchiver.h
+++ b/src/components/cpp/Archiver/FileArchiver.h
@@ -25,26 +25,29 @@
 #include <vector>
 #include "spdlog/spdlog.h"
 
-namespace gravity {
+namespace gravity
+{
 
 class FileArchiver : public GravitySubscriber, GravityServiceProvider
 {
 private:
-	static const char* ComponentName;
-	GravityNode gravityNode;
-	std::ofstream archiveFile;
-	bool suspend;
+    static const char* ComponentName;
+    GravityNode gravityNode;
+    std::ofstream archiveFile;
+    bool suspend;
 
-	std::vector<std::string> split(std::string s);
-	
-	std::shared_ptr<spdlog::logger> logger;
+    std::vector<std::string> split(std::string s);
+
+    std::shared_ptr<spdlog::logger> logger;
+
 public:
-	FileArchiver();
-	virtual ~FileArchiver();
+    FileArchiver();
+    virtual ~FileArchiver();
 
-	virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
-    virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID, const GravityDataProduct& dataProduct);
-	void waitForExit();
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
+    virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID,
+                                                        const GravityDataProduct& dataProduct);
+    void waitForExit();
 };
 
 } /* namespace gravity */

--- a/src/components/cpp/ConfigServer/ConfigServer.cpp
+++ b/src/components/cpp/ConfigServer/ConfigServer.cpp
@@ -30,40 +30,42 @@ using namespace std;
 
 struct ConfigEntry
 {
-	ConfigEntry(std::string s1, std::string s2, std::string s3)
-	{
-		section = s1;
-		key = s2;
-		value = s3;
-	}
-	std::string section;
-	std::string key;
-	std::string value;
+    ConfigEntry(std::string s1, std::string s2, std::string s3)
+    {
+        section = s1;
+        key = s2;
+        value = s3;
+    }
+    std::string section;
+    std::string key;
+    std::string value;
 };
 
 class ConfigServer : public GravityServiceProvider
 {
 public:
-	ConfigServer() {}
-    virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID, const GravityDataProduct& dataProduct);
-    ~ConfigServer() {};
+    ConfigServer() {}
+    virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID,
+                                                        const GravityDataProduct& dataProduct);
+    ~ConfigServer(){};
 };
 
-std::shared_ptr<GravityDataProduct> ConfigServer::request(const std::string serviceID, const GravityDataProduct& dataProduct)
+std::shared_ptr<GravityDataProduct> ConfigServer::request(const std::string serviceID,
+                                                          const GravityDataProduct& dataProduct)
 {
-	ConfigRequestPB cfpb;
-	dataProduct.populateMessage(cfpb);
-    std::vector<const char *> sections;
+    ConfigRequestPB cfpb;
+    dataProduct.populateMessage(cfpb);
+    std::vector<const char*> sections;
 
-	//Get the parameters we're going to send from the config file.
-	std::map<std::string, std::string> key_value_map;
+    //Get the parameters we're going to send from the config file.
+    std::map<std::string, std::string> key_value_map;
     std::vector<std::string> keys;
 
-	//First send all general parameters
+    //First send all general parameters
     sections.push_back("general");
 
-	//Then override/add to general parameters with specific parameters
-	sections.push_back(cfpb.componentid().c_str());
+    //Then override/add to general parameters with specific parameters
+    sections.push_back(cfpb.componentid().c_str());
 
     sections.push_back(NULL);
 
@@ -71,51 +73,48 @@ std::shared_ptr<GravityDataProduct> ConfigServer::request(const std::string serv
 
     keys = parser.GetKeys();
 
-	for(std::vector<std::string>::iterator i = keys.begin();
-			i != keys.end(); i++)
-	{
-		std::string value = parser.GetString(*i);
-		if(value != "")
-			key_value_map[*i] = value;
-	}
+    for (std::vector<std::string>::iterator i = keys.begin(); i != keys.end(); i++)
+    {
+        std::string value = parser.GetString(*i);
+        if (value != "") key_value_map[*i] = value;
+    }
 
-    if(!key_value_map.size())
-	{
-		cout << "Critical Error: Could not open config file: config_file.ini" << endl;
-		return std::shared_ptr<GravityDataProduct>();
-	}
+    if (!key_value_map.size())
+    {
+        cout << "Critical Error: Could not open config file: config_file.ini" << endl;
+        return std::shared_ptr<GravityDataProduct>();
+    }
 
-	//Populate Response Message and Send it
-	shared_ptr<spdlog::logger> logger = spdlog::get("GravityLogger");
-	logger->info("Sending Config to {}", cfpb.componentid());
-	ConfigeResponsePB message;
-	for(std::map<std::string, std::string>::iterator i = key_value_map.begin();
-			i != key_value_map.end(); i++)
-	{
-		logger->info("\t{}={}", i->first, i->second);
-		message.add_key(i->first);
-		message.add_value(i->second);
-	}
+    //Populate Response Message and Send it
+    shared_ptr<spdlog::logger> logger = spdlog::get("GravityLogger");
+    logger->info("Sending Config to {}", cfpb.componentid());
+    ConfigeResponsePB message;
+    for (std::map<std::string, std::string>::iterator i = key_value_map.begin(); i != key_value_map.end(); i++)
+    {
+        logger->info("\t{}={}", i->first, i->second);
+        message.add_key(i->first);
+        message.add_value(i->second);
+    }
 
-	std::shared_ptr<GravityDataProduct> response(new GravityDataProduct("ConfigResponsePB"));
-	response->setData(message);
+    std::shared_ptr<GravityDataProduct> response(new GravityDataProduct("ConfigResponsePB"));
+    response->setData(message);
 
-	return response; //Returning the message will send it.
+    return response;  //Returning the message will send it.
 }
 
 int main(int argc, const char** argv)
 {
-	ConfigServer server;
+    ConfigServer server;
 
-	GravityNode gn;
-	GravityReturnCode ret = gn.init("ConfigServer");
-	while (ret != GravityReturnCodes::SUCCESS)
-	{
-	    cerr << "Failed to initialize ConfigServer, retrying..." << endl;
-	    ret = gn.init("ConfigServer");
-	}
+    GravityNode gn;
+    GravityReturnCode ret = gn.init("ConfigServer");
+    while (ret != GravityReturnCodes::SUCCESS)
+    {
+        cerr << "Failed to initialize ConfigServer, retrying..." << endl;
+        ret = gn.init("ConfigServer");
+    }
 
-	gn.registerService("ConfigService", GravityTransportTypes::TCP, server);
+    gn.registerService("ConfigService", GravityTransportTypes::TCP, server);
 
-	gn.waitForExit();
+    gn.waitForExit();
 }

--- a/src/components/cpp/LogRecorder/GravityLogRecorder.cpp
+++ b/src/components/cpp/LogRecorder/GravityLogRecorder.cpp
@@ -29,7 +29,8 @@
 
 using namespace std;
 
-namespace gravity {
+namespace gravity
+{
 
 const string LogRecorder::logDataProductID(gravity::constants::GRAVITY_LOGGER_DPID);
 
@@ -37,7 +38,7 @@ const string LogRecorder::logDataProductID(gravity::constants::GRAVITY_LOGGER_DP
 void LogRecorder::getNewFilename(char* outfilename, string basefilename)
 {
     int len = filebasename.length();
-    if(len > (511 - 19))
+    if (len > (511 - 19))
     {
         //throw new Exception("File Base name too long");
         cerr << "File Base name too long" << endl;
@@ -47,15 +48,15 @@ void LogRecorder::getNewFilename(char* outfilename, string basefilename)
     //Add time string to filename.
     char* timestr = outfilename + len;
     time_t rawtime;
-    struct tm * timeinfo;
+    struct tm* timeinfo;
 
     time(&rawtime);
-    timeinfo = localtime( &rawtime );
+    timeinfo = localtime(&rawtime);
 
-    strftime(timestr, 100, "%Y_%m_%d_%H_%M_%S", timeinfo); //2012/08/23 12:12:12 - 19 chars
+    strftime(timestr, 100, "%Y_%m_%d_%H_%M_%S", timeinfo);  //2012/08/23 12:12:12 - 19 chars
 
     strncpy(outfilename, filebasename.c_str(), len);
-    strncpy(outfilename+len, timestr, 19);
+    strncpy(outfilename + len, timestr, 19);
 }
 
 LogRecorder::LogRecorder(GravityNode* gn, string filebasename)
@@ -67,24 +68,21 @@ LogRecorder::LogRecorder(GravityNode* gn, string filebasename)
     getNewFilename(filename, filebasename);
 
     log_file = fopen(filename, "w");
-    if(log_file == NULL)
+    if (log_file == NULL)
     {
         cerr << "Could not open Log file: " << filename << endl;
         //throw new Exception("");
     }
 }
 
-void LogRecorder::start()
-{
-    grav_node->subscribe(logDataProductID, *this);
-}
+void LogRecorder::start() { grav_node->subscribe(logDataProductID, *this); }
 
-
-void LogRecorder::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void LogRecorder::subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
     //std::shared_ptr<GravityDataProduct> gdp = *dataProducts.begin();
     //for_each(dataProducts.begin(), dataProducts.end(), [ this ] (std::shared_ptr<GravityDataProduct> dataProduct) { //Lambda function
-    for(vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin(); i != dataProducts.end(); i++)
+    for (vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin(); i != dataProducts.end();
+         i++)
     {
         std::shared_ptr<GravityDataProduct> dataProduct = *i;
         num_logs++;
@@ -94,18 +92,18 @@ void LogRecorder::subscriptionFilled(const std::vector< std::shared_ptr<GravityD
 
         //Format the Logs nicely.
         char timestr[100];
-        time_t rawtime = (time_t) (dataProduct->getGravityTimestamp() / 1000000);
-        struct tm * timeinfo;
+        time_t rawtime = (time_t)(dataProduct->getGravityTimestamp() / 1000000);
+        struct tm* timeinfo;
 
-        timeinfo = gmtime( &rawtime );
+        timeinfo = gmtime(&rawtime);
 
         strftime(timestr, 100, "%m/%d/%y %H:%M:%S", timeinfo);
 
-        fprintf(log_file, "[%s %s %s] %s\n", dataProduct->getDomain().c_str(), message.level().c_str(), timestr, message.message().c_str());
+        fprintf(log_file, "[%s %s %s] %s\n", dataProduct->getDomain().c_str(), message.level().c_str(), timestr,
+                message.message().c_str());
         fflush(log_file);
 
-        if(num_logs >= NUM_LOGS_BEFORE_ROTATE)
-            rotateLogs();
+        if (num_logs >= NUM_LOGS_BEFORE_ROTATE) rotateLogs();
         return;
     }
 }
@@ -118,8 +116,7 @@ void LogRecorder::rotateLogs()
     getNewFilename(filename, filebasename);
 
     log_file = fopen(filename, "w");
-    if(log_file == NULL)
-        cerr << "LogWriter::Rotate - Could not open Log file: " << filename << endl;
+    if (log_file == NULL) cerr << "LogWriter::Rotate - Could not open Log file: " << filename << endl;
 }
 
-}
+}  // namespace gravity

--- a/src/components/cpp/LogRecorder/GravityLogRecorder.h
+++ b/src/components/cpp/LogRecorder/GravityLogRecorder.h
@@ -21,9 +21,10 @@
 #include "protobuf/GravityLogMessagePB.pb.h"
 #include <string>
 
-namespace gravity {
+namespace gravity
+{
 
-#define NUM_LOGS_BEFORE_ROTATE (1000000/81) //About 1MB.  (1Mil chars / 81 (chars/line))
+#define NUM_LOGS_BEFORE_ROTATE (1000000 / 81)  //About 1MB.  (1Mil chars / 81 (chars/line))
 
 class LogRecorder : public GravitySubscriber
 {
@@ -42,7 +43,8 @@ public:
     /**
      * Writes to the Log.
      */
-    virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
+
 private:
     GravityNode* grav_node;
     FILE* log_file;
@@ -56,4 +58,4 @@ private:
     void rotateLogs();
 };
 
-}
+}  // namespace gravity

--- a/src/components/cpp/LogRecorder/main.cpp
+++ b/src/components/cpp/LogRecorder/main.cpp
@@ -22,13 +22,13 @@
 
 int main()
 {
-  using namespace gravity;
-  GravityNode gn;
-  gn.init("GravityLogRecorder");
+    using namespace gravity;
+    GravityNode gn;
+    gn.init("GravityLogRecorder");
 
-  LogRecorder lr(&gn, "MyBase");
+    LogRecorder lr(&gn, "MyBase");
 
-  lr.start();
+    lr.start();
 
-  gn.waitForExit();
+    gn.waitForExit();
 }

--- a/src/components/cpp/Playback/FileReader.cpp
+++ b/src/components/cpp/Playback/FileReader.cpp
@@ -28,156 +28,156 @@
 
 using namespace std;
 
-namespace {
-  std::mutex mtx;
-} //end anonymous namespace
+namespace
+{
+std::mutex mtx;
+}  //end anonymous namespace
 
-namespace gravity {
+namespace gravity
+{
 
 FileReader::FileReader() {}
 
 void FileReader::init(const string& filename, const string& dataProductList)
 {
-	// Open archive file
-	archiveFile.open(filename.c_str(), ios::in | ios::binary);
+    // Open archive file
+    archiveFile.open(filename.c_str(), ios::in | ios::binary);
 
-	// Check endian-ness
-	int i;
-	archiveFile.read((char*)&i, sizeof(i));
-	swapEndian = (i != 1);
+    // Check endian-ness
+    int i;
+    archiveFile.read((char*)&i, sizeof(i));
+    swapEndian = (i != 1);
 
-	// Build list of data products of interest
-	dpList = split(dataProductList);
+    // Build list of data products of interest
+    dpList = split(dataProductList);
 }
 
 FileReader::~FileReader() {}
 
 void* FileReader::start(void* context)
 {
-	((FileReader*)context)->processArchive();
-	return NULL;
+    ((FileReader*)context)->processArchive();
+    return NULL;
 }
 
 void FileReader::processArchive()
 {
     while (readNextDataProduct())
     {
-	    bool condition;
-      {
-        std::lock_guard<std::mutex> guard(mtx);
-        condition = archiveFile && dataProducts.size() > 100;
-      }
-      
-    while (condition)
-    {
+        bool condition;
+        {
+            std::lock_guard<std::mutex> guard(mtx);
+            condition = archiveFile && dataProducts.size() > 100;
+        }
+
+        while (condition)
+        {
 #ifdef WIN32
-gravity::sleep(10);
+            gravity::sleep(10);
 #else
-usleep(10000);
-#endif  
-      {
-        std::lock_guard<std::mutex> guard(mtx);
-        condition = archiveFile && dataProducts.size() > 100;
-      }
+            usleep(10000);
+#endif
+            {
+                std::lock_guard<std::mutex> guard(mtx);
+                condition = archiveFile && dataProducts.size() > 100;
+            }
+        }
     }
-  }
 }
 
 int FileReader::readNextDataProduct()
 {
-	int size;
-  std::lock_guard<std::mutex> guard(mtx);
+    int size;
+    std::lock_guard<std::mutex> guard(mtx);
 
-	while (archiveFile)
-	{
-        	// Read the size of the next data product
-        	archiveFile.read((char*)&size, sizeof(size));
-        	if (!archiveFile)
-        	{
-            		// Likely we've reached the end of file.
-            		break;
-        	}
+    while (archiveFile)
+    {
+        // Read the size of the next data product
+        archiveFile.read((char*)&size, sizeof(size));
+        if (!archiveFile)
+        {
+            // Likely we've reached the end of file.
+            break;
+        }
 
-		if (swapEndian)
-		{
-			endian_swap(size);
-		}
-        	// Read the data product
-        	std::vector<char> buffer(size);
-        	archiveFile.read(&buffer[0], size);
-        	if (!archiveFile)
-        	{
-            		// Treat this as end of file
-            		break;
-        	}
+        if (swapEndian)
+        {
+            endian_swap(size);
+        }
+        // Read the data product
+        std::vector<char> buffer(size);
+        archiveFile.read(&buffer[0], size);
+        if (!archiveFile)
+        {
+            // Treat this as end of file
+            break;
+        }
 
-        	// Convert to GravityDataProduct
-        std::shared_ptr<GravityDataProduct> gdp = std::shared_ptr<GravityDataProduct>(new GravityDataProduct(buffer.data(), size));
-		//gdp->parseFromArray(buffer, size);
+        // Convert to GravityDataProduct
+        std::shared_ptr<GravityDataProduct> gdp =
+            std::shared_ptr<GravityDataProduct>(new GravityDataProduct(buffer.data(), size));
+        //gdp->parseFromArray(buffer, size);
 
-		// Make sure this is a data product we care about
-		if (!dpList.empty() && find(dpList.begin(), dpList.end(), gdp->getDataProductID()) == dpList.end())
-		{
-			continue;
-		}
+        // Make sure this is a data product we care about
+        if (!dpList.empty() && find(dpList.begin(), dpList.end(), gdp->getDataProductID()) == dpList.end())
+        {
+            continue;
+        }
 
-		dataProducts.push_back(gdp);
-		break;
-	}
+        dataProducts.push_back(gdp);
+        break;
+    }
 
-	int sz = dataProducts.size();
+    int sz = dataProducts.size();
 
-	return sz;
+    return sz;
 }
 
 vector<string> FileReader::split(string s)
 {
-        vector<string> tokens;
+    vector<string> tokens;
 
-        istringstream iss(s);
-        string tok;
-        while (getline(iss, tok, ','))
-        {
-                // trim any spaces from the ends
-                tok.erase(tok.find_last_not_of(" ") + 1);
-                tok.erase(0, tok.find_first_not_of(" "));
-                tokens.push_back(tok);
-        }
+    istringstream iss(s);
+    string tok;
+    while (getline(iss, tok, ','))
+    {
+        // trim any spaces from the ends
+        tok.erase(tok.find_last_not_of(" ") + 1);
+        tok.erase(0, tok.find_first_not_of(" "));
+        tokens.push_back(tok);
+    }
 
-        return tokens;
+    return tokens;
 }
 
 bool FileReader::hasData()
 {
-  std::lock_guard<std::mutex> guard(mtx);
-	bool ret = !dataProducts.empty();
-	return ret;
+    std::lock_guard<std::mutex> guard(mtx);
+    bool ret = !dataProducts.empty();
+    return ret;
 }
 
 std::shared_ptr<GravityDataProduct> FileReader::popGravityDataProduct()
 {
-  	std::lock_guard<std::mutex> guard(mtx);
-	std::shared_ptr<GravityDataProduct> gdp = dataProducts[0];
-	dataProducts.erase(dataProducts.begin());
-	return gdp;
+    std::lock_guard<std::mutex> guard(mtx);
+    std::shared_ptr<GravityDataProduct> gdp = dataProducts[0];
+    dataProducts.erase(dataProducts.begin());
+    return gdp;
 }
 
 std::shared_ptr<GravityDataProduct> FileReader::getNextDataProduct()
 {
     std::shared_ptr<GravityDataProduct> gdp;
-	if (!hasData() && !readNextDataProduct())
-	{
-	}
-	else
-	{
-		gdp = popGravityDataProduct();
-	}
-	return gdp;
+    if (!hasData() && !readNextDataProduct())
+    {
+    }
+    else
+    {
+        gdp = popGravityDataProduct();
+    }
+    return gdp;
 }
 
-void FileReader::endian_swap(int& i)
-{
-	i = (i >> 24) | ((i<<8)&0x00FF0000) | ((i>>8) & 0x0000FF00) | (i << 24);
-}
+void FileReader::endian_swap(int& i) { i = (i >> 24) | ((i << 8) & 0x00FF0000) | ((i >> 8) & 0x0000FF00) | (i << 24); }
 
 } /* namespace gravity */

--- a/src/components/cpp/Playback/FileReader.h
+++ b/src/components/cpp/Playback/FileReader.h
@@ -23,28 +23,30 @@
 #include <fstream>
 #include <vector>
 
-namespace gravity {
+namespace gravity
+{
 
 class FileReader
 {
 private:
-	std::ifstream archiveFile;
-	std::vector<std::shared_ptr<GravityDataProduct> > dataProducts;
-	std::vector<std::string> dpList;
-	void processArchive();
-	std::shared_ptr<GravityDataProduct> popGravityDataProduct();
-	bool hasData();
-	std::vector<std::string> split(std::string s);
-	int readNextDataProduct();
+    std::ifstream archiveFile;
+    std::vector<std::shared_ptr<GravityDataProduct> > dataProducts;
+    std::vector<std::string> dpList;
+    void processArchive();
+    std::shared_ptr<GravityDataProduct> popGravityDataProduct();
+    bool hasData();
+    std::vector<std::string> split(std::string s);
+    int readNextDataProduct();
 
-	bool swapEndian;
-	void endian_swap(int& i);
+    bool swapEndian;
+    void endian_swap(int& i);
+
 public:
-	FileReader();
-	void init(const std::string& filename, const std::string& dataProductList);
-	virtual ~FileReader();
-	static void* start(void* context);
-	std::shared_ptr<GravityDataProduct> getNextDataProduct();
+    FileReader();
+    void init(const std::string& filename, const std::string& dataProductList);
+    virtual ~FileReader();
+    static void* start(void* context);
+    std::shared_ptr<GravityDataProduct> getNextDataProduct();
 };
 
 } /* namespace gravity */

--- a/src/components/cpp/Playback/FileReplay.cpp
+++ b/src/components/cpp/Playback/FileReplay.cpp
@@ -32,41 +32,42 @@ using namespace std;
 
 int main(int argc, const char* argv[])
 {
-	gravity::FileReplay replay;
-	replay.waitForExit();
+    gravity::FileReplay replay;
+    replay.waitForExit();
 }
 
-namespace gravity {
+namespace gravity
+{
 
 const char* FileReplay::ComponentName = "FileReplay";
 
 FileReplay::FileReplay()
 {
-	// Initialize Gravity Node
-	gravityNode.init(FileReplay::ComponentName);
-	
-	// Get logger
-	logger = spdlog::get("GravityLogger");
+    // Initialize Gravity Node
+    gravityNode.init(FileReplay::ComponentName);
 
-	// Configure logger to log to console
-	//Log::initAndAddConsoleLogger(FileReplay::ComponentName, Log::MESSAGE);
+    // Get logger
+    logger = spdlog::get("GravityLogger");
 
-	// Initialize firstPublishTime
-	firstPublishTime = 0;
-	firstDataTime = 0;
+    // Configure logger to log to console
+    //Log::initAndAddConsoleLogger(FileReplay::ComponentName, Log::MESSAGE);
 
-	// Get archive filename
-	string filename = gravityNode.getStringParam("ArchiveFilename", "archive.bin");
+    // Initialize firstPublishTime
+    firstPublishTime = 0;
+    firstDataTime = 0;
 
-	string dpList = gravityNode.getStringParam("DataProductList", "");
+    // Get archive filename
+    string filename = gravityNode.getStringParam("ArchiveFilename", "archive.bin");
 
-	// Kick off the thread to start reading the file
-	fileReader.init(filename, dpList);
-  std::thread readerThread(&FileReader::start, &fileReader);
-  readerThread.detach();
+    string dpList = gravityNode.getStringParam("DataProductList", "");
 
-	// Start processing the archive file
-	processArchive();
+    // Kick off the thread to start reading the file
+    fileReader.init(filename, dpList);
+    std::thread readerThread(&FileReader::start, &fileReader);
+    readerThread.detach();
+
+    // Start processing the archive file
+    processArchive();
 }
 
 FileReplay::~FileReplay() {}
@@ -102,9 +103,9 @@ void FileReplay::processArchive()
             uint64_t elapsedTime = gravity::getCurrentTime() - firstPublishTime;
             if (elapsedTime < timeToWait)
             {
-				logger->debug("waiting {}", timeToWait-elapsedTime);
+                logger->debug("waiting {}", timeToWait - elapsedTime);
 #ifdef WIN32
-				gravity::sleep( (timeToWait-elapsedTime) / 1000 );
+                gravity::sleep((timeToWait - elapsedTime) / 1000);
 #else
                 usleep(timeToWait - elapsedTime);
 #endif
@@ -115,16 +116,13 @@ void FileReplay::processArchive()
         logger->debug("publishing {}", gdp->getDataProductID());
         gravityNode.publish(*gdp);
 
-	// Get the next one
-	gdp = fileReader.getNextDataProduct();
+        // Get the next one
+        gdp = fileReader.getNextDataProduct();
     }
 
     logger->info("Reached end of archive");
 }
 
-void FileReplay::waitForExit()
-{
-	gravityNode.waitForExit();
-}
+void FileReplay::waitForExit() { gravityNode.waitForExit(); }
 
 } /* namespace gravity */

--- a/src/components/cpp/Playback/FileReplay.h
+++ b/src/components/cpp/Playback/FileReplay.h
@@ -24,7 +24,8 @@
 #include <set>
 #include "spdlog/spdlog.h"
 
-namespace gravity {
+namespace gravity
+{
 
 using namespace gravity;
 using namespace std;
@@ -32,22 +33,23 @@ using namespace std;
 class FileReplay
 {
 private:
-	static const char* ComponentName;
-	uint64_t firstPublishTime;
-	uint64_t firstDataTime;
+    static const char* ComponentName;
+    uint64_t firstPublishTime;
+    uint64_t firstDataTime;
 
-	FileReader fileReader;
+    FileReader fileReader;
 
-	GravityNode gravityNode;
-	set<string> datatypes;
+    GravityNode gravityNode;
+    set<string> datatypes;
 
-	void processArchive();
-	
-	std::shared_ptr<spdlog::logger> logger;
+    void processArchive();
+
+    std::shared_ptr<spdlog::logger> logger;
+
 public:
-	FileReplay();
-	virtual ~FileReplay();
-	void waitForExit();
+    FileReplay();
+    virtual ~FileReplay();
+    void waitForExit();
 };
 
 } /* namespace gravity */

--- a/src/components/cpp/Relay/Relay.cpp
+++ b/src/components/cpp/Relay/Relay.cpp
@@ -29,9 +29,9 @@ gravity::Semaphore relayLock;
 bool quit = false;
 
 #ifdef WIN32
-#include <windows.h> 
-BOOL WINAPI consoleHandler(DWORD sig) {
-
+#include <windows.h>
+BOOL WINAPI consoleHandler(DWORD sig)
+{
     if (sig == CTRL_C_EVENT)
     {
         relayLock.Lock();
@@ -61,14 +61,14 @@ class Relay : public GravitySubscriber
 {
 private:
     GravityNode gravityNode;
-	shared_ptr<spdlog::logger> logger;
+    shared_ptr<spdlog::logger> logger;
 
 public:
-    Relay() {};
-    virtual ~Relay() {};
+    Relay(){};
+    virtual ~Relay(){};
 
     int run();
-    void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 int Relay::run()
@@ -79,9 +79,9 @@ int Relay::run()
         cerr << "Failed to initialize " << COMPONENT_ID << ", retrying..." << endl;
         ret = gravityNode.init(COMPONENT_ID);
     }
-	
-	// Get Gravity logger
-	logger = spdlog::get("GravityLogger");
+
+    // Get Gravity logger
+    logger = spdlog::get("GravityLogger");
 
     bool localOnly = gravityNode.getBoolParam("ProvideLocalOnly", true);
 
@@ -104,9 +104,10 @@ int Relay::run()
     }
 
 #ifdef WIN32
-	if (!SetConsoleCtrlHandler(consoleHandler, TRUE)) {
-		logger->error("ERROR: Could not set control handler - Relay will not be able to unregister when terminated"); 
-	}
+    if (!SetConsoleCtrlHandler(consoleHandler, TRUE))
+    {
+        logger->error("ERROR: Could not set control handler - Relay will not be able to unregister when terminated");
+    }
 #else
     struct sigaction sigIntHandler;
 
@@ -122,8 +123,7 @@ int Relay::run()
     {
         gravity::sleep(1000);
         relayLock.Lock();
-        if (quit)
-            break;
+        if (quit) break;
         relayLock.Unlock();
     }
 
@@ -141,7 +141,7 @@ int Relay::run()
  * Not much happens here, it just passes along the GDP's that it receives.  The main work is done in the ServiceDirectory
  * where it recognizes subscribers that are collocated with the Relay and just provides data from there.
  */
-void Relay::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void Relay::subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
     for (unsigned int i = 0; i < dataProducts.size(); i++)
     {
@@ -154,9 +154,9 @@ void Relay::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataPro
 
 int main(int argc, const char** argv)
 {
-	Relay relay;
+    Relay relay;
 
-	// Need to explicitly call exit here since we're capturing SIGINT and SIGTERM.  Otherwise, if the SD
-	// goes away while we're trying to unregister, this could hang indefinitely.
-	exit(relay.run());
+    // Need to explicitly call exit here since we're capturing SIGINT and SIGTERM.  Otherwise, if the SD
+    // goes away while we're trying to unregister, this could hang indefinitely.
+    exit(relay.run());
 }

--- a/src/components/cpp/ServiceDirectory/ServiceDirectory.cpp
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectory.cpp
@@ -75,181 +75,178 @@ static void* registration(void* regData)
     gn->registerDataProduct(gravity::constants::REGISTERED_PUBLISHERS_DPID, gravity::GravityTransportTypes::TCP, true);
 
     // Register the data product for domain broadcast details
-	gn->registerDataProduct(gravity::constants::DOMAIN_DETAILS_DPID, gravity::GravityTransportTypes::TCP);
-    
+    gn->registerDataProduct(gravity::constants::DOMAIN_DETAILS_DPID, gravity::GravityTransportTypes::TCP);
+
     // Register service for external requests
     gn->registerService(gravity::constants::DIRECTORY_SERVICE_DPID, gravity::GravityTransportTypes::TCP, *provider);
 
-	// Register the data products for adding and removing domains
-	gn->registerDataProduct(gravity::constants::DOMAIN_UPDATE_DPID, gravity::GravityTransportTypes::TCP);
+    // Register the data products for adding and removing domains
+    gn->registerDataProduct(gravity::constants::DOMAIN_UPDATE_DPID, gravity::GravityTransportTypes::TCP);
 
     return NULL;
 }
 
 static void* startUDPBroadcastManager(void* context)
 {
-	// Create and start the UDP Broadcaster thread
-	gravity::ServiceDirectoryUDPBroadcaster udpBroadcaster(context);
-	udpBroadcaster.start();
+    // Create and start the UDP Broadcaster thread
+    gravity::ServiceDirectoryUDPBroadcaster udpBroadcaster(context);
+    udpBroadcaster.start();
 
-	return NULL;
+    return NULL;
 }
 
 static void* startUDPReceiveManager(void* context)
 {
+    // Create and start the UDP receiver thread
+    gravity::ServiceDirectoryUDPReceiver udpReceiver(context);
+    udpReceiver.start();
 
-	// Create and start the UDP receiver thread
-	gravity::ServiceDirectoryUDPReceiver udpReceiver(context);
-	udpReceiver.start();
-
-	return NULL;
+    return NULL;
 }
 
 static void* startSynchronizer(void* args)
 {
-	// Create and start the thread to manage synchronization with other service directories
-	gravity::SyncInitDetails* syncInitDetails = (gravity::SyncInitDetails*)args;
-	gravity::ServiceDirectorySynchronizer synchronizer(syncInitDetails->context, syncInitDetails->url);
-	synchronizer.start();
+    // Create and start the thread to manage synchronization with other service directories
+    gravity::SyncInitDetails* syncInitDetails = (gravity::SyncInitDetails*)args;
+    gravity::ServiceDirectorySynchronizer synchronizer(syncInitDetails->context, syncInitDetails->url);
+    synchronizer.start();
 
-	return NULL;
+    return NULL;
 }
 
 static bool validateDomainName(string domain)
 {
-	// Validate domain name
-	bool valid = true;
-	std::locale loc;
-	for (std::string::iterator it = domain.begin(); it != domain.end(); ++it)
-	{
-		if (!std::isalnum(*it, loc) && *it != '.')
-		{
-			valid = false;
-			break;
-		}
-	}
+    // Validate domain name
+    bool valid = true;
+    std::locale loc;
+    for (std::string::iterator it = domain.begin(); it != domain.end(); ++it)
+    {
+        if (!std::isalnum(*it, loc) && *it != '.')
+        {
+            valid = false;
+            break;
+        }
+    }
 
-	return valid;
+    return valid;
 }
 
-static int parseDomainCSV(string &csv)
+static int parseDomainCSV(string& csv)
 {
-	int prevPos=0;
-	size_t pos = csv.find(",",0);
-	int commaCount = 0;
-	if(csv.length()==0)
-	{
-		return 0;
-	}
+    int prevPos = 0;
+    size_t pos = csv.find(",", 0);
+    int commaCount = 0;
+    if (csv.length() == 0)
+    {
+        return 0;
+    }
 
-	while(pos != string::npos)
-	{
-		if(!validateDomainName(csv.substr(prevPos,pos-prevPos)))
-		{
-			return -1;
-		}
-		commaCount++;
-		prevPos=pos+1;
-		pos=csv.find(",",pos+1);
-	}
+    while (pos != string::npos)
+    {
+        if (!validateDomainName(csv.substr(prevPos, pos - prevPos)))
+        {
+            return -1;
+        }
+        commaCount++;
+        prevPos = pos + 1;
+        pos = csv.find(",", pos + 1);
+    }
 
-	return commaCount+1;	
+    return commaCount + 1;
 }
 
 namespace gravity
 {
 
-ServiceDirectory::~ServiceDirectory()
-{
-}
+ServiceDirectory::~ServiceDirectory() {}
 
 void ServiceDirectory::start()
 {
-  //Declare threads to be spawned
-  std::thread udpBroadcasterThread;
-  std::thread udpReceiverThread;
-  std::thread synchronizerThread;
-	
-  //set up zmq context
-	context = zmq_init(1);
+    //Declare threads to be spawned
+    std::thread udpBroadcasterThread;
+    std::thread udpReceiverThread;
+    std::thread synchronizerThread;
 
-	//set up broadcast and recieve managers
-	if (!context)
-	{
-		//logger->critical("Could not create ZMQ Context");
-		return;
-	}
-	
-  registeredPublishersReady = registeredPublishersProcessed = false;
-  gn.init("ServiceDirectory");
-  
-  // Get Gravity logger
-  logger = spdlog::get("GravityLogger");
+    //set up zmq context
+    context = zmq_init(1);
 
-  std::string sdURL = gn.getStringParam("ServiceDirectoryUrl", "tcp://*:5555");
-  replaceAll(sdURL, "localhost", "127.0.0.1");
-  logger->info("running with SD connection string: {}", sdURL);
+    //set up broadcast and recieve managers
+    if (!context)
+    {
+        //logger->critical("Could not create ZMQ Context");
+        return;
+    }
 
-	// Get the optional domain for this Service Directory instance
-	domain = gn.getStringParam("Domain", "");
+    registeredPublishersReady = registeredPublishersProcessed = false;
+    gn.init("ServiceDirectory");
 
-	// If domain IS specified, default broadcastEnabled to true
-	bool broadcastEnabled = gn.getBoolParam("BroadcastEnabled", !domain.empty());
-	
-	if (!validateDomainName(domain))
-	{
-		domain = "";
-		logger->warn("Invalid Domain (must be alpha-numeric or '.').");
+    // Get Gravity logger
+    logger = spdlog::get("GravityLogger");
 
-		//don't broadcast if domain is invalid
-		broadcastEnabled = false;
-	}
-	logger->info("Domain set to '{}'", domain);
+    std::string sdURL = gn.getStringParam("ServiceDirectoryUrl", "tcp://*:5555");
+    replaceAll(sdURL, "localhost", "127.0.0.1");
+    logger->info("running with SD connection string: {}", sdURL);
 
+    // Get the optional domain for this Service Directory instance
+    domain = gn.getStringParam("Domain", "");
 
-	unsigned int broadcastPort = gn.getIntParam("ServiceDirectoryBroadcastPort",DEFAULT_BROADCAST_PORT);
+    // If domain IS specified, default broadcastEnabled to true
+    bool broadcastEnabled = gn.getBoolParam("BroadcastEnabled", !domain.empty());
 
+    if (!validateDomainName(domain))
+    {
+        domain = "";
+        logger->warn("Invalid Domain (must be alpha-numeric or '.').");
 
+        //don't broadcast if domain is invalid
+        broadcastEnabled = false;
+    }
+    logger->info("Domain set to '{}'", domain);
 
-	string knownDomainCSV = gn.getStringParam("DomainSyncList","");
-	int  numDomains = parseDomainCSV(knownDomainCSV);
+    unsigned int broadcastPort = gn.getIntParam("ServiceDirectoryBroadcastPort", DEFAULT_BROADCAST_PORT);
 
-	if(numDomains < 0)
-	{
-		knownDomainCSV="";
-		numDomains=0;
-		logger->warn("Invalid DomainSyncList (must be alpha-numeric or '.').");
-	}
-	logger->info("DomainSyncList set to '{}'",knownDomainCSV);
+    string knownDomainCSV = gn.getStringParam("DomainSyncList", "");
+    int numDomains = parseDomainCSV(knownDomainCSV);
 
-    void *context = zmq_init(1);
+    if (numDomains < 0)
+    {
+        knownDomainCSV = "";
+        numDomains = 0;
+        logger->warn("Invalid DomainSyncList (must be alpha-numeric or '.').");
+    }
+    logger->info("DomainSyncList set to '{}'", knownDomainCSV);
+
+    void* context = zmq_init(1);
     if (!context)
     {
         logger->critical("Could not create ZeroMQ context, exiting");
         exit(1);
     }
 
-    // Remember the user-specified URL in case we fall back to binding on all interfaces. 
+    // Remember the user-specified URL in case we fall back to binding on all interfaces.
     // We'll broadcast this one to the clients.
     string originalSDURL = sdURL;
     // Set up the inproc socket to listen for requests messages from the GravityNode
-    void *socket = zmq_socket(context, ZMQ_REP);
+    void* socket = zmq_socket(context, ZMQ_REP);
     int rc = zmq_bind(socket, sdURL.c_str());
     if (rc < 0)
     {
-        if (sdURL.rfind("tcp://",0) == 0) {   // Try to bind to all interfaces
-            string newURL = "tcp://*:" + sdURL.substr(sdURL.rfind(":")+1);
+        if (sdURL.rfind("tcp://", 0) == 0)
+        {  // Try to bind to all interfaces
+            string newURL = "tcp://*:" + sdURL.substr(sdURL.rfind(":") + 1);
             sdURL = newURL;
-	    logger->warn("ZMQ bind failed: Try fallback socket: '{}'",sdURL);
+            logger->warn("ZMQ bind failed: Try fallback socket: '{}'", sdURL);
             rc = zmq_bind(socket, sdURL.c_str());
         }
-        if (rc < 0) {
-            logger->critical("Could not bind address for ServiceDirectory, error code was {} ({})", rc, strerror(errno));
+        if (rc < 0)
+        {
+            logger->critical("Could not bind address for ServiceDirectory, error code was {} ({})", rc,
+                             strerror(errno));
             exit(1);
-       }
+        }
     }
 
-	std::vector<zmq_pollitem_t> pollItems;
+    std::vector<zmq_pollitem_t> pollItems;
 
     // Always have at least the gravity node to poll
     zmq_pollitem_t pollItem;
@@ -257,62 +254,62 @@ void ServiceDirectory::start()
     pollItem.events = ZMQ_POLLIN;
     pollItem.fd = 0;
     pollItem.revents = 0;
-	pollItems.push_back(pollItem);
+    pollItems.push_back(pollItem);
 
-	//If broadcast was enabled, start the broadcaster
-	if(broadcastEnabled)
-	{
-		logger->info("Starting ServiceDirectoryBroadcaster");
+    //If broadcast was enabled, start the broadcaster
+    if (broadcastEnabled)
+    {
+        logger->info("Starting ServiceDirectoryBroadcaster");
 
-		string broadcastIP = gn.getStringParam("ServiceDirectoryBroadcastIP", "");
-		unsigned int broadcastRate = gn.getIntParam("ServiceDirectoryBroadcastRate",DEFAULT_BROADCAST_RATE_SEC);
+        string broadcastIP = gn.getStringParam("ServiceDirectoryBroadcastIP", "");
+        unsigned int broadcastRate = gn.getIntParam("ServiceDirectoryBroadcastRate", DEFAULT_BROADCAST_RATE_SEC);
 
-		//start the udp broadcaster
-		udpBroadcastSocket.socket = zmq_socket(context,ZMQ_REQ);
-		zmq_bind(udpBroadcastSocket.socket,"inproc://service_directory_udp_broadcast");
-    udpBroadcasterThread = std::thread(&startUDPBroadcastManager,context);
+        //start the udp broadcaster
+        udpBroadcastSocket.socket = zmq_socket(context, ZMQ_REQ);
+        zmq_bind(udpBroadcastSocket.socket, "inproc://service_directory_udp_broadcast");
+        udpBroadcasterThread = std::thread(&startUDPBroadcastManager, context);
 
-		//configure the broadcaster
-		sendBroadcasterParameters(domain,originalSDURL,broadcastIP,broadcastPort,broadcastRate);
-	}
+        //configure the broadcaster
+        sendBroadcasterParameters(domain, originalSDURL, broadcastIP, broadcastPort, broadcastRate);
+    }
 
-	SyncInitDetails syncInitDetails;
+    SyncInitDetails syncInitDetails;
 
-	//only start the receiver is there is at least one domain to sync to
-	if(numDomains > 0)
-	{
-		logger->info("Starting ServiceDirectoryReceiver");
-		//create the socket for receiving domains from the udp receiver, used for polling
-		void *domainRecvSocket = zmq_socket(context,ZMQ_SUB);
-		zmq_bind(domainRecvSocket,"inproc://service_directory_domain_socket");
-		zmq_setsockopt(domainRecvSocket,ZMQ_SUBSCRIBE,NULL,0);
+    //only start the receiver is there is at least one domain to sync to
+    if (numDomains > 0)
+    {
+        logger->info("Starting ServiceDirectoryReceiver");
+        //create the socket for receiving domains from the udp receiver, used for polling
+        void* domainRecvSocket = zmq_socket(context, ZMQ_SUB);
+        zmq_bind(domainRecvSocket, "inproc://service_directory_domain_socket");
+        zmq_setsockopt(domainRecvSocket, ZMQ_SUBSCRIBE, NULL, 0);
 
-		//start the udp receiver
-		udpReceiverSocket.socket = zmq_socket(context,ZMQ_REQ);
-		zmq_bind(udpReceiverSocket.socket,"inproc://service_directory_udp_receive");
-    udpReceiverThread = std::thread(startUDPReceiveManager,context);
+        //start the udp receiver
+        udpReceiverSocket.socket = zmq_socket(context, ZMQ_REQ);
+        zmq_bind(udpReceiverSocket.socket, "inproc://service_directory_udp_receive");
+        udpReceiverThread = std::thread(startUDPReceiveManager, context);
 
-		//configure the receiver
-		sendReceiverParameters(domain,sdURL,broadcastPort,numDomains,knownDomainCSV);
+        //configure the receiver
+        sendReceiverParameters(domain, sdURL, broadcastPort, numDomains, knownDomainCSV);
 
-		// start the synchronization thread
-		logger->info("Starting ServiceDirectorySynchronization thread");
-		syncInitDetails.context = context;
-		syncInitDetails.url = sdURL;
-    synchronizerThread = std::thread(startSynchronizer, (void*)&syncInitDetails);
+        // start the synchronization thread
+        logger->info("Starting ServiceDirectorySynchronization thread");
+        syncInitDetails.context = context;
+        syncInitDetails.url = sdURL;
+        synchronizerThread = std::thread(startSynchronizer, (void*)&syncInitDetails);
 
-		// Configure the comms channel to direct the synchronizer thread
-		synchronizerSocket = zmq_socket(context, ZMQ_PUB);
-		zmq_bind(synchronizerSocket, "inproc://service_directory_synchronizer");			
+        // Configure the comms channel to direct the synchronizer thread
+        synchronizerSocket = zmq_socket(context, ZMQ_PUB);
+        zmq_bind(synchronizerSocket, "inproc://service_directory_synchronizer");
 
-		// Poll the UDP Receiver
-		zmq_pollitem_t udpRecvPollItem;
-		udpRecvPollItem.socket=domainRecvSocket;
-		udpRecvPollItem.events=ZMQ_POLLIN;
-		udpRecvPollItem.fd=0;
-		udpRecvPollItem.revents=0;
-		pollItems.push_back(udpRecvPollItem);
-	}
+        // Poll the UDP Receiver
+        zmq_pollitem_t udpRecvPollItem;
+        udpRecvPollItem.socket = domainRecvSocket;
+        udpRecvPollItem.events = ZMQ_POLLIN;
+        udpRecvPollItem.fd = 0;
+        udpRecvPollItem.revents = 0;
+        pollItems.push_back(udpRecvPollItem);
+    }
 
     /*************
      * IMPORTANT: The following block of code should be the last thing the SD does before entering the main loop.
@@ -332,7 +329,7 @@ void ServiceDirectory::start()
     regData.provider = this;
     std::thread registerThread(registration, (void*)&regData);
     registerThread.detach();
-        
+
     /****
      * End last block of code before main loop
      */
@@ -341,7 +338,7 @@ void ServiceDirectory::start()
     while (true)
     {
         // Start polling socket(s), blocking while we wait
-        int rc = zmq_poll(&pollItems[0], pollItems.size(), -1); // 0 --> return immediately, -1 --> blocks
+        int rc = zmq_poll(&pollItems[0], pollItems.size(), -1);  // 0 --> return immediately, -1 --> blocks
         if (rc == -1)
         {
             // Interrupted
@@ -383,68 +380,66 @@ void ServiceDirectory::start()
             sendGravityDataProduct(pollItem.socket, *response, ZMQ_DONTWAIT);
         }
 
-		if(numDomains > 0)
-		{
-			//process domain commands
-			if(pollItems[1].revents & ZMQ_POLLIN)
-			{
-				void* domainSocket = pollItems[1].socket;
+        if (numDomains > 0)
+        {
+            //process domain commands
+            if (pollItems[1].revents & ZMQ_POLLIN)
+            {
+                void* domainSocket = pollItems[1].socket;
 
-				string command = readStringMessage(domainSocket);
+                string command = readStringMessage(domainSocket);
 
-				if (command == "Add")
-				{
-					string domainToAdd = readStringMessage(domainSocket);
-					string url = readStringMessage(domainSocket);
+                if (command == "Add")
+                {
+                    string domainToAdd = readStringMessage(domainSocket);
+                    string url = readStringMessage(domainSocket);
 
-					domainMap[domainToAdd] = url;
-		
-					// publish domain added message
-					publishDomainUpdateMessage(domainToAdd,url,ADD);
+                    domainMap[domainToAdd] = url;
 
-					// Send Add command to synchronization thread
-					logger->debug("Sending add command to synchronization thread for {}:{}", domainToAdd, url);
-					sendStringMessage(synchronizerSocket, "Add", ZMQ_SNDMORE);
-					sendStringMessage(synchronizerSocket, domainToAdd, ZMQ_SNDMORE);
-					sendStringMessage(synchronizerSocket, url, ZMQ_DONTWAIT);
+                    // publish domain added message
+                    publishDomainUpdateMessage(domainToAdd, url, ADD);
 
-				}
-				if (command == "Update")
-				{
-					string domainToUpdate = readStringMessage(domainSocket);
-					string url = readStringMessage(domainSocket);
+                    // Send Add command to synchronization thread
+                    logger->debug("Sending add command to synchronization thread for {}:{}", domainToAdd, url);
+                    sendStringMessage(synchronizerSocket, "Add", ZMQ_SNDMORE);
+                    sendStringMessage(synchronizerSocket, domainToAdd, ZMQ_SNDMORE);
+                    sendStringMessage(synchronizerSocket, url, ZMQ_DONTWAIT);
+                }
+                if (command == "Update")
+                {
+                    string domainToUpdate = readStringMessage(domainSocket);
+                    string url = readStringMessage(domainSocket);
 
-					domainMap[domainToUpdate] = url;
+                    domainMap[domainToUpdate] = url;
 
-					// Send Add command to synchronization thread
-					logger->debug("Sending update command to synchronization thread for {}:{}", domainToUpdate, url);
-					sendStringMessage(synchronizerSocket, "Update", ZMQ_SNDMORE);
-					sendStringMessage(synchronizerSocket, domainToUpdate, ZMQ_SNDMORE);
-					sendStringMessage(synchronizerSocket, url, ZMQ_DONTWAIT);
+                    // Send Add command to synchronization thread
+                    logger->debug("Sending update command to synchronization thread for {}:{}", domainToUpdate, url);
+                    sendStringMessage(synchronizerSocket, "Update", ZMQ_SNDMORE);
+                    sendStringMessage(synchronizerSocket, domainToUpdate, ZMQ_SNDMORE);
+                    sendStringMessage(synchronizerSocket, url, ZMQ_DONTWAIT);
+                }
+                else if (command == "Remove")
+                {
+                    string domainToRemove = readStringMessage(domainSocket);
+                    string url = domainMap[domainToRemove];
 
-				}
-				else if (command == "Remove")
-				{
-					string domainToRemove = readStringMessage(domainSocket);
-					string url = domainMap[domainToRemove];
+                    domainMap.erase(domainToRemove);
 
-					domainMap.erase(domainToRemove);
+                    // publish domain removed message
+                    publishDomainUpdateMessage(domainToRemove, url, REMOVE);
 
-					// publish domain removed message
-					publishDomainUpdateMessage(domainToRemove,url,REMOVE);
-
-					// Send Remove command to synchronization thread
-					logger->debug("Sending remove command to synchronziation thread for {}", domainToRemove);
-					sendStringMessage(synchronizerSocket, "Remove", ZMQ_SNDMORE);
-					sendStringMessage(synchronizerSocket, domainToRemove, ZMQ_DONTWAIT);
-				}
-			}
-		}
+                    // Send Remove command to synchronization thread
+                    logger->debug("Sending remove command to synchronziation thread for {}", domainToRemove);
+                    sendStringMessage(synchronizerSocket, "Remove", ZMQ_SNDMORE);
+                    sendStringMessage(synchronizerSocket, domainToRemove, ZMQ_DONTWAIT);
+                }
+            }
+        }
     }
     //join the threads that were spawned before exiting loop
     udpBroadcasterThread.join();
     udpReceiverThread.join();
-		synchronizerThread.join();
+    synchronizerThread.join();
 }
 
 /**
@@ -453,7 +448,8 @@ void ServiceDirectory::start()
  */
 std::shared_ptr<GravityDataProduct> ServiceDirectory::request(const GravityDataProduct& dataProduct)
 {
-    std::shared_ptr<GravityDataProduct> gdpResponse = std::shared_ptr<GravityDataProduct>(new GravityDataProduct("DataProductRegistrationResponse"));
+    std::shared_ptr<GravityDataProduct> gdpResponse =
+        std::shared_ptr<GravityDataProduct>(new GravityDataProduct("DataProductRegistrationResponse"));
     string requestType = dataProduct.getDataProductID();
 
     ///////////////////////////////////
@@ -490,11 +486,13 @@ std::shared_ptr<GravityDataProduct> ServiceDirectory::request(const GravityDataP
  * Because the lock in this method blocks the main SD loop above, we can't issue any GravityNode calls
  * here that require SD support (e.g. register, etc).
  */
-std::shared_ptr<GravityDataProduct> ServiceDirectory::request(const std::string serviceID, const GravityDataProduct& request)
+std::shared_ptr<GravityDataProduct> ServiceDirectory::request(const std::string serviceID,
+                                                              const GravityDataProduct& request)
 {
     logger->debug("Received service request of type '{}'", serviceID);
-    std::shared_ptr<GravityDataProduct> gdpResponse = std::shared_ptr<GravityDataProduct>(new GravityDataProduct("DirectoryServiceResponse"));
-   
+    std::shared_ptr<GravityDataProduct> gdpResponse =
+        std::shared_ptr<GravityDataProduct>(new GravityDataProduct("DirectoryServiceResponse"));
+
     if (serviceID == gravity::constants::DIRECTORY_SERVICE_DPID)
     {
         lock.Lock();
@@ -505,47 +503,48 @@ std::shared_ptr<GravityDataProduct> ServiceDirectory::request(const std::string 
             ServiceDirectoryMapPB providerMap;
             providerMap.set_domain(domain);
 
-			for (map<string, map<string, string> >::iterator it = serviceMap.begin(); it != serviceMap.end(); it++)
-			{
-				string domain = it->first;
-				map<string,string> sMap = it->second;
-				for (map<string,string>::iterator it2 = sMap.begin(); it2 != sMap.end(); it2++)
-				{
-					ProductLocations* locs = providerMap.add_service_provider();
-					locs->set_product_id(it2->first); // service ID
-					locs->add_url(it2->second); // url
-					locs->add_component_id(urlToComponentMap[it2->second]); // component id
-					locs->add_timestamp(registrationInstanceMap[it2->second]); //timestamp
-					locs->add_domain_id(domain); // domain
-				}
-			}            
-            
-			for (map<string, map<string, list<PublisherInfoPB> > >::iterator it = dataProductMap.begin(); it != dataProductMap.end(); it++)
-			{
-				string domain = it->first;
-				map<string, list<PublisherInfoPB> > dpMap = it->second;
-				for(map<string, list<PublisherInfoPB> >::iterator it = dpMap.begin(); it != dpMap.end(); it++)
-				{
-					ProductLocations* locs = providerMap.add_data_provider();
-					locs->set_product_id(it->first); // data product ID
-					locs->add_domain_id(domain); // domain
-					list<PublisherInfoPB> urls = it->second;
-					for(list<PublisherInfoPB>::iterator lit = urls.begin(); lit != urls.end(); lit++)
-					{
-						locs->add_url(lit->url()); // url
-						locs->add_component_id(urlToComponentMap[lit->url()]); // component id
-						locs->add_timestamp(registrationInstanceMap[lit->url()]); //timestamp
-					}
-				}
-			}            
+            for (map<string, map<string, string> >::iterator it = serviceMap.begin(); it != serviceMap.end(); it++)
+            {
+                string domain = it->first;
+                map<string, string> sMap = it->second;
+                for (map<string, string>::iterator it2 = sMap.begin(); it2 != sMap.end(); it2++)
+                {
+                    ProductLocations* locs = providerMap.add_service_provider();
+                    locs->set_product_id(it2->first);                           // service ID
+                    locs->add_url(it2->second);                                 // url
+                    locs->add_component_id(urlToComponentMap[it2->second]);     // component id
+                    locs->add_timestamp(registrationInstanceMap[it2->second]);  //timestamp
+                    locs->add_domain_id(domain);                                // domain
+                }
+            }
+
+            for (map<string, map<string, list<PublisherInfoPB> > >::iterator it = dataProductMap.begin();
+                 it != dataProductMap.end(); it++)
+            {
+                string domain = it->first;
+                map<string, list<PublisherInfoPB> > dpMap = it->second;
+                for (map<string, list<PublisherInfoPB> >::iterator it = dpMap.begin(); it != dpMap.end(); it++)
+                {
+                    ProductLocations* locs = providerMap.add_data_provider();
+                    locs->set_product_id(it->first);  // data product ID
+                    locs->add_domain_id(domain);      // domain
+                    list<PublisherInfoPB> urls = it->second;
+                    for (list<PublisherInfoPB>::iterator lit = urls.begin(); lit != urls.end(); lit++)
+                    {
+                        locs->add_url(lit->url());                                 // url
+                        locs->add_component_id(urlToComponentMap[lit->url()]);     // component id
+                        locs->add_timestamp(registrationInstanceMap[lit->url()]);  //timestamp
+                    }
+                }
+            }
 
             // Place map on response data product
             gdpResponse->setData(providerMap);
         }
-		else if (requestType == "GetDomain")
+        else if (requestType == "GetDomain")
         {
-			gdpResponse->setData(domain.c_str(), domain.length());
-		}
+            gdpResponse->setData(domain.c_str(), domain.length());
+        }
         lock.Unlock();
     }
 
@@ -557,112 +556,111 @@ void ServiceDirectory::handleLookup(const GravityDataProduct& request, GravityDa
     ComponentLookupRequestPB lookupRequest;
     request.populateMessage(lookupRequest);
 
-	// Get the requested domain (defaulting to our own)
-	string lookupDomain = domain;
-	if (lookupRequest.has_domain_id() && !lookupRequest.domain_id().empty())
-	{
-		lookupDomain = lookupRequest.domain_id();
-	}
+    // Get the requested domain (defaulting to our own)
+    string lookupDomain = domain;
+    if (lookupRequest.has_domain_id() && !lookupRequest.domain_id().empty())
+    {
+        lookupDomain = lookupRequest.domain_id();
+    }
 
-    //NOTE: 0MQ does not have a concept of who the message was sent from so that info is lost.    
+    //NOTE: 0MQ does not have a concept of who the message was sent from so that info is lost.
     if (lookupRequest.type() == ComponentLookupRequestPB_RegistrationType_DATA)
     {
-		// Get data product map for requested domain (defaulting to our own)
-		if (dataProductMap.count(lookupDomain) > 0)
-		{
-			map<string, list<PublisherInfoPB> > dpMap = dataProductMap[lookupDomain];
+        // Get data product map for requested domain (defaulting to our own)
+        if (dataProductMap.count(lookupDomain) > 0)
+        {
+            map<string, list<PublisherInfoPB> > dpMap = dataProductMap[lookupDomain];
 
-			logger->info("[Lookup Request] ID: {}, Domain: {}, MessageType: Data Product, First Server: {}", 
-					 lookupRequest.lookupid(),
-					 lookupDomain,
-                     (dpMap.count(lookupRequest.lookupid()) != 0 && dpMap[lookupRequest.lookupid()].size() > 0) ?
-                     dpMap[lookupRequest.lookupid()].front().url(): "");
-		}
-		else
-		{
-			logger->info("[Lookup Request] No data provider found for ID: {} in Domain: {}",
-						lookupRequest.lookupid(), lookupDomain);
-		}
+            logger->info("[Lookup Request] ID: {}, Domain: {}, MessageType: Data Product, First Server: {}",
+                         lookupRequest.lookupid(), lookupDomain,
+                         (dpMap.count(lookupRequest.lookupid()) != 0 && dpMap[lookupRequest.lookupid()].size() > 0)
+                             ? dpMap[lookupRequest.lookupid()].front().url()
+                             : "");
+        }
+        else
+        {
+            logger->info("[Lookup Request] No data provider found for ID: {} in Domain: {}", lookupRequest.lookupid(),
+                         lookupDomain);
+        }
 
-		addPublishers(lookupRequest.lookupid(), response, lookupDomain);
+        addPublishers(lookupRequest.lookupid(), response, lookupDomain);
     }
     else
     {
-		ComponentServiceLookupResponsePB lookupResponse;
-		lookupResponse.set_lookupid(lookupRequest.lookupid());        
-		lookupResponse.set_url("");
-		lookupResponse.set_domain_id(lookupDomain);
+        ComponentServiceLookupResponsePB lookupResponse;
+        lookupResponse.set_lookupid(lookupRequest.lookupid());
+        lookupResponse.set_url("");
+        lookupResponse.set_domain_id(lookupDomain);
 
-		if (serviceMap.count(lookupDomain) > 0)
-		{
-			// Get service map for our domain
-			map<string, string> sMap = serviceMap[lookupDomain];
+        if (serviceMap.count(lookupDomain) > 0)
+        {
+            // Get service map for our domain
+            map<string, string> sMap = serviceMap[lookupDomain];
 
-			logger->info("[Lookup Request] ID: {}, MessageType: Service, Server: {}", lookupRequest.lookupid(),
-                     sMap.count(lookupRequest.lookupid()) != 0 ?
-                     sMap[lookupRequest.lookupid()]: "");
+            logger->info("[Lookup Request] ID: {}, MessageType: Service, Server: {}", lookupRequest.lookupid(),
+                         sMap.count(lookupRequest.lookupid()) != 0 ? sMap[lookupRequest.lookupid()] : "");
 
-			if (sMap.count(lookupRequest.lookupid()) > 0)
-			{
-				lookupResponse.set_url(sMap[lookupRequest.lookupid()]);
+            if (sMap.count(lookupRequest.lookupid()) > 0)
+            {
+                lookupResponse.set_url(sMap[lookupRequest.lookupid()]);
 
-				uint32_t regTime = static_cast<uint32_t>(registrationInstanceMap[sMap[lookupRequest.lookupid()]] / 1e6);
-				lookupResponse.set_registration_time(regTime);
-			}
-		}
+                uint32_t regTime = static_cast<uint32_t>(registrationInstanceMap[sMap[lookupRequest.lookupid()]] / 1e6);
+                lookupResponse.set_registration_time(regTime);
+            }
+        }
 
         response.setData(lookupResponse);
     }
 }
 
-void ServiceDirectory::updateProductLocations(string productID, string url, uint64_t timestamp, ChangeType changeType, RegistrationType registrationType)
+void ServiceDirectory::updateProductLocations(string productID, string url, uint64_t timestamp, ChangeType changeType,
+                                              RegistrationType registrationType)
 {
-	ServiceDirectoryMapPB providerMap;
-	providerMap.set_domain(domain);
+    ServiceDirectoryMapPB providerMap;
+    providerMap.set_domain(domain);
 
-	map<string,string> sMap = serviceMap[domain];	
-	for (map<string,string>::iterator it2 = sMap.begin(); it2 != sMap.end(); it2++)
-	{
-		ProductLocations* locs = providerMap.add_service_provider();
-		locs->set_product_id(it2->first); // service ID
-		locs->add_url(it2->second); // url
-		locs->add_component_id(urlToComponentMap[it2->second]); // component id
-		locs->add_timestamp(registrationInstanceMap[it2->second]); //timestamp
-		locs->add_domain_id(domain); // domain
-	}            
-            
-	map<string, list<PublisherInfoPB> > dpMap = dataProductMap[domain];
-	for(map<string, list<PublisherInfoPB> >::iterator it = dpMap.begin(); it != dpMap.end(); it++)
-	{
-		ProductLocations* locs = providerMap.add_data_provider();
-		locs->set_product_id(it->first); // data product ID
-		locs->add_domain_id(domain); // domain
-		list<PublisherInfoPB> urls = it->second;
-		for(list<PublisherInfoPB>::iterator lit = urls.begin(); lit != urls.end(); lit++)
-		{
-			locs->add_url(lit->url()); // url
-			locs->add_component_id(urlToComponentMap[lit->url()]); // component id
-			locs->add_timestamp(registrationInstanceMap[lit->url()]); // timestamp
-		}
-	}
-	
-	// Add change to data product
-	logger->debug("Adding Change : {} {} {} {}", productID, url, 
-			urlToComponentMap[url], timestamp);
-	ProductChange* change = providerMap.mutable_change();
-	change->set_product_id(productID);
-	change->set_url(url);
-	change->set_component_id(urlToComponentMap[url]);
-	change->set_timestamp(timestamp);
+    map<string, string> sMap = serviceMap[domain];
+    for (map<string, string>::iterator it2 = sMap.begin(); it2 != sMap.end(); it2++)
+    {
+        ProductLocations* locs = providerMap.add_service_provider();
+        locs->set_product_id(it2->first);                           // service ID
+        locs->add_url(it2->second);                                 // url
+        locs->add_component_id(urlToComponentMap[it2->second]);     // component id
+        locs->add_timestamp(registrationInstanceMap[it2->second]);  //timestamp
+        locs->add_domain_id(domain);                                // domain
+    }
+
+    map<string, list<PublisherInfoPB> > dpMap = dataProductMap[domain];
+    for (map<string, list<PublisherInfoPB> >::iterator it = dpMap.begin(); it != dpMap.end(); it++)
+    {
+        ProductLocations* locs = providerMap.add_data_provider();
+        locs->set_product_id(it->first);  // data product ID
+        locs->add_domain_id(domain);      // domain
+        list<PublisherInfoPB> urls = it->second;
+        for (list<PublisherInfoPB>::iterator lit = urls.begin(); lit != urls.end(); lit++)
+        {
+            locs->add_url(lit->url());                                 // url
+            locs->add_component_id(urlToComponentMap[lit->url()]);     // component id
+            locs->add_timestamp(registrationInstanceMap[lit->url()]);  // timestamp
+        }
+    }
+
+    // Add change to data product
+    logger->debug("Adding Change : {} {} {} {}", productID, url, urlToComponentMap[url], timestamp);
+    ProductChange* change = providerMap.mutable_change();
+    change->set_product_id(productID);
+    change->set_url(url);
+    change->set_component_id(urlToComponentMap[url]);
+    change->set_timestamp(timestamp);
     change->set_change_type(changeType == REMOVE ? ProductChange_ChangeType_REMOVE : ProductChange_ChangeType_ADD);
-    change->set_registration_type(registrationType == SERVICE ? 
-                    ProductChange_RegistrationType_SERVICE : ProductChange_RegistrationType_DATA);
+    change->set_registration_type(registrationType == SERVICE ? ProductChange_RegistrationType_SERVICE
+                                                              : ProductChange_RegistrationType_DATA);
 
-	// Publish update
-	logger->debug("Publishing ServiceDirectory_DomainDetails");
-	GravityDataProduct gdp(gravity::constants::DOMAIN_DETAILS_DPID);
-	gdp.setData(providerMap);
-	gn.publish(gdp);
+    // Publish update
+    logger->debug("Publishing ServiceDirectory_DomainDetails");
+    GravityDataProduct gdp(gravity::constants::DOMAIN_DETAILS_DPID);
+    gdp.setData(providerMap);
+    gn.publish(gdp);
 }
 
 void ServiceDirectory::handleRegister(const GravityDataProduct& request, GravityDataProduct& response)
@@ -672,138 +670,139 @@ void ServiceDirectory::handleRegister(const GravityDataProduct& request, Gravity
     bool foundDup = false;
 
     // If the registration does not specify a domain, default to our own
-	string domain = registration.has_domain() ? registration.domain() : this->domain;
-    
-	bool update = true;
+    string domain = registration.has_domain() ? registration.domain() : this->domain;
 
-	// if the request does not have a timestamp
-	if(!registration.has_timestamp())
-	{
-		logger->warn("Received Register for URL: {} with no timestamp. Ignoring Request",registration.url());
-		update = false;
-	}
-	//if we already have an instance for this URL
-	else if(registrationInstanceMap.find(registration.url())!=registrationInstanceMap.end())
-	{
-		//check if the update for the specified URL is older then our current mapping
-		if(registration.timestamp() < registrationInstanceMap[registration.url()])
-		{
-			logger->warn("Received Register for URL: {} with old timestamp {}",registration.url(),registration.timestamp());
-			update = false;
-		}
-	}
+    bool update = true;
 
-	if(update)
-	{
-		if (registration.type() == ServiceDirectoryRegistrationPB_RegistrationType_DATA)
-		{
-			map<string, list<PublisherInfoPB> >& dpMap = dataProductMap[domain];
+    // if the request does not have a timestamp
+    if (!registration.has_timestamp())
+    {
+        logger->warn("Received Register for URL: {} with no timestamp. Ignoring Request", registration.url());
+        update = false;
+    }
+    //if we already have an instance for this URL
+    else if (registrationInstanceMap.find(registration.url()) != registrationInstanceMap.end())
+    {
+        //check if the update for the specified URL is older then our current mapping
+        if (registration.timestamp() < registrationInstanceMap[registration.url()])
+        {
+            logger->warn("Received Register for URL: {} with old timestamp {}", registration.url(),
+                         registration.timestamp());
+            update = false;
+        }
+    }
 
-			if (registration.id() == gravity::constants::REGISTERED_PUBLISHERS_DPID)
-			{
-				// When this request is received here, this product ID has already been registered with our GravityNode, so
-				// it's safe to start publishing to it (cached values will be sent to new subscribers).
-				registeredPublishersReady = true;
-			}
-			list<PublisherInfoPB>& urls = dpMap[registration.id()];
-			list<PublisherInfoPB>::iterator iter = urls.begin();
-			for (;iter != urls.end();iter++)
-			{
-				if (iter->url() == registration.url())
-					break;
-			}
-			
-			// Insert new instance mapping for URL
-			registrationInstanceMap[registration.url()] = registration.timestamp();
+    if (update)
+    {
+        if (registration.type() == ServiceDirectoryRegistrationPB_RegistrationType_DATA)
+        {
+            map<string, list<PublisherInfoPB> >& dpMap = dataProductMap[domain];
 
-			uint32_t regTimeSecs = static_cast<uint32_t>(registration.timestamp() / 1e6);
-			if (iter == urls.end() || iter->registration_time() != regTimeSecs)
-			{
-				if (iter == urls.end())
-				{
-					PublisherInfoPB infoPB;
-					infoPB.set_url(registration.url());
-					if (registration.has_is_relay()) infoPB.set_isrelay(registration.is_relay());
-					if (registration.has_component_id()) infoPB.set_componentid(registration.component_id());
-					if (registration.has_ip_address()) infoPB.set_ipaddress(registration.ip_address());
-					infoPB.set_registration_time(regTimeSecs);
+            if (registration.id() == gravity::constants::REGISTERED_PUBLISHERS_DPID)
+            {
+                // When this request is received here, this product ID has already been registered with our GravityNode, so
+                // it's safe to start publishing to it (cached values will be sent to new subscribers).
+                registeredPublishersReady = true;
+            }
+            list<PublisherInfoPB>& urls = dpMap[registration.id()];
+            list<PublisherInfoPB>::iterator iter = urls.begin();
+            for (; iter != urls.end(); iter++)
+            {
+                if (iter->url() == registration.url()) break;
+            }
 
-					dpMap[registration.id()].push_back(infoPB);
-				}
-				else
-				{
-					if (registration.has_is_relay()) iter->set_isrelay(registration.is_relay());
-					if (registration.has_component_id()) iter->set_componentid(registration.component_id());
-					if (registration.has_ip_address()) iter->set_ipaddress(registration.ip_address());
-					iter->set_registration_time(regTimeSecs);
-				}				
-				
-				urlToComponentMap[registration.url()] = registration.component_id();
+            // Insert new instance mapping for URL
+            registrationInstanceMap[registration.url()] = registration.timestamp();
 
-				if (registeredPublishersReady)
-				{
-					GravityDataProduct update(gravity::constants::REGISTERED_PUBLISHERS_DPID);
-					addPublishers(registration.id(), update, domain);
-					gn.publish(update, registration.id());
-				}
-				else
-				{
-					registerUpdatesToSend.insert(registration.id());
-				}
+            uint32_t regTimeSecs = static_cast<uint32_t>(registration.timestamp() / 1e6);
+            if (iter == urls.end() || iter->registration_time() != regTimeSecs)
+            {
+                if (iter == urls.end())
+                {
+                    PublisherInfoPB infoPB;
+                    infoPB.set_url(registration.url());
+                    if (registration.has_is_relay()) infoPB.set_isrelay(registration.is_relay());
+                    if (registration.has_component_id()) infoPB.set_componentid(registration.component_id());
+                    if (registration.has_ip_address()) infoPB.set_ipaddress(registration.ip_address());
+                    infoPB.set_registration_time(regTimeSecs);
 
-				// Remove any previous registrations at this URL as they obviously no longer exist
-				purgeObsoletePublishers(registration.id(), registration.url());
+                    dpMap[registration.id()].push_back(infoPB);
+                }
+                else
+                {
+                    if (registration.has_is_relay()) iter->set_isrelay(registration.is_relay());
+                    if (registration.has_component_id()) iter->set_componentid(registration.component_id());
+                    if (registration.has_ip_address()) iter->set_ipaddress(registration.ip_address());
+                    iter->set_registration_time(regTimeSecs);
+                }
 
-				// Update any subscribers interested in our providers
-				if (domain == this->domain && registration.id() != gravity::constants::REGISTERED_PUBLISHERS_DPID)
-				{
-					logger->debug("Sending update of product definitions (resulting from added data for '{}' @ '{}')", registration.id(), registration.url());
-					updateProductLocations(registration.id(), registration.url(), registration.timestamp(), ADD, DATA);
-				}
-			}
-			else
-			{
-				foundDup = true;
-				
-				// Update any subscribers interested in our providers
-				if(domain == this->domain)
-				{
-					updateProductLocations(registration.id(), registration.url(), registration.timestamp(), ADD, DATA);
-				}
-			}
-		}
-		else
-		{
-			map<string, string>& sMap = serviceMap[domain];
+                urlToComponentMap[registration.url()] = registration.component_id();
 
-			if (sMap.find(registration.id()) != sMap.end())
-			{
-				logger->warn("Replacing existing provider for service id '{}'", registration.id()); 
-			}
-			// Add as service provider, overwriting any existing provider for this service
-			sMap[registration.id()] = registration.url();
-			
-			urlToComponentMap[registration.url()] = registration.component_id();
-			
-			// Remove any previous publisher registrations at this URL as they obviously no longer exist
-			purgeObsoletePublishers(registration.id(), registration.url());
+                if (registeredPublishersReady)
+                {
+                    GravityDataProduct update(gravity::constants::REGISTERED_PUBLISHERS_DPID);
+                    addPublishers(registration.id(), update, domain);
+                    gn.publish(update, registration.id());
+                }
+                else
+                {
+                    registerUpdatesToSend.insert(registration.id());
+                }
 
-			//insert new instance mapping for URL
-			registrationInstanceMap[registration.url()] = registration.timestamp();
+                // Remove any previous registrations at this URL as they obviously no longer exist
+                purgeObsoletePublishers(registration.id(), registration.url());
 
+                // Update any subscribers interested in our providers
+                if (domain == this->domain && registration.id() != gravity::constants::REGISTERED_PUBLISHERS_DPID)
+                {
+                    logger->debug("Sending update of product definitions (resulting from added data for '{}' @ '{}')",
+                                  registration.id(), registration.url());
+                    updateProductLocations(registration.id(), registration.url(), registration.timestamp(), ADD, DATA);
+                }
+            }
+            else
+            {
+                foundDup = true;
 
-			// Update any subscribers interested in our providers
-			if (domain == this->domain)
-			{
-				logger->debug("Sending update of product definitions (resulting from added service for '{}' @ '{}')", registration.id(), registration.url());
-				updateProductLocations(registration.id(), registration.url(), registration.timestamp(), ADD, SERVICE);
-			}
-		}
-		logger->info("[Register] ID: {}, MessageType: {}, URL: {}, Domain: {}", registration.id(),
-				registration.type() == ServiceDirectoryRegistrationPB_RegistrationType_DATA ? "Data Product": "Service", 
-				registration.url(), registration.domain());
-	
-	}
+                // Update any subscribers interested in our providers
+                if (domain == this->domain)
+                {
+                    updateProductLocations(registration.id(), registration.url(), registration.timestamp(), ADD, DATA);
+                }
+            }
+        }
+        else
+        {
+            map<string, string>& sMap = serviceMap[domain];
+
+            if (sMap.find(registration.id()) != sMap.end())
+            {
+                logger->warn("Replacing existing provider for service id '{}'", registration.id());
+            }
+            // Add as service provider, overwriting any existing provider for this service
+            sMap[registration.id()] = registration.url();
+
+            urlToComponentMap[registration.url()] = registration.component_id();
+
+            // Remove any previous publisher registrations at this URL as they obviously no longer exist
+            purgeObsoletePublishers(registration.id(), registration.url());
+
+            //insert new instance mapping for URL
+            registrationInstanceMap[registration.url()] = registration.timestamp();
+
+            // Update any subscribers interested in our providers
+            if (domain == this->domain)
+            {
+                logger->debug("Sending update of product definitions (resulting from added service for '{}' @ '{}')",
+                              registration.id(), registration.url());
+                updateProductLocations(registration.id(), registration.url(), registration.timestamp(), ADD, SERVICE);
+            }
+        }
+        logger->info(
+            "[Register] ID: {}, MessageType: {}, URL: {}, Domain: {}", registration.id(),
+            registration.type() == ServiceDirectoryRegistrationPB_RegistrationType_DATA ? "Data Product" : "Service",
+            registration.url(), registration.domain());
+    }
 
     ServiceDirectoryResponsePB sdr;
     sdr.set_id(registration.id());
@@ -827,92 +826,94 @@ void ServiceDirectory::handleUnregister(const GravityDataProduct& request, Gravi
     bool foundUrl = false;
 
     // If the registration does not specify a domain, default to our own
-	string domain = unregistration.has_domain() ? unregistration.domain() : this->domain;
+    string domain = unregistration.has_domain() ? unregistration.domain() : this->domain;
 
     if (unregistration.type() == ServiceDirectoryUnregistrationPB_RegistrationType_DATA)
     {
-		map<string, list<PublisherInfoPB> >& dpMap = dataProductMap[domain];
+        map<string, list<PublisherInfoPB> >& dpMap = dataProductMap[domain];
 
         list<PublisherInfoPB>* infoPBs = &dpMap[unregistration.id()];
         list<PublisherInfoPB>::iterator iter = infoPBs->begin();
-        for (;iter != infoPBs->end(); iter++)
+        for (; iter != infoPBs->end(); iter++)
         {
-			if (iter->url() == unregistration.url() && iter->registration_time() == unregistration.registration_time())
-			{
-				break;
-			}
+            if (iter->url() == unregistration.url() && iter->registration_time() == unregistration.registration_time())
+            {
+                break;
+            }
         }
         if (iter != infoPBs->end())
         {
             dpMap[unregistration.id()].erase(iter);
-			if (dpMap[unregistration.id()].empty())
-			{
-				dpMap.erase(unregistration.id());
-			}
+            if (dpMap[unregistration.id()].empty())
+            {
+                dpMap.erase(unregistration.id());
+            }
 
-			if (registeredPublishersReady)
-			{
-			    GravityDataProduct update(gravity::constants::REGISTERED_PUBLISHERS_DPID);
-			    addPublishers(unregistration.id(), update, domain);
-			    gn.publish(update, unregistration.id());
-			}
-			else
-			{
-			    registerUpdatesToSend.insert(unregistration.id());
-			}
+            if (registeredPublishersReady)
+            {
+                GravityDataProduct update(gravity::constants::REGISTERED_PUBLISHERS_DPID);
+                addPublishers(unregistration.id(), update, domain);
+                gn.publish(update, unregistration.id());
+            }
+            else
+            {
+                registerUpdatesToSend.insert(unregistration.id());
+            }
 
             // Update any subscribers interested in our providers
             if (domain == this->domain)
             {
-				updateProductLocations(unregistration.id(), unregistration.url(), 
-						registrationInstanceMap[unregistration.url()], REMOVE, DATA);
+                updateProductLocations(unregistration.id(), unregistration.url(),
+                                       registrationInstanceMap[unregistration.url()], REMOVE, DATA);
             }
-					
-			//remove instance mapping
-			registrationInstanceMap.erase(unregistration.url());
 
-			foundUrl = true;
+            //remove instance mapping
+            registrationInstanceMap.erase(unregistration.url());
+
+            foundUrl = true;
         }
     }
     else
     {
-		map<string, string>& sMap = serviceMap[domain];
+        map<string, string>& sMap = serviceMap[domain];
 
-		// Check that we have a submap for the requested domain and a registration instance for the requested url
-		if (sMap.find(unregistration.id()) != sMap.end() && registrationInstanceMap.find(unregistration.url()) != registrationInstanceMap.end())
+        // Check that we have a submap for the requested domain and a registration instance for the requested url
+        if (sMap.find(unregistration.id()) != sMap.end() &&
+            registrationInstanceMap.find(unregistration.url()) != registrationInstanceMap.end())
         {
-			// Confirm that the requested removal matches the registered time
-			uint32_t regTime = static_cast<uint32_t>(registrationInstanceMap[unregistration.url()] / 1e6);
-			if (regTime == unregistration.registration_time())
-			{
-				sMap.erase(unregistration.id());
+            // Confirm that the requested removal matches the registered time
+            uint32_t regTime = static_cast<uint32_t>(registrationInstanceMap[unregistration.url()] / 1e6);
+            if (regTime == unregistration.registration_time())
+            {
+                sMap.erase(unregistration.id());
 
-				// Update any subscribers interested in our providers
-				if (domain == this->domain)
-				{
-					updateProductLocations(unregistration.id(), unregistration.url(),
-						registrationInstanceMap[unregistration.url()], REMOVE, SERVICE);
-				}
+                // Update any subscribers interested in our providers
+                if (domain == this->domain)
+                {
+                    updateProductLocations(unregistration.id(), unregistration.url(),
+                                           registrationInstanceMap[unregistration.url()], REMOVE, SERVICE);
+                }
 
-				// remove instance mapping
-				registrationInstanceMap.erase(unregistration.url());
+                // remove instance mapping
+                registrationInstanceMap.erase(unregistration.url());
 
-				foundUrl = true;
-			}
+                foundUrl = true;
+            }
         }
     }
 
-    logger->info("[Unregister] ID: {}, MessageType: {}, URL: {}, Domain: {}", unregistration.id(),
-            unregistration.type() == ServiceDirectoryUnregistrationPB_RegistrationType_DATA? "Data Product": "Service", 
-            unregistration.url(), unregistration.domain());
+    logger->info(
+        "[Unregister] ID: {}, MessageType: {}, URL: {}, Domain: {}", unregistration.id(),
+        unregistration.type() == ServiceDirectoryUnregistrationPB_RegistrationType_DATA ? "Data Product" : "Service",
+        unregistration.url(), unregistration.domain());
 
     ServiceDirectoryResponsePB sdr;
     sdr.set_id(unregistration.id());
     if (!foundUrl)
     {
         sdr.set_returncode(ServiceDirectoryResponsePB::NOT_REGISTERED);
-        logger->warn("Attempt to unregister unregistered/invalid provider: {}, {}, {}, {}", unregistration.id(), 
-            unregistration.url(), unregistration.domain(), unregistration.registration_time());
+        logger->warn("Attempt to unregister unregistered/invalid provider: {}, {}, {}, {}", unregistration.id(),
+                     unregistration.url(), unregistration.domain(), unregistration.registration_time());
     }
     else
     {
@@ -922,20 +923,19 @@ void ServiceDirectory::handleUnregister(const GravityDataProduct& request, Gravi
     response.setData(sdr);
 }
 
-void ServiceDirectory::purgeObsoletePublishers(const string &dataProductID, const string &url)
+void ServiceDirectory::purgeObsoletePublishers(const string& dataProductID, const string& url)
 {
-	map<string, list<PublisherInfoPB> >& dpMap = dataProductMap[domain];
-	map<string,list<PublisherInfoPB> >::iterator iter = dpMap.begin();
-	while (iter != dpMap.end())
-    {		
+    map<string, list<PublisherInfoPB> >& dpMap = dataProductMap[domain];
+    map<string, list<PublisherInfoPB> >::iterator iter = dpMap.begin();
+    while (iter != dpMap.end())
+    {
         if (iter->first != dataProductID)
         {
             list<PublisherInfoPB>& infoPBs = iter->second;
             list<PublisherInfoPB>::iterator it = infoPBs.begin();
-            for (;it != infoPBs.end(); it++)
+            for (; it != infoPBs.end(); it++)
             {
-            	if (it->url() == url)
-            		break;
+                if (it->url() == url) break;
             }
             if (it != infoPBs.end())
             {
@@ -957,109 +957,111 @@ void ServiceDirectory::purgeObsoletePublishers(const string &dataProductID, cons
                 // Update any subscribers interested in our providers
                 updateProductLocations(iter->first, url, registrationInstanceMap[url], REMOVE, DATA);
 
-				//remove old Instance Mapping
-				registrationInstanceMap.erase(url);
+                //remove old Instance Mapping
+                registrationInstanceMap.erase(url);
             }
         }
 
-		if (iter->second.empty())
-		{
-			dpMap.erase(iter++);
-		}
-		else
-		{
-			++iter;
-		}
-	}	
+        if (iter->second.empty())
+        {
+            dpMap.erase(iter++);
+        }
+        else
+        {
+            ++iter;
+        }
+    }
 }
 
-void ServiceDirectory::addPublishers(const string &dataProductID, GravityDataProduct &response, const string &domain)
+void ServiceDirectory::addPublishers(const string& dataProductID, GravityDataProduct& response, const string& domain)
 {
-	map<string, list<PublisherInfoPB> > dpMap = dataProductMap[domain];
+    map<string, list<PublisherInfoPB> > dpMap = dataProductMap[domain];
     ComponentDataLookupResponsePB lookupResponse;
     lookupResponse.set_lookupid(dataProductID);
-	lookupResponse.set_domain_id(domain);
-	if (dpMap.count(dataProductID) != 0)
-	{
-		list<PublisherInfoPB>* infoPBs = &dpMap[dataProductID];
-		for (list<PublisherInfoPB>::iterator iter = infoPBs->begin(); iter != infoPBs->end(); iter++)
-		{
-			PublisherInfoPB* lookupInfoPB = lookupResponse.add_publishers();
-			lookupInfoPB->CopyFrom(*iter);
-		}
-	}
+    lookupResponse.set_domain_id(domain);
+    if (dpMap.count(dataProductID) != 0)
+    {
+        list<PublisherInfoPB>* infoPBs = &dpMap[dataProductID];
+        for (list<PublisherInfoPB>::iterator iter = infoPBs->begin(); iter != infoPBs->end(); iter++)
+        {
+            PublisherInfoPB* lookupInfoPB = lookupResponse.add_publishers();
+            lookupInfoPB->CopyFrom(*iter);
+        }
+    }
     response.setData(lookupResponse);
 }
 
-void ServiceDirectory::sendBroadcasterParameters(string sdDomain, string url, string ip, unsigned int port, unsigned int rate)
+void ServiceDirectory::sendBroadcasterParameters(string sdDomain, string url, string ip, unsigned int port,
+                                                 unsigned int rate)
 {
-	udpBroadcastSocket.lock.Lock();
+    udpBroadcastSocket.lock.Lock();
 
-	sendStringMessage(udpBroadcastSocket.socket,"broadcast",ZMQ_SNDMORE);
-	sendStringMessage(udpBroadcastSocket.socket,sdDomain,ZMQ_SNDMORE);
-	sendStringMessage(udpBroadcastSocket.socket,url,ZMQ_SNDMORE);
-	sendStringMessage(udpBroadcastSocket.socket,ip,ZMQ_SNDMORE);
-	
-	zmq_msg_t msg;
-	zmq_msg_init_size(&msg,sizeof(port));
-	memcpy(zmq_msg_data(&msg),&port,sizeof(port));
-	zmq_sendmsg(udpBroadcastSocket.socket,&msg,ZMQ_SNDMORE);
-	zmq_msg_close(&msg);
+    sendStringMessage(udpBroadcastSocket.socket, "broadcast", ZMQ_SNDMORE);
+    sendStringMessage(udpBroadcastSocket.socket, sdDomain, ZMQ_SNDMORE);
+    sendStringMessage(udpBroadcastSocket.socket, url, ZMQ_SNDMORE);
+    sendStringMessage(udpBroadcastSocket.socket, ip, ZMQ_SNDMORE);
 
-	zmq_msg_t msg2;
-	zmq_msg_init_size(&msg2,sizeof(rate));
-	memcpy(zmq_msg_data(&msg2),&rate,sizeof(rate));
-	zmq_sendmsg(udpBroadcastSocket.socket,&msg2,ZMQ_DONTWAIT);
-	zmq_msg_close(&msg2);
+    zmq_msg_t msg;
+    zmq_msg_init_size(&msg, sizeof(port));
+    memcpy(zmq_msg_data(&msg), &port, sizeof(port));
+    zmq_sendmsg(udpBroadcastSocket.socket, &msg, ZMQ_SNDMORE);
+    zmq_msg_close(&msg);
 
-	udpBroadcastSocket.lock.Unlock();
+    zmq_msg_t msg2;
+    zmq_msg_init_size(&msg2, sizeof(rate));
+    memcpy(zmq_msg_data(&msg2), &rate, sizeof(rate));
+    zmq_sendmsg(udpBroadcastSocket.socket, &msg2, ZMQ_DONTWAIT);
+    zmq_msg_close(&msg2);
+
+    udpBroadcastSocket.lock.Unlock();
 }
 
-void ServiceDirectory::sendReceiverParameters(string sdDomain, string url, unsigned int port, unsigned int numValidDomains, string validDomains)
+void ServiceDirectory::sendReceiverParameters(string sdDomain, string url, unsigned int port,
+                                              unsigned int numValidDomains, string validDomains)
 {
-	udpReceiverSocket.lock.Lock();
+    udpReceiverSocket.lock.Lock();
 
-	sendStringMessage(udpReceiverSocket.socket,"receive",ZMQ_SNDMORE);
-	sendStringMessage(udpReceiverSocket.socket,sdDomain,ZMQ_SNDMORE);
-	sendStringMessage(udpReceiverSocket.socket,url,ZMQ_SNDMORE);
+    sendStringMessage(udpReceiverSocket.socket, "receive", ZMQ_SNDMORE);
+    sendStringMessage(udpReceiverSocket.socket, sdDomain, ZMQ_SNDMORE);
+    sendStringMessage(udpReceiverSocket.socket, url, ZMQ_SNDMORE);
 
-	zmq_msg_t msg;
-	zmq_msg_init_size(&msg,sizeof(port));
-	memcpy(zmq_msg_data(&msg),&port,sizeof(port));
-	zmq_sendmsg(udpReceiverSocket.socket,&msg,ZMQ_SNDMORE);
-	zmq_msg_close(&msg);
+    zmq_msg_t msg;
+    zmq_msg_init_size(&msg, sizeof(port));
+    memcpy(zmq_msg_data(&msg), &port, sizeof(port));
+    zmq_sendmsg(udpReceiverSocket.socket, &msg, ZMQ_SNDMORE);
+    zmq_msg_close(&msg);
 
-	zmq_msg_t msg2;
-	zmq_msg_init_size(&msg2,sizeof(numValidDomains));
-	memcpy(zmq_msg_data(&msg2),&numValidDomains,sizeof(numValidDomains));
-	zmq_sendmsg(udpReceiverSocket.socket,&msg2,ZMQ_SNDMORE);
-	zmq_msg_close(&msg2);
+    zmq_msg_t msg2;
+    zmq_msg_init_size(&msg2, sizeof(numValidDomains));
+    memcpy(zmq_msg_data(&msg2), &numValidDomains, sizeof(numValidDomains));
+    zmq_sendmsg(udpReceiverSocket.socket, &msg2, ZMQ_SNDMORE);
+    zmq_msg_close(&msg2);
 
-	sendStringMessage(udpReceiverSocket.socket,validDomains,ZMQ_DONTWAIT);
+    sendStringMessage(udpReceiverSocket.socket, validDomains, ZMQ_DONTWAIT);
 
-	udpReceiverSocket.lock.Unlock();
+    udpReceiverSocket.lock.Unlock();
 }
 
 void ServiceDirectory::publishDomainUpdateMessage(string updateDomain, string url, ChangeType type)
 {
-	ServiceDirectoryDomainUpdatePB updatePB;
+    ServiceDirectoryDomainUpdatePB updatePB;
 
-	//add all the currently synced domain to the message
-	map<string,string>::iterator iter = domainMap.begin();
-	while (iter != domainMap.end())
-    {	
-		updatePB.add_known_domains(iter->first);
-		++iter;
-	}
+    //add all the currently synced domain to the message
+    map<string, string>::iterator iter = domainMap.begin();
+    while (iter != domainMap.end())
+    {
+        updatePB.add_known_domains(iter->first);
+        ++iter;
+    }
 
-	updatePB.set_update_domain(updateDomain);
+    updatePB.set_update_domain(updateDomain);
 
-	updatePB.set_type(type == ADD? ServiceDirectoryDomainUpdatePB_UpdateType_ADD : 
-		ServiceDirectoryDomainUpdatePB_UpdateType_REMOVE);
+    updatePB.set_type(type == ADD ? ServiceDirectoryDomainUpdatePB_UpdateType_ADD
+                                  : ServiceDirectoryDomainUpdatePB_UpdateType_REMOVE);
 
-	GravityDataProduct gdp(gravity::constants::DOMAIN_UPDATE_DPID);
-	gdp.setData(updatePB);
-	gn.publish(gdp);
+    GravityDataProduct gdp(gravity::constants::DOMAIN_UPDATE_DPID);
+    gdp.setData(updatePB);
+    gn.publish(gdp);
 }
 
 } /* namespace gravity */

--- a/src/components/cpp/ServiceDirectory/ServiceDirectory.h
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectory.h
@@ -41,39 +41,38 @@ namespace gravity
 
 enum RegistrationType
 {
-	SERVICE,
-	DATA
+    SERVICE,
+    DATA
 };
 
 enum ChangeType
 {
-	REMOVE,
-	ADD
+    REMOVE,
+    ADD
 };
 
 class ServiceDirectory : GravityServiceProvider
 {
 private:
+    // domain name for this service directory
+    std::string domain;
 
-	// domain name for this service directory
-	std::string domain;
+    // dataProductMap <domain, map<dataProductID, list<publishers> > >
+    std::map<std::string, std::map<std::string, std::list<gravity::PublisherInfoPB> > > dataProductMap;
 
-	// dataProductMap <domain, map<dataProductID, list<publishers> > >
-	std::map<std::string, std::map<std::string, std::list<gravity::PublisherInfoPB> > > dataProductMap;
+    // serviceMap <domain, map<serviceID, serviceProvider> >
+    std::map<std::string, std::map<std::string, std::string> > serviceMap;
 
-	// serviceMap <domain, map<serviceID, serviceProvider> >
-	std::map<std::string, std::map<std::string, std::string> > serviceMap;
+    // mapping from URL to name of publisher/service provider
+    std::map<std::string, std::string> urlToComponentMap;
 
-	// mapping from URL to name of publisher/service provider
-	std::map<std::string, std::string> urlToComponentMap;
+    // mapping from URL to registered timestamp
+    std::map<std::string, uint64_t> registrationInstanceMap;
 
-	// mapping from URL to registered timestamp
-	std::map<std::string, uint64_t> registrationInstanceMap;
+    // mapping from Domain to URL
+    std::map<std::string, std::string> domainMap;
 
-	// mapping from Domain to URL
-	std::map<std::string, std::string> domainMap;
-
-	// own GravityNode
+    // own GravityNode
     GravityNode gn;
 
     bool registeredPublishersReady, registeredPublishersProcessed;
@@ -82,21 +81,24 @@ private:
     // needed to manage objects accessed from ServiceProvider thread
     Semaphore lock;
 
-	void* context;
-	SocketWithLock udpBroadcastSocket;
-	SocketWithLock udpReceiverSocket;
-	void* synchronizerSocket;
+    void* context;
+    SocketWithLock udpBroadcastSocket;
+    SocketWithLock udpReceiverSocket;
+    void* synchronizerSocket;
 
-	void sendBroadcasterParameters(std::string sdDomain, std::string url, std::string ip, unsigned int port, unsigned int rate);
-	void sendReceiverParameters(std::string sdDomain, std::string url, unsigned int port, unsigned int numValidDomains, std::string validDomains);
-	void publishDomainUpdateMessage(std::string updateDomain, std::string url, ChangeType type);
+    void sendBroadcasterParameters(std::string sdDomain, std::string url, std::string ip, unsigned int port,
+                                   unsigned int rate);
+    void sendReceiverParameters(std::string sdDomain, std::string url, unsigned int port, unsigned int numValidDomains,
+                                std::string validDomains);
+    void publishDomainUpdateMessage(std::string updateDomain, std::string url, ChangeType type);
 
-	void updateProductLocations(std::string productID, std::string url, uint64_t timestamp, ChangeType changeType, RegistrationType registrationType);
-	void updateProductLocations();
-	std::shared_ptr<ServiceDirectoryMapPB> createOwnProviderMap();
-	
-	// Gravity logger
-	std::shared_ptr<spdlog::logger> logger;
+    void updateProductLocations(std::string productID, std::string url, uint64_t timestamp, ChangeType changeType,
+                                RegistrationType registrationType);
+    void updateProductLocations();
+    std::shared_ptr<ServiceDirectoryMapPB> createOwnProviderMap();
+
+    // Gravity logger
+    std::shared_ptr<spdlog::logger> logger;
 
 public:
     virtual ~ServiceDirectory();
@@ -108,8 +110,8 @@ private:
     void handleLookup(const GravityDataProduct& request, GravityDataProduct& response);
     void handleRegister(const GravityDataProduct& request, GravityDataProduct& response);
     void handleUnregister(const GravityDataProduct& request, GravityDataProduct& response);
-    void addPublishers(const std::string &dataProductID, GravityDataProduct &response, const std::string &domain);
-	void purgeObsoletePublishers(const std::string &dataProductID, const std::string &url);
+    void addPublishers(const std::string& dataProductID, GravityDataProduct& response, const std::string& domain);
+    void purgeObsoletePublishers(const std::string& dataProductID, const std::string& url);
 };
 
 } /* namespace gravity */

--- a/src/components/cpp/ServiceDirectory/ServiceDirectorySynchronizer.cpp
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectorySynchronizer.cpp
@@ -40,51 +40,51 @@ namespace gravity
 
 ServiceDirectorySynchronizer::ServiceDirectorySynchronizer(void* context, string url)
 {
-	// This is the zmq context that is shared with the ServiceDirectory. Must use
+    // This is the zmq context that is shared with the ServiceDirectory. Must use
     // a shared context to establish an inproc socket.
     this->context = context;
-	this->ownURL = url;
-	logger = spdlog::get("GravityLogger");
+    this->ownURL = url;
+    logger = spdlog::get("GravityLogger");
 }
 
-ServiceDirectorySynchronizer::~ServiceDirectorySynchronizer() {};
+ServiceDirectorySynchronizer::~ServiceDirectorySynchronizer(){};
 
 void ServiceDirectorySynchronizer::start()
 {
-	// Setup inproc socket to subscribe to commands from Service Directory
+    // Setup inproc socket to subscribe to commands from Service Directory
     commandSocket = zmq_socket(context, ZMQ_SUB);
     zmq_connect(commandSocket, "inproc://service_directory_synchronizer");
     zmq_setsockopt(commandSocket, ZMQ_SUBSCRIBE, NULL, 0);
 
-	// Setup the poll item for control
+    // Setup the poll item for control
     zmq_pollitem_t pollItemControl;
     pollItemControl.socket = commandSocket;
     pollItemControl.events = ZMQ_POLLIN;
     pollItemControl.fd = 0;
     pollItemControl.revents = 0;
-    pollItems.push_back(pollItemControl);	
+    pollItems.push_back(pollItemControl);
 
-	// Create request socket for update to own Service Directory
-	requestSocket = zmq_socket(context, ZMQ_REQ);
+    // Create request socket for update to own Service Directory
+    requestSocket = zmq_socket(context, ZMQ_REQ);
 
-	// Create poll item for response to this request and add to vector
-	// we're listening to
-	zmq_pollitem_t pollItem;
-	pollItem.socket = requestSocket;
-	pollItem.events = ZMQ_POLLIN;
-	pollItem.fd = 0;
-	pollItem.revents = 0;
-	pollItems.push_back(pollItem);
+    // Create poll item for response to this request and add to vector
+    // we're listening to
+    zmq_pollitem_t pollItem;
+    pollItem.socket = requestSocket;
+    pollItem.events = ZMQ_POLLIN;
+    pollItem.fd = 0;
+    pollItem.revents = 0;
+    pollItems.push_back(pollItem);
 
-	// Connect to service
-	zmq_connect(requestSocket, ownURL.c_str());
+    // Connect to service
+    zmq_connect(requestSocket, ownURL.c_str());
 
-	pendingResponse = false;
+    pendingResponse = false;
 
-	while (true)
+    while (true)
     {
-		// Start polling metrics control socket		
-        int rc = zmq_poll(&pollItems[0], pollItems.size(), -1); // 0 --> return immediately, -1 --> blocks
+        // Start polling metrics control socket
+        int rc = zmq_poll(&pollItems[0], pollItems.size(), -1);  // 0 --> return immediately, -1 --> blocks
         if (rc == -1)
         {
             // Interrupted
@@ -93,286 +93,295 @@ void ServiceDirectorySynchronizer::start()
 
         // Process incoming data requests from the gravity node
         if (pollItems[0].revents & ZMQ_POLLIN)
-        {		
-            // Get new GravityNode request
-            string command = readStringMessage(commandSocket);		
-
-			if (command == "Add")
-			{
-				// Get Domain from message 
-				string domain = readStringMessage(commandSocket);
-
-				// Get URL from message
-				string domainIP = readStringMessage(commandSocket);
-
-				logger->info("Received Domain Add command for {}:{}", domain, domainIP);
-
-				// We need to sychronize with a newly connected domain
-				if (syncMap.find(domain) == syncMap.end())
-				{					
-					// Create details
-				    std::shared_ptr<SyncDomainDetails> details(new SyncDomainDetails());
-					details->domain = domain;
-					details->ipAddress = domainIP;
-					details->initialized = false;
-
-					// Create the request socket to the other Service Directory
-					details->socket = zmq_socket(context, ZMQ_REQ);
-
-					// Create poll item for response to this request and add to vector
-					// we're listening to
-					zmq_pollitem_t pollItem;
-					pollItem.socket = details->socket;
-					pollItem.events = ZMQ_POLLIN;
-					pollItem.fd = 0;
-					pollItem.revents = 0;
-					pollItems.push_back(pollItem);
-
-					// Connect to service
-					zmq_connect(details->socket, domainIP.c_str());
-
-					// Construct lookup request. This will register us as a 
-					// subscriber to updates from the "remote" service directory
-					GravityDataProduct request("ComponentLookupRequest");
-					ComponentLookupRequestPB lookup;
-					lookup.set_lookupid(gravity::constants::DOMAIN_DETAILS_DPID);
-					lookup.set_type(gravity::ComponentLookupRequestPB_RegistrationType_DATA);
-					lookup.set_domain_id(domain);
-					request.setData(lookup);
-
-					// Submit request
-					zmq_msg_t data;
-					zmq_msg_init_size(&data, request.getSize());
-					request.serializeToArray(zmq_msg_data(&data));
-					zmq_sendmsg(details->socket, &data, ZMQ_DONTWAIT);
-					zmq_msg_close(&data);
-
-					// Save details to our internal map
-					syncMap[domain] = details;
-				}
-			}		
-			else if (command == "Update")
-			{
-				// Get Domain from message 
-				string domain = readStringMessage(commandSocket);
-
-				// Get URL from message
-				string domainIP = readStringMessage(commandSocket);
-
-				logger->info("Received Domain Update command for {}:{}", domain, domainIP);
-
-				// A domain has been update and should be reset. 
-				std::shared_ptr<SyncDomainDetails> details = syncMap[domain];
-
-				// Remove our subscription listener from pollItems vector
-				vector<zmq_pollitem_t>::iterator pollIter = pollItems.begin();
-				while (pollIter != pollItems.end())
-				{
-					if (pollIter->socket == details->socket)
-					{
-						pollIter = pollItems.erase(pollIter);
-					}
-					else
-					{
-						pollIter++;
-					}
-				}
-				logger->info("deleted from Synchronizer pollItems: pollItems len = {}", pollItems.size());
-
-				// Close SUB socket
-				socketToDomainDetailsMap.erase(details->socket);
-				logger->trace("deleted from Synchronizer socketToDomainDetailsMap: socketToDomainDetailsMap len = {}", socketToDomainDetailsMap.size());
-				zmq_close(details->socket);
-
-				// Update details
-				details->domain = domain;
-				details->ipAddress = domainIP;
-				details->initialized = false;
-
-				// Create the request socket to the other Service Directory
-				details->socket = zmq_socket(context, ZMQ_REQ);
-
-				// Create poll item for response to this request and add to vector
-				// we're listening to
-				zmq_pollitem_t pollItem;
-				pollItem.socket = details->socket;
-				pollItem.events = ZMQ_POLLIN;
-				pollItem.fd = 0;
-				pollItem.revents = 0;
-				pollItems.push_back(pollItem);
-
-				// Connect to service
-				zmq_connect(details->socket, domainIP.c_str());
-
-				// Construct lookup request. This will register us as a 
-				// subscriber to updates from the "remote" service directory
-				GravityDataProduct request("ComponentLookupRequest");
-				ComponentLookupRequestPB lookup;
-				lookup.set_lookupid(gravity::constants::DOMAIN_DETAILS_DPID);
-				lookup.set_type(gravity::ComponentLookupRequestPB_RegistrationType_DATA);
-				lookup.set_domain_id(domain);
-				request.setData(lookup);
-
-				// Submit request
-				zmq_msg_t data;
-				zmq_msg_init_size(&data, request.getSize());
-				request.serializeToArray(zmq_msg_data(&data));
-				zmq_sendmsg(details->socket, &data, ZMQ_DONTWAIT);
-				zmq_msg_close(&data);
-
-				// Save details to our internal map
-				syncMap[domain] = details;
-			}
-			else if (command == "Remove")
-			{
-				// Get Domain from message 
-				string domain = readStringMessage(commandSocket);
-
-				logger->info("Received Domain Remove command for '{}'", domain);
-
-				//make sure we have a mapping to the domain
-				if(syncMap.find(domain)!=syncMap.end())
-				{
-					// A domain is no longer available and needs to be removed. Get 
-					// details from map
-				    std::shared_ptr<SyncDomainDetails> details = syncMap[domain];
-
-				    // Remove our subscription listener from pollItems vector
-				    // (i.e. no longer care to receive updates)
-				    vector<zmq_pollitem_t>::iterator pollIter = pollItems.begin();
-				    while (pollIter != pollItems.end())
-				    {
-				        if (pollIter->socket == details->socket)
-				        {
-				            pollIter = pollItems.erase(pollIter);
-				        }
-				        else
-				        {
-				            pollIter++;
-				        }
-				    }
-				    logger->info("deleted from Synchronizer pollItems: pollItems len = {}", pollItems.size());
-
-					// Close SUB socket
-					zmq_close(details->socket);				
-
-					// Clear all domain data from Service Directory							
-					for (int i = 0; i < details->providerMap.service_provider_size(); i++)
-					{
-						string productID = details->providerMap.service_provider(i).product_id();						
-						for (int j = 0; j < details->providerMap.service_provider(i).url_size(); j++)
-						{
-							string url = details->providerMap.service_provider(i).url(j);						
-							createUnregistrationRequest(productID, url, domain, details->providerMap.change().registration_type(), details->registrationTime);
-						}
-					}								
-					for (int i = 0; i < details->providerMap.data_provider_size(); i++)
-					{
-						string productID = details->providerMap.data_provider(i).product_id();
-						for (int j = 0; j < details->providerMap.data_provider(i).url_size(); j++)
-						{
-							string url = details->providerMap.data_provider(i).url(j);						
-							createUnregistrationRequest(productID, url, domain, details->providerMap.change().registration_type(), details->registrationTime);
-						}			
-					}				
-
-					// Remove from map
-					syncMap.erase(domain);
-					socketToDomainDetailsMap.erase(details->socket);
-				}
-			}			
-		}
-		else if (pollItems[1].revents & ZMQ_POLLIN)
         {
-			// This is a response from our request to update our own Service Directory
-			logger->debug("Received response from own SD for an update");
+            // Get new GravityNode request
+            string command = readStringMessage(commandSocket);
 
-			// Read (and ignore for now) the response
-			zmq_msg_t message;
-			zmq_msg_init(&message);
-			zmq_recvmsg(pollItems[1].socket, &message, 0);
-			zmq_msg_close(&message);
+            if (command == "Add")
+            {
+                // Get Domain from message
+                string domain = readStringMessage(commandSocket);
 
-			// Clear the flag indicating that we're no longer awaiting a response and
-			// can send another update
-			pendingResponse = false;
-		}
+                // Get URL from message
+                string domainIP = readStringMessage(commandSocket);
 
-		if (pollItems.size() > 2)
-		{
-			// Now check for any updates from synchronized service directories
-			vector<zmq_pollitem_t>::iterator pollItemIter = pollItems.begin() + 2;
+                logger->info("Received Domain Add command for {}:{}", domain, domainIP);
 
-			// Check for responses
-			while(pollItemIter != pollItems.end())
-			{
-				if (pollItemIter->revents && ZMQ_POLLIN)
-				{
-					// Process response from ServiceDirectory
-					zmq_msg_t message;
-					zmq_msg_init(&message);
-					int ret = zmq_recvmsg(pollItemIter->socket, &message, 0);
-					if (ret < 0)
-					{
-					    logger->warn("Received error from zmq_recvmsg, errno = {}", errno);
-					}
+                // We need to sychronize with a newly connected domain
+                if (syncMap.find(domain) == syncMap.end())
+                {
+                    // Create details
+                    std::shared_ptr<SyncDomainDetails> details(new SyncDomainDetails());
+                    details->domain = domain;
+                    details->ipAddress = domainIP;
+                    details->initialized = false;
 
-					// Create new GravityDataProduct from the incoming message
-					GravityDataProduct response(zmq_msg_data(&message), zmq_msg_size(&message));
+                    // Create the request socket to the other Service Directory
+                    details->socket = zmq_socket(context, ZMQ_REQ);
 
-					logger->trace("Response domain:reg time = {}:{}, pollItemIter->socket = {}, socketToDomainDetailsMap size = {}, msg id = {}",
-					        response.getDomain(),
-					        response.getRegistrationTime(),
-					        pollItemIter->socket,
-					        socketToDomainDetailsMap.size(),
-							response.getDataProductID());
+                    // Create poll item for response to this request and add to vector
+                    // we're listening to
+                    zmq_pollitem_t pollItem;
+                    pollItem.socket = details->socket;
+                    pollItem.events = ZMQ_POLLIN;
+                    pollItem.fd = 0;
+                    pollItem.revents = 0;
+                    pollItems.push_back(pollItem);
 
-					if (zmq_msg_size(&message) > 0 &&
-					        socketToDomainDetailsMap.find(pollItemIter->socket) != socketToDomainDetailsMap.end() &&
-					        socketToDomainDetailsMap[pollItemIter->socket]->registrationTime != response.getRegistrationTime())
-					{
-					    logger->debug("Found invalid socket - expecting domain:time {}:{}, but found {}:{} with GDP id = {} and msg size = {}, ignoring",
-					            socketToDomainDetailsMap[pollItemIter->socket]->domain,
-					            socketToDomainDetailsMap[pollItemIter->socket]->registrationTime,
-					            response.getDomain(),
-					            response.getRegistrationTime(),
-					            response.getDataProductID(),
-					            zmq_msg_size(&message));
-					}
-					else if (response.getDataProductID() == "DataProductRegistrationResponse")
-					{					
-						// This is a response to our request for a subscription to
-						// updates from the "remote" service directory
-						ComponentDataLookupResponsePB resp;
-						response.populateMessage(resp);
-						if (resp.publishers_size() == 0 || !resp.publishers(0).has_url())
-						{
-						    logger->warn("Received empty response to request for subscription updates from remote service directory, trying again...");
+                    // Connect to service
+                    zmq_connect(details->socket, domainIP.c_str());
 
-							gravity::sleep(500);
+                    // Construct lookup request. This will register us as a
+                    // subscriber to updates from the "remote" service directory
+                    GravityDataProduct request("ComponentLookupRequest");
+                    ComponentLookupRequestPB lookup;
+                    lookup.set_lookupid(gravity::constants::DOMAIN_DETAILS_DPID);
+                    lookup.set_type(gravity::ComponentLookupRequestPB_RegistrationType_DATA);
+                    lookup.set_domain_id(domain);
+                    request.setData(lookup);
 
-							// Construct lookup request. This will register us as a 
-							// subscriber to updates from the "remote" service directory
-							GravityDataProduct request("ComponentLookupRequest");
-							ComponentLookupRequestPB lookup;
-							lookup.set_lookupid(gravity::constants::DOMAIN_DETAILS_DPID);
-							lookup.set_type(gravity::ComponentLookupRequestPB_RegistrationType_DATA);
-							lookup.set_domain_id(response.getDomain());
-							request.setData(lookup);
+                    // Submit request
+                    zmq_msg_t data;
+                    zmq_msg_init_size(&data, request.getSize());
+                    request.serializeToArray(zmq_msg_data(&data));
+                    zmq_sendmsg(details->socket, &data, ZMQ_DONTWAIT);
+                    zmq_msg_close(&data);
 
-							// Submit request
-							zmq_msg_t data;
-							zmq_msg_init_size(&data, request.getSize());
-							request.serializeToArray(zmq_msg_data(&data));
-							zmq_sendmsg(pollItemIter->socket, &data, ZMQ_DONTWAIT);
-							zmq_msg_close(&data);
-						}
-						else
-						{
+                    // Save details to our internal map
+                    syncMap[domain] = details;
+                }
+            }
+            else if (command == "Update")
+            {
+                // Get Domain from message
+                string domain = readStringMessage(commandSocket);
+
+                // Get URL from message
+                string domainIP = readStringMessage(commandSocket);
+
+                logger->info("Received Domain Update command for {}:{}", domain, domainIP);
+
+                // A domain has been update and should be reset.
+                std::shared_ptr<SyncDomainDetails> details = syncMap[domain];
+
+                // Remove our subscription listener from pollItems vector
+                vector<zmq_pollitem_t>::iterator pollIter = pollItems.begin();
+                while (pollIter != pollItems.end())
+                {
+                    if (pollIter->socket == details->socket)
+                    {
+                        pollIter = pollItems.erase(pollIter);
+                    }
+                    else
+                    {
+                        pollIter++;
+                    }
+                }
+                logger->info("deleted from Synchronizer pollItems: pollItems len = {}", pollItems.size());
+
+                // Close SUB socket
+                socketToDomainDetailsMap.erase(details->socket);
+                logger->trace("deleted from Synchronizer socketToDomainDetailsMap: socketToDomainDetailsMap len = {}",
+                              socketToDomainDetailsMap.size());
+                zmq_close(details->socket);
+
+                // Update details
+                details->domain = domain;
+                details->ipAddress = domainIP;
+                details->initialized = false;
+
+                // Create the request socket to the other Service Directory
+                details->socket = zmq_socket(context, ZMQ_REQ);
+
+                // Create poll item for response to this request and add to vector
+                // we're listening to
+                zmq_pollitem_t pollItem;
+                pollItem.socket = details->socket;
+                pollItem.events = ZMQ_POLLIN;
+                pollItem.fd = 0;
+                pollItem.revents = 0;
+                pollItems.push_back(pollItem);
+
+                // Connect to service
+                zmq_connect(details->socket, domainIP.c_str());
+
+                // Construct lookup request. This will register us as a
+                // subscriber to updates from the "remote" service directory
+                GravityDataProduct request("ComponentLookupRequest");
+                ComponentLookupRequestPB lookup;
+                lookup.set_lookupid(gravity::constants::DOMAIN_DETAILS_DPID);
+                lookup.set_type(gravity::ComponentLookupRequestPB_RegistrationType_DATA);
+                lookup.set_domain_id(domain);
+                request.setData(lookup);
+
+                // Submit request
+                zmq_msg_t data;
+                zmq_msg_init_size(&data, request.getSize());
+                request.serializeToArray(zmq_msg_data(&data));
+                zmq_sendmsg(details->socket, &data, ZMQ_DONTWAIT);
+                zmq_msg_close(&data);
+
+                // Save details to our internal map
+                syncMap[domain] = details;
+            }
+            else if (command == "Remove")
+            {
+                // Get Domain from message
+                string domain = readStringMessage(commandSocket);
+
+                logger->info("Received Domain Remove command for '{}'", domain);
+
+                //make sure we have a mapping to the domain
+                if (syncMap.find(domain) != syncMap.end())
+                {
+                    // A domain is no longer available and needs to be removed. Get
+                    // details from map
+                    std::shared_ptr<SyncDomainDetails> details = syncMap[domain];
+
+                    // Remove our subscription listener from pollItems vector
+                    // (i.e. no longer care to receive updates)
+                    vector<zmq_pollitem_t>::iterator pollIter = pollItems.begin();
+                    while (pollIter != pollItems.end())
+                    {
+                        if (pollIter->socket == details->socket)
+                        {
+                            pollIter = pollItems.erase(pollIter);
+                        }
+                        else
+                        {
+                            pollIter++;
+                        }
+                    }
+                    logger->info("deleted from Synchronizer pollItems: pollItems len = {}", pollItems.size());
+
+                    // Close SUB socket
+                    zmq_close(details->socket);
+
+                    // Clear all domain data from Service Directory
+                    for (int i = 0; i < details->providerMap.service_provider_size(); i++)
+                    {
+                        string productID = details->providerMap.service_provider(i).product_id();
+                        for (int j = 0; j < details->providerMap.service_provider(i).url_size(); j++)
+                        {
+                            string url = details->providerMap.service_provider(i).url(j);
+                            createUnregistrationRequest(productID, url, domain,
+                                                        details->providerMap.change().registration_type(),
+                                                        details->registrationTime);
+                        }
+                    }
+                    for (int i = 0; i < details->providerMap.data_provider_size(); i++)
+                    {
+                        string productID = details->providerMap.data_provider(i).product_id();
+                        for (int j = 0; j < details->providerMap.data_provider(i).url_size(); j++)
+                        {
+                            string url = details->providerMap.data_provider(i).url(j);
+                            createUnregistrationRequest(productID, url, domain,
+                                                        details->providerMap.change().registration_type(),
+                                                        details->registrationTime);
+                        }
+                    }
+
+                    // Remove from map
+                    syncMap.erase(domain);
+                    socketToDomainDetailsMap.erase(details->socket);
+                }
+            }
+        }
+        else if (pollItems[1].revents & ZMQ_POLLIN)
+        {
+            // This is a response from our request to update our own Service Directory
+            logger->debug("Received response from own SD for an update");
+
+            // Read (and ignore for now) the response
+            zmq_msg_t message;
+            zmq_msg_init(&message);
+            zmq_recvmsg(pollItems[1].socket, &message, 0);
+            zmq_msg_close(&message);
+
+            // Clear the flag indicating that we're no longer awaiting a response and
+            // can send another update
+            pendingResponse = false;
+        }
+
+        if (pollItems.size() > 2)
+        {
+            // Now check for any updates from synchronized service directories
+            vector<zmq_pollitem_t>::iterator pollItemIter = pollItems.begin() + 2;
+
+            // Check for responses
+            while (pollItemIter != pollItems.end())
+            {
+                if (pollItemIter->revents && ZMQ_POLLIN)
+                {
+                    // Process response from ServiceDirectory
+                    zmq_msg_t message;
+                    zmq_msg_init(&message);
+                    int ret = zmq_recvmsg(pollItemIter->socket, &message, 0);
+                    if (ret < 0)
+                    {
+                        logger->warn("Received error from zmq_recvmsg, errno = {}", errno);
+                    }
+
+                    // Create new GravityDataProduct from the incoming message
+                    GravityDataProduct response(zmq_msg_data(&message), zmq_msg_size(&message));
+
+                    logger->trace(
+                        "Response domain:reg time = {}:{}, pollItemIter->socket = {}, socketToDomainDetailsMap size = "
+                        "{}, msg id = {}",
+                        response.getDomain(), response.getRegistrationTime(), pollItemIter->socket,
+                        socketToDomainDetailsMap.size(), response.getDataProductID());
+
+                    if (zmq_msg_size(&message) > 0 &&
+                        socketToDomainDetailsMap.find(pollItemIter->socket) != socketToDomainDetailsMap.end() &&
+                        socketToDomainDetailsMap[pollItemIter->socket]->registrationTime !=
+                            response.getRegistrationTime())
+                    {
+                        logger->debug(
+                            "Found invalid socket - expecting domain:time {}:{}, but found {}:{} with GDP id = {} and "
+                            "msg size = {}, ignoring",
+                            socketToDomainDetailsMap[pollItemIter->socket]->domain,
+                            socketToDomainDetailsMap[pollItemIter->socket]->registrationTime, response.getDomain(),
+                            response.getRegistrationTime(), response.getDataProductID(), zmq_msg_size(&message));
+                    }
+                    else if (response.getDataProductID() == "DataProductRegistrationResponse")
+                    {
+                        // This is a response to our request for a subscription to
+                        // updates from the "remote" service directory
+                        ComponentDataLookupResponsePB resp;
+                        response.populateMessage(resp);
+                        if (resp.publishers_size() == 0 || !resp.publishers(0).has_url())
+                        {
+                            logger->warn(
+                                "Received empty response to request for subscription updates from remote service "
+                                "directory, trying again...");
+
+                            gravity::sleep(500);
+
+                            // Construct lookup request. This will register us as a
+                            // subscriber to updates from the "remote" service directory
+                            GravityDataProduct request("ComponentLookupRequest");
+                            ComponentLookupRequestPB lookup;
+                            lookup.set_lookupid(gravity::constants::DOMAIN_DETAILS_DPID);
+                            lookup.set_type(gravity::ComponentLookupRequestPB_RegistrationType_DATA);
+                            lookup.set_domain_id(response.getDomain());
+                            request.setData(lookup);
+
+                            // Submit request
+                            zmq_msg_t data;
+                            zmq_msg_init_size(&data, request.getSize());
+                            request.serializeToArray(zmq_msg_data(&data));
+                            zmq_sendmsg(pollItemIter->socket, &data, ZMQ_DONTWAIT);
+                            zmq_msg_close(&data);
+                        }
+                        else
+                        {
                             string domain = resp.domain_id();
                             string url = resp.publishers(0).url();
 
-                            logger->info("Received DataProductRegistrationResponse response from ServiceDirectory for domain: '{}'", domain);
+                            logger->info(
+                                "Received DataProductRegistrationResponse response from ServiceDirectory for domain: "
+                                "'{}'",
+                                domain);
 
                             // Get the details for the domain that is providing an update
                             std::shared_ptr<SyncDomainDetails> details = syncMap[domain];
@@ -384,8 +393,9 @@ void ServiceDirectorySynchronizer::start()
                             // Set up subscription socket for updates from the "remote" service directory
                             details->socket = zmq_socket(context, ZMQ_SUB);
                             details->initialized = false;
-							details->registrationTime = resp.publishers(0).has_registration_time() ? resp.publishers(0).registration_time() : 0;
-							socketToDomainDetailsMap[details->socket] = details;
+                            details->registrationTime =
+                                resp.publishers(0).has_registration_time() ? resp.publishers(0).registration_time() : 0;
+                            socketToDomainDetailsMap[details->socket] = details;
 
                             // Update poll item with new subscription socket
                             // (replace REP socket with new SUB socket)
@@ -396,145 +406,158 @@ void ServiceDirectorySynchronizer::start()
                             // Connect to publisher
                             zmq_connect(details->socket, url.c_str());
                             zmq_setsockopt(details->socket, ZMQ_SUBSCRIBE, NULL, 0);
-						}
-					}
-					else if (response.getDataProductID() == gravity::constants::DOMAIN_DETAILS_DPID)
-					{
-						// This is a subscription update of a service directory's content map
-						ServiceDirectoryMapPB providerMap;
-						response.populateMessage(providerMap);					
-						string domain = providerMap.domain();
+                        }
+                    }
+                    else if (response.getDataProductID() == gravity::constants::DOMAIN_DETAILS_DPID)
+                    {
+                        // This is a subscription update of a service directory's content map
+                        ServiceDirectoryMapPB providerMap;
+                        response.populateMessage(providerMap);
+                        string domain = providerMap.domain();
 
-						logger->info("Received update from ServiceDirectory for domain: '{}'", domain);
+                        logger->info("Received update from ServiceDirectory for domain: '{}'", domain);
 
-						std::shared_ptr<SyncDomainDetails> details = syncMap[domain];
-						details->providerMap.Clear();
-						response.populateMessage(details->providerMap);					
-						if (!details->initialized)
-						{
-							// First update from this Service Directory
-							details->initialized = true;
-							logger->info("Initial Update from domain '{}'", domain);
+                        std::shared_ptr<SyncDomainDetails> details = syncMap[domain];
+                        details->providerMap.Clear();
+                        response.populateMessage(details->providerMap);
+                        if (!details->initialized)
+                        {
+                            // First update from this Service Directory
+                            details->initialized = true;
+                            logger->info("Initial Update from domain '{}'", domain);
 
-							// Test code
-							//logger->debug("Received new providerMap: ");
-							//printMap(providerMap);
+                            // Test code
+                            //logger->debug("Received new providerMap: ");
+                            //printMap(providerMap);
 
-							// Send all content as updates to our service directory
-							for (int i = 0; i < providerMap.service_provider_size(); i++)
-							{
-								string productID = providerMap.service_provider(i).product_id();						
-								for (int j = 0; j < providerMap.service_provider(i).url_size(); j++)
-								{
-									string url = providerMap.service_provider(i).url(j);
-									string componentID = providerMap.service_provider(i).component_id(j);
-									uint64_t timestamp = providerMap.service_provider(i).timestamp(j);
-									createRegistrationRequest(productID, url, componentID, domain, ProductChange_RegistrationType_SERVICE,timestamp);
-								}
-							}								
-							for (int i = 0; i < providerMap.data_provider_size(); i++)
-							{
-								string productID = providerMap.data_provider(i).product_id();
-								for (int j = 0; j < providerMap.data_provider(i).url_size(); j++)
-								{
-									string url = providerMap.data_provider(i).url(j);
-									string componentID = providerMap.data_provider(i).component_id(j);	
-									uint64_t timestamp = providerMap.data_provider(i).timestamp(j);
-									createRegistrationRequest(productID, url, componentID, domain, ProductChange_RegistrationType_DATA,timestamp);
-								}
-							}
-						}
-						else
-						{
-							// Incremental update							
-							string productID = providerMap.change().product_id();
-							string url = providerMap.change().url();
-							string change = providerMap.change().change_type() == ProductChange_ChangeType_ADD ? "Add" : "Remove";
-							string type = providerMap.change().registration_type() == ProductChange_RegistrationType_DATA ? "Data" : "Service";	
-							string componentID = providerMap.change().component_id();
-							uint64_t timestamp = providerMap.change().timestamp();
+                            // Send all content as updates to our service directory
+                            for (int i = 0; i < providerMap.service_provider_size(); i++)
+                            {
+                                string productID = providerMap.service_provider(i).product_id();
+                                for (int j = 0; j < providerMap.service_provider(i).url_size(); j++)
+                                {
+                                    string url = providerMap.service_provider(i).url(j);
+                                    string componentID = providerMap.service_provider(i).component_id(j);
+                                    uint64_t timestamp = providerMap.service_provider(i).timestamp(j);
+                                    createRegistrationRequest(productID, url, componentID, domain,
+                                                              ProductChange_RegistrationType_SERVICE, timestamp);
+                                }
+                            }
+                            for (int i = 0; i < providerMap.data_provider_size(); i++)
+                            {
+                                string productID = providerMap.data_provider(i).product_id();
+                                for (int j = 0; j < providerMap.data_provider(i).url_size(); j++)
+                                {
+                                    string url = providerMap.data_provider(i).url(j);
+                                    string componentID = providerMap.data_provider(i).component_id(j);
+                                    uint64_t timestamp = providerMap.data_provider(i).timestamp(j);
+                                    createRegistrationRequest(productID, url, componentID, domain,
+                                                              ProductChange_RegistrationType_DATA, timestamp);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // Incremental update
+                            string productID = providerMap.change().product_id();
+                            string url = providerMap.change().url();
+                            string change =
+                                providerMap.change().change_type() == ProductChange_ChangeType_ADD ? "Add" : "Remove";
+                            string type =
+                                providerMap.change().registration_type() == ProductChange_RegistrationType_DATA
+                                    ? "Data"
+                                    : "Service";
+                            string componentID = providerMap.change().component_id();
+                            uint64_t timestamp = providerMap.change().timestamp();
 
-							logger->info("Incremental Update from domain '{}': {} {} named {} at {}", domain, change, type, productID, url);							
+                            logger->info("Incremental Update from domain '{}': {} {} named {} at {}", domain, change,
+                                         type, productID, url);
 
-							if (providerMap.change().change_type() == ProductChange_ChangeType_ADD)
-							{
-								createRegistrationRequest(productID, url, componentID, domain, providerMap.change().registration_type() ,timestamp);								
-							}
-							else
-							{
-								uint32_t regTimeSecs = static_cast<uint32_t>(timestamp/1e6);
-								createUnregistrationRequest(productID, url, domain, providerMap.change().registration_type(), regTimeSecs);
-							}
-							// Test code
-							//logger->debug("Received updated providerMap: ");
-							//printMap(providerMap);
-						}
-					}				
+                            if (providerMap.change().change_type() == ProductChange_ChangeType_ADD)
+                            {
+                                createRegistrationRequest(productID, url, componentID, domain,
+                                                          providerMap.change().registration_type(), timestamp);
+                            }
+                            else
+                            {
+                                uint32_t regTimeSecs = static_cast<uint32_t>(timestamp / 1e6);
+                                createUnregistrationRequest(productID, url, domain,
+                                                            providerMap.change().registration_type(), regTimeSecs);
+                            }
+                            // Test code
+                            //logger->debug("Received updated providerMap: ");
+                            //printMap(providerMap);
+                        }
+                    }
 
-					// Clean up message
-					zmq_msg_close(&message);				
-				}
-				pollItemIter++;
-			}		
-		}
-		
-		// If we're not awaiting a response from our SD for an update and we
-		// have another one update to send then we'll send it
-		if (!pendingResponse && !registrationUpdates.empty())
-		{
-			// Pop the next update to send from the queue
-		    std::shared_ptr<GravityDataProduct> gdp = registrationUpdates.front();
-			registrationUpdates.pop();
+                    // Clean up message
+                    zmq_msg_close(&message);
+                }
+                pollItemIter++;
+            }
+        }
 
-			// Send data product
-			zmq_msg_t data;
-			zmq_msg_init_size(&data, gdp->getSize());
-			gdp->serializeToArray(zmq_msg_data(&data));
-			zmq_sendmsg(requestSocket, &data, ZMQ_DONTWAIT);
-			zmq_msg_close(&data);
+        // If we're not awaiting a response from our SD for an update and we
+        // have another one update to send then we'll send it
+        if (!pendingResponse && !registrationUpdates.empty())
+        {
+            // Pop the next update to send from the queue
+            std::shared_ptr<GravityDataProduct> gdp = registrationUpdates.front();
+            registrationUpdates.pop();
 
-			// Set flag to indicate we're awaiting a response
-			pendingResponse = true;
-		}
-	}
+            // Send data product
+            zmq_msg_t data;
+            zmq_msg_init_size(&data, gdp->getSize());
+            gdp->serializeToArray(zmq_msg_data(&data));
+            zmq_sendmsg(requestSocket, &data, ZMQ_DONTWAIT);
+            zmq_msg_close(&data);
+
+            // Set flag to indicate we're awaiting a response
+            pendingResponse = true;
+        }
+    }
 }
 
 // Utility to create a RegistrationRequest message and add it to the queue to be submitted
-void ServiceDirectorySynchronizer::createRegistrationRequest(string productID, string url, string componentID, 
-															 string domain, ProductChange_RegistrationType type, uint64_t timestamp)
+void ServiceDirectorySynchronizer::createRegistrationRequest(string productID, string url, string componentID,
+                                                             string domain, ProductChange_RegistrationType type,
+                                                             uint64_t timestamp)
 {
-	ServiceDirectoryRegistrationPB_RegistrationType rtype = type == ProductChange_RegistrationType_DATA ?
-			ServiceDirectoryRegistrationPB_RegistrationType_DATA : ServiceDirectoryRegistrationPB_RegistrationType_SERVICE;
+    ServiceDirectoryRegistrationPB_RegistrationType rtype =
+        type == ProductChange_RegistrationType_DATA ? ServiceDirectoryRegistrationPB_RegistrationType_DATA
+                                                    : ServiceDirectoryRegistrationPB_RegistrationType_SERVICE;
 
-	ServiceDirectoryRegistrationPB registerRequest;
-	registerRequest.set_id(productID);
-	registerRequest.set_url(url);
-	registerRequest.set_type(rtype);	
-	registerRequest.set_component_id(componentID);
-	registerRequest.set_domain(domain);
-	registerRequest.set_timestamp(timestamp);
+    ServiceDirectoryRegistrationPB registerRequest;
+    registerRequest.set_id(productID);
+    registerRequest.set_url(url);
+    registerRequest.set_type(rtype);
+    registerRequest.set_component_id(componentID);
+    registerRequest.set_domain(domain);
+    registerRequest.set_timestamp(timestamp);
 
-	std::shared_ptr<GravityDataProduct> gdp(new GravityDataProduct("RegistrationRequest"));
-	gdp->setData(registerRequest);
-	registrationUpdates.push(gdp);
+    std::shared_ptr<GravityDataProduct> gdp(new GravityDataProduct("RegistrationRequest"));
+    gdp->setData(registerRequest);
+    registrationUpdates.push(gdp);
 }
 
 // Utility to create a UnregistrationRequest message and add it to the queue to be submitted
-void ServiceDirectorySynchronizer::createUnregistrationRequest(string productID, string url, string domain, ProductChange_RegistrationType type, uint32_t regTime)
+void ServiceDirectorySynchronizer::createUnregistrationRequest(string productID, string url, string domain,
+                                                               ProductChange_RegistrationType type, uint32_t regTime)
 {
-	ServiceDirectoryUnregistrationPB_RegistrationType rtype = type == ProductChange_RegistrationType_DATA ?
-				ServiceDirectoryUnregistrationPB_RegistrationType_DATA : ServiceDirectoryUnregistrationPB_RegistrationType_SERVICE;
+    ServiceDirectoryUnregistrationPB_RegistrationType rtype =
+        type == ProductChange_RegistrationType_DATA ? ServiceDirectoryUnregistrationPB_RegistrationType_DATA
+                                                    : ServiceDirectoryUnregistrationPB_RegistrationType_SERVICE;
 
-	ServiceDirectoryUnregistrationPB unregisterRequest;
-	unregisterRequest.set_id(productID);
-	unregisterRequest.set_url(url);
-	unregisterRequest.set_type(rtype);	
-	unregisterRequest.set_domain(domain);
-	unregisterRequest.set_registration_time(regTime);
+    ServiceDirectoryUnregistrationPB unregisterRequest;
+    unregisterRequest.set_id(productID);
+    unregisterRequest.set_url(url);
+    unregisterRequest.set_type(rtype);
+    unregisterRequest.set_domain(domain);
+    unregisterRequest.set_registration_time(regTime);
 
-	std::shared_ptr<GravityDataProduct> gdp(new GravityDataProduct("UnregistrationRequest"));
-	gdp->setData(unregisterRequest);
-	registrationUpdates.push(gdp);
+    std::shared_ptr<GravityDataProduct> gdp(new GravityDataProduct("UnregistrationRequest"));
+    gdp->setData(unregisterRequest);
+    registrationUpdates.push(gdp);
 }
 
 // test function
@@ -584,4 +607,4 @@ void ServiceDirectorySynchronizer::printMap(ServiceDirectoryMapPB providerMap)
     }
 }
 
-}/*namespace gravity*/
+} /*namespace gravity*/

--- a/src/components/cpp/ServiceDirectory/ServiceDirectorySynchronizer.h
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectorySynchronizer.h
@@ -39,50 +39,52 @@
 #include "protobuf/ServiceDirectoryUnregistrationPB.pb.h"
 #include "spdlog/spdlog.h"
 
-namespace gravity{
+namespace gravity
+{
 
 typedef struct SyncInitDetails
 {
-	void* context;
-	std::string url;
+    void* context;
+    std::string url;
 } SyncInitDetails;
 
 typedef struct SyncDomainDetails
 {
-	std::string domain;
-	std::string ipAddress;
-	void* socket;
-	bool initialized;
-	ServiceDirectoryMapPB providerMap;
-	uint32_t registrationTime;
+    std::string domain;
+    std::string ipAddress;
+    void* socket;
+    bool initialized;
+    ServiceDirectoryMapPB providerMap;
+    uint32_t registrationTime;
 } SyncDomainDetails;
 
 class ServiceDirectorySynchronizer
 {
 private:
-	void* context;
-	std::string ownURL;
-	void* commandSocket;
-	void* requestSocket;
-	std::vector<zmq_pollitem_t> pollItems;
-	std::map<std::string, std::shared_ptr<SyncDomainDetails> > syncMap; // key: domain name
-	std::map<void*, std::shared_ptr<SyncDomainDetails> > socketToDomainDetailsMap;
-	std::queue<std::shared_ptr<GravityDataProduct> > registrationUpdates;
-	bool pendingResponse;
+    void* context;
+    std::string ownURL;
+    void* commandSocket;
+    void* requestSocket;
+    std::vector<zmq_pollitem_t> pollItems;
+    std::map<std::string, std::shared_ptr<SyncDomainDetails> > syncMap;  // key: domain name
+    std::map<void*, std::shared_ptr<SyncDomainDetails> > socketToDomainDetailsMap;
+    std::queue<std::shared_ptr<GravityDataProduct> > registrationUpdates;
+    bool pendingResponse;
 
-	void printMap(ServiceDirectoryMapPB providerMap);
+    void printMap(ServiceDirectoryMapPB providerMap);
 
-	void createRegistrationRequest(std::string productID, std::string url, std::string componentID, std::string domain, 
-									ProductChange_RegistrationType type, uint64_t timestamp);
-	void createUnregistrationRequest(std::string productID, std::string url, std::string domain, ProductChange_RegistrationType type, uint32_t regTime);
-	
-	std::shared_ptr<spdlog::logger> logger;
+    void createRegistrationRequest(std::string productID, std::string url, std::string componentID, std::string domain,
+                                   ProductChange_RegistrationType type, uint64_t timestamp);
+    void createUnregistrationRequest(std::string productID, std::string url, std::string domain,
+                                     ProductChange_RegistrationType type, uint32_t regTime);
+
+    std::shared_ptr<spdlog::logger> logger;
 
 public:
-	ServiceDirectorySynchronizer(void* context, std::string url);
-	virtual ~ServiceDirectorySynchronizer();
+    ServiceDirectorySynchronizer(void* context, std::string url);
+    virtual ~ServiceDirectorySynchronizer();
 
-	void start();
+    void start();
 };
-}/* namespace gravity */
-#endif //SERVICEDIRECTORYSYNCHRONIZER__H__
+} /* namespace gravity */
+#endif  //SERVICEDIRECTORYSYNCHRONIZER__H__

--- a/src/components/cpp/ServiceDirectory/ServiceDirectoryUDPBroadcaster.cpp
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectoryUDPBroadcaster.cpp
@@ -38,195 +38,192 @@ using namespace std;
 
 namespace gravity
 {
-ServiceDirectoryUDPBroadcaster::ServiceDirectoryUDPBroadcaster(void* context)
+ServiceDirectoryUDPBroadcaster::ServiceDirectoryUDPBroadcaster(void *context)
 {
-	this->context = context;
-	logger = spdlog::get("GravityLogger");
+    this->context = context;
+    logger = spdlog::get("GravityLogger");
 }
 
 ServiceDirectoryUDPBroadcaster::~ServiceDirectoryUDPBroadcaster()
 {
-	//close sockets
-	#ifdef _WIN32
-	closesocket(broadcastSocket);
-	#else
-	close(broadcastSocket);
-	#endif
-	zmq_close(sdSocket);
+//close sockets
+#ifdef _WIN32
+    closesocket(broadcastSocket);
+#else
+    close(broadcastSocket);
+#endif
+    zmq_close(sdSocket);
 };
-
 
 void ServiceDirectoryUDPBroadcaster::start()
 {
     starttime = time(NULL);
-	sdSocket = zmq_socket(context,ZMQ_REP);
-	zmq_connect(sdSocket,"inproc://service_directory_udp_broadcast");
-	zmq_setsockopt(sdSocket,ZMQ_SUBSCRIBE,NULL,0);
+    sdSocket = zmq_socket(context, ZMQ_REP);
+    zmq_connect(sdSocket, "inproc://service_directory_udp_broadcast");
+    zmq_setsockopt(sdSocket, ZMQ_SUBSCRIBE, NULL, 0);
 
-	// Poll the gravity node
-	zmq_pollitem_t pollItem;
-	pollItem.socket = sdSocket;
-	pollItem.events = ZMQ_POLLIN;
-	pollItem.fd = 0;
-	pollItem.revents = 0;
+    // Poll the gravity node
+    zmq_pollitem_t pollItem;
+    pollItem.socket = sdSocket;
+    pollItem.events = ZMQ_POLLIN;
+    pollItem.fd = 0;
+    pollItem.revents = 0;
 
-	int block = -1;
+    int block = -1;
 
+    ServiceDirectoryBroadcastPB broadcastMessage;
+    string broadcastString;
 
-	ServiceDirectoryBroadcastPB broadcastMessage;
-	string broadcastString;
+    bool broadcast = false;
+    while (true)
+    {
+        // Start polling socket(s), blocking while we wait
+        int rc = zmq_poll(&pollItem, 1, block);  // 0 --> return immediately, -1 --> blocks
+        if (rc == -1)
+        {
+            logger->debug("Interrupted, exiting (rc = {})", rc);
+            // Interrupted
+            break;
+        }
 
-	bool broadcast = false;
-	while(true)
-	{
-		// Start polling socket(s), blocking while we wait
-		int rc = zmq_poll(&pollItem, 1, block); // 0 --> return immediately, -1 --> blocks
-		if (rc == -1)
-		{
-			logger->debug("Interrupted, exiting (rc = {})", rc);
-			// Interrupted
-			break;
-		}
+        if (pollItem.revents & ZMQ_POLLIN)
+        {
+            string command = readStringMessage(sdSocket);
 
-		if (pollItem.revents & ZMQ_POLLIN)
-		{
-			string command = readStringMessage(sdSocket);
+            if (command == "broadcast")
+            {
+                logger->info("Initializing Service Directory Broadcast");
+                block = 0;
+                //read broadcast parameters
+                receiveBroadcastParameters();
+                broadcastMessage.set_id("");
+                broadcastMessage.set_domain(domainName);
+                broadcastMessage.set_url(url);
+                broadcastMessage.set_rate(broadcastRate);
+                broadcastMessage.set_starttime(starttime);
+                broadcastMessage.SerializeToString(&broadcastString);
+                rc = initBroadcastSocket();
+                if (rc < 0)
+                {
+                    logger->critical("Broadcast: Socket Init Error: {}", broadcastSocket);
+                }
+                broadcast = true;
+            }
+            else if (command == "stop")
+            {
+#ifdef _WIN32
+                closesocket(broadcastSocket);
+#else
+                close(broadcastSocket);
+#endif
+                block = -1;
+                broadcast = false;
+            }
+            else if (command == "kill")
+            {
+                break;
+            }
+        }
+        if (broadcast)
+        {
+            //broadcast
+            int bytesSent = sendto(broadcastSocket, broadcastString.c_str(), broadcastMessage.ByteSize(), 0,
+                                   (sockaddr *)&destAddress, sizeof(struct sockaddr_in));
+            if (bytesSent < 0)
+            {
+                //exit
+                logger->critical("Broadcast: sendto() Error");
+                break;
+            }
+#ifdef _WIN32
+            Sleep(broadcastRate * 1000);
+#else
+            usleep(broadcastRate * 1000000);  //Maybe replace this guy with clock_nanosleep???
+#endif
+        }
+    }
 
-			if (command == "broadcast")
-			{
-				logger->info("Initializing Service Directory Broadcast");
-				block = 0;
-				//read broadcast parameters
-				receiveBroadcastParameters();
-				broadcastMessage.set_id("");
-				broadcastMessage.set_domain(domainName);
-				broadcastMessage.set_url(url);
-				broadcastMessage.set_rate(broadcastRate);
-				broadcastMessage.set_starttime(starttime);
-				broadcastMessage.SerializeToString(&broadcastString);
-				rc = initBroadcastSocket();
-				if (rc < 0)
-				{
-					logger->critical("Broadcast: Socket Init Error: {}", broadcastSocket);
-				}
-				broadcast = true;
-			}
-			else if (command == "stop")
-			{
-				#ifdef _WIN32
-				closesocket(broadcastSocket);
-				#else
-				close(broadcastSocket);
-				#endif
-				block = -1;
-				broadcast = false;
-			}
-			else if(command =="kill")
-			{
-				break;
-			}
-		}
-		if(broadcast)
-		{
-			//broadcast
-			int bytesSent = sendto(broadcastSocket,broadcastString.c_str(),broadcastMessage.ByteSize(),0,(sockaddr*)&destAddress,sizeof(struct sockaddr_in));
-			if (bytesSent < 0)
-			{
-				//exit
-				logger->critical("Broadcast: sendto() Error");
-				break;
-			}
-			#ifdef _WIN32
-			Sleep(broadcastRate*1000);
-			#else
-			usleep(broadcastRate*1000000); //Maybe replace this guy with clock_nanosleep???
-			#endif
-		}
-	}
-
-	//close sockets
-	#ifdef _WIN32
-	closesocket(broadcastSocket);
-	#else
-	close(broadcastSocket);
-	#endif
-	zmq_close(sdSocket);
-
+//close sockets
+#ifdef _WIN32
+    closesocket(broadcastSocket);
+#else
+    close(broadcastSocket);
+#endif
+    zmq_close(sdSocket);
 }
 
 void ServiceDirectoryUDPBroadcaster::receiveBroadcastParameters()
 {
-	domainName = readStringMessage(sdSocket);
-	url = readStringMessage(sdSocket);
-	broadcastIP = readStringMessage(sdSocket);
-	logger->info("Broadcast params: domain '{}' url '{}' ip: '{}'", domainName, url, broadcastIP);
+    domainName = readStringMessage(sdSocket);
+    url = readStringMessage(sdSocket);
+    broadcastIP = readStringMessage(sdSocket);
+    logger->info("Broadcast params: domain '{}' url '{}' ip: '{}'", domainName, url, broadcastIP);
 
-	//receive port
-	zmq_msg_t msg;
-	zmq_msg_init(&msg);
-	zmq_recvmsg(sdSocket,&msg,ZMQ_DONTWAIT);
-	memcpy(&port,zmq_msg_data(&msg),sizeof(unsigned int));
-	zmq_msg_close(&msg);
+    //receive port
+    zmq_msg_t msg;
+    zmq_msg_init(&msg);
+    zmq_recvmsg(sdSocket, &msg, ZMQ_DONTWAIT);
+    memcpy(&port, zmq_msg_data(&msg), sizeof(unsigned int));
+    zmq_msg_close(&msg);
 
-	//receive broadcast rate
-	zmq_msg_t msg2;
-	zmq_msg_init(&msg2);
-	zmq_recvmsg(sdSocket,&msg2,ZMQ_DONTWAIT);
-	memcpy(&broadcastRate,zmq_msg_data(&msg2),sizeof(unsigned int));
-	zmq_msg_close(&msg2);
+    //receive broadcast rate
+    zmq_msg_t msg2;
+    zmq_msg_init(&msg2);
+    zmq_recvmsg(sdSocket, &msg2, ZMQ_DONTWAIT);
+    memcpy(&broadcastRate, zmq_msg_data(&msg2), sizeof(unsigned int));
+    zmq_msg_close(&msg2);
 
-	sendStringMessage(sdSocket,"ACK",ZMQ_DONTWAIT);
+    sendStringMessage(sdSocket, "ACK", ZMQ_DONTWAIT);
 
 #ifdef _WIN32
-	//if windows and broadcasting on loopback
-	if(url.find("127.0.0.1")!=std::string::npos)
-	{
-		logger->warn("Windows bug: Broadcasting Domain on loopback interface may block other broadcast messages");
-	}
+    //if windows and broadcasting on loopback
+    if (url.find("127.0.0.1") != std::string::npos)
+    {
+        logger->warn("Windows bug: Broadcasting Domain on loopback interface may block other broadcast messages");
+    }
 #endif
-
 }
 
 int ServiceDirectoryUDPBroadcaster::initBroadcastSocket()
 {
-	struct sockaddr_storage destStorage;
-	std::memset(&destStorage,0,sizeof(destStorage));
+    struct sockaddr_storage destStorage;
+    std::memset(&destStorage, 0, sizeof(destStorage));
 
-	struct sockaddr_in *destAddr = (struct sockaddr_in*) &destStorage;
-	destAddr->sin_family=AF_INET;
-	destAddr->sin_port=htons(port);
+    struct sockaddr_in *destAddr = (struct sockaddr_in *)&destStorage;
+    destAddr->sin_family = AF_INET;
+    destAddr->sin_port = htons(port);
 
-	string ip = broadcastIP;
-	if (ip.size() == 0)
-	{
-	    if(url.find("127.0.0.1")!=std::string::npos)
-	    {
-	        ip = "127.255.255.255";
-	    }
-	    else
-	    {
-	        ip = "255.255.255.255";
-	    }
-	}
-	logger->debug("Using broadcast IP {}", ip);
-	destAddr->sin_addr.s_addr = inet_addr(ip.c_str());
+    string ip = broadcastIP;
+    if (ip.size() == 0)
+    {
+        if (url.find("127.0.0.1") != std::string::npos)
+        {
+            ip = "127.255.255.255";
+        }
+        else
+        {
+            ip = "255.255.255.255";
+        }
+    }
+    logger->debug("Using broadcast IP {}", ip);
+    destAddr->sin_addr.s_addr = inet_addr(ip.c_str());
 
-	memcpy(&destAddress,destAddr,sizeof(struct sockaddr_in));
+    memcpy(&destAddress, destAddr, sizeof(struct sockaddr_in));
 
-	broadcastSocket = socket(destAddress.sin_family,SOCK_DGRAM,IPPROTO_UDP);
+    broadcastSocket = socket(destAddress.sin_family, SOCK_DGRAM, IPPROTO_UDP);
 
-	if(broadcastSocket < 0)
-	{
-		return -1;
-	}
+    if (broadcastSocket < 0)
+    {
+        return -1;
+    }
 
-	int broadcastPerm=1;
+    int broadcastPerm = 1;
 
-	if(setsockopt(broadcastSocket,SOL_SOCKET,SO_BROADCAST,(char *)&broadcastPerm,sizeof(broadcastPerm)) != 0)
-	{
-		return -1;
-	}
+    if (setsockopt(broadcastSocket, SOL_SOCKET, SO_BROADCAST, (char *)&broadcastPerm, sizeof(broadcastPerm)) != 0)
+    {
+        return -1;
+    }
 
-	return broadcastSocket;
+    return broadcastSocket;
 }
-}/*namespace gravity*/
+} /*namespace gravity*/

--- a/src/components/cpp/ServiceDirectory/ServiceDirectoryUDPBroadcaster.h
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectoryUDPBroadcaster.h
@@ -40,40 +40,38 @@
 #endif
 #include "spdlog/spdlog.h"
 
-namespace gravity{
-
+namespace gravity
+{
 
 class ServiceDirectoryUDPBroadcaster
 {
 private:
-	void* context;
-	std::string domainName;
-	std::string url;
-	std::string broadcastIP;
-	unsigned int port;
-	unsigned int broadcastRate;
-	int broadcastSocket;
-	struct sockaddr_in destAddress;
-	static bool loop;
-	void* sdSocket;
-	time_t starttime;
+    void* context;
+    std::string domainName;
+    std::string url;
+    std::string broadcastIP;
+    unsigned int port;
+    unsigned int broadcastRate;
+    int broadcastSocket;
+    struct sockaddr_in destAddress;
+    static bool loop;
+    void* sdSocket;
+    time_t starttime;
 
-	void receiveBroadcastParameters();
-	int initBroadcastSocket();
+    void receiveBroadcastParameters();
+    int initBroadcastSocket();
 
-	std::shared_ptr<spdlog::logger> logger;
+    std::shared_ptr<spdlog::logger> logger;
 
 public:
-	ServiceDirectoryUDPBroadcaster(void* context);
+    ServiceDirectoryUDPBroadcaster(void* context);
 
-	virtual ~ServiceDirectoryUDPBroadcaster();
+    virtual ~ServiceDirectoryUDPBroadcaster();
 
-	void start();
+    void start();
 
-	void setDomainName(std::string domain){domainName=domain;};
-	void setBroadcastRate(u_int rate){broadcastRate=rate;};
-
-
+    void setDomainName(std::string domain) { domainName = domain; };
+    void setBroadcastRate(u_int rate) { broadcastRate = rate; };
 };
-}/* namespace gravity */
-#endif //SERVICEDIRECTORYUDPBROADCASTER__H__
+} /* namespace gravity */
+#endif  //SERVICEDIRECTORYUDPBROADCASTER__H__

--- a/src/components/cpp/ServiceDirectory/ServiceDirectoryUDPReceiver.cpp
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectoryUDPReceiver.cpp
@@ -30,7 +30,7 @@
 #include <cstring>
 #include <iostream>
 #include <errno.h>
-#include<set>
+#include <set>
 #ifdef _WIN32
 #include <winSock2.h>
 #include <WS2tcpip.h>
@@ -47,371 +47,365 @@
 
 using namespace std;
 
-
 namespace gravity
 {
 
-map<string,unsigned int> receivedCountMap;
-map<string,unsigned int> broadcastRateMap;
-map<string,struct timeval> expectedMsgTimeMap;
+map<string, unsigned int> receivedCountMap;
+map<string, unsigned int> broadcastRateMap;
+map<string, struct timeval> expectedMsgTimeMap;
 map<string, int64_t> connectedDomainMap;
 
 ServiceDirectoryUDPReceiver::ServiceDirectoryUDPReceiver(void* context)
 {
-	this->context = context;
-	logger = spdlog::get("GravityLogger");
+    this->context = context;
+    logger = spdlog::get("GravityLogger");
 }
 
 ServiceDirectoryUDPReceiver::~ServiceDirectoryUDPReceiver()
 {
-	#ifdef _WIN32
-	closesocket(receiveSocket);
-	#else
-	close(receiveSocket);
-	#endif
-	zmq_close(sdSocket);
+#ifdef _WIN32
+    closesocket(receiveSocket);
+#else
+    close(receiveSocket);
+#endif
+    zmq_close(sdSocket);
 };
-
 
 void ServiceDirectoryUDPReceiver::start()
 {
+    sdSocket = zmq_socket(context, ZMQ_REP);
+    zmq_connect(sdSocket, "inproc://service_directory_udp_receive");
+    zmq_setsockopt(sdSocket, ZMQ_SUBSCRIBE, NULL, 0);
 
-	sdSocket = zmq_socket(context,ZMQ_REP);
-	zmq_connect(sdSocket,"inproc://service_directory_udp_receive");
-	zmq_setsockopt(sdSocket,ZMQ_SUBSCRIBE,NULL,0);
+    void* domainSocket = zmq_socket(context, ZMQ_PUB);
+    zmq_connect(domainSocket, "inproc://service_directory_domain_socket");
 
-	void* domainSocket = zmq_socket(context,ZMQ_PUB);
-	zmq_connect(domainSocket,"inproc://service_directory_domain_socket");
-	
+    // Poll the service directory node
+    zmq_pollitem_t pollItem;
+    pollItem.socket = sdSocket;
+    pollItem.events = ZMQ_POLLIN;
+    pollItem.fd = 0;
+    pollItem.revents = 0;
 
-	// Poll the service directory node
-	zmq_pollitem_t pollItem;
-	pollItem.socket = sdSocket;
-	pollItem.events = ZMQ_POLLIN;
-	pollItem.fd = 0;
-	pollItem.revents = 0;
+    bool waiting = true;
+    // Wait for command to start reciever
+    // Start polling socket(s), blocking while we wait
+    while (waiting)
+    {
+        int rc = zmq_poll(&pollItem, 1, -1);  // 0 --> return immediately, -1 --> blocks
+        if (rc == -1)
+        {
+            logger->critical("Interrupted, exiting (rc = {})", rc);
+            // Interrupted
+            return;
+        }
 
-	bool waiting = true;
-	// Wait for command to start reciever
-	// Start polling socket(s), blocking while we wait
-	while(waiting)
-	{
+        if (pollItem.revents & ZMQ_POLLIN)
+        {
+            string command = readStringMessage(sdSocket);
 
-		int rc = zmq_poll(&pollItem, 1, -1); // 0 --> return immediately, -1 --> blocks
-		if (rc == -1)
-		{
-			logger->critical("Interrupted, exiting (rc = {})", rc);
-			// Interrupted
-			return;
-		}
+            if (command == "receive")
+            {
+                receiveReceiverParameters();
+                if (initReceiveSocket() < 0)
+                {
+                    logger->critical("UDP Receiver init error");
+                }
+                waiting = false;
+            }
+        }
+    }
 
-		if (pollItem.revents & ZMQ_POLLIN)
-		{
-			string command = readStringMessage(sdSocket);
+    char recvString[MAXRECVSTRING + 1]; /* Buffer for received string */
+    int recvStringLen;                  /* Length of received string */
+    ServiceDirectoryBroadcastPB broadcastPB;
 
-			if (command == "receive")
-			{
-				receiveReceiverParameters();
-				if(initReceiveSocket()<0)
-				{
-					logger->critical("UDP Receiver init error");
-				}
-				waiting = false;
-			}
-		}
-	}
+    struct timeval currTime;
+    struct timeval timeout;
+    timeout.tv_sec = 0;
+    timeout.tv_usec = 0;
 
-	char recvString[MAXRECVSTRING+1]; /* Buffer for received string */
-    int recvStringLen;                /* Length of received string */
-	ServiceDirectoryBroadcastPB broadcastPB;
-
-	struct timeval currTime;
-	struct timeval timeout;
-	timeout.tv_sec=0;
-	timeout.tv_usec=0;
-
-	//set socket to block forever initially
+    //set socket to block forever initially
 #ifdef _WIN32
-	unsigned int timeout_int = timevalToMilliSeconds(&timeout);
-	setsockopt(receiveSocket,SOL_SOCKET,SO_RCVTIMEO,(const char*)&timeout_int,sizeof(unsigned int));
+    unsigned int timeout_int = timevalToMilliSeconds(&timeout);
+    setsockopt(receiveSocket, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout_int, sizeof(unsigned int));
 #else
-	//set socket to block forever initially
-	setsockopt(receiveSocket,SOL_SOCKET,SO_RCVTIMEO,(char*)&timeout,sizeof(struct timeval));
+    //set socket to block forever initially
+    setsockopt(receiveSocket, SOL_SOCKET, SO_RCVTIMEO, (char*)&timeout, sizeof(struct timeval));
 #endif
 
-	while(true)
-	{
-		memset(recvString,0,MAXRECVSTRING+1);
+    while (true)
+    {
+        memset(recvString, 0, MAXRECVSTRING + 1);
 
-		/* Receive a broadcast message or timeout */
-	    recvStringLen = recvfrom(receiveSocket, recvString, MAXRECVSTRING, 0, NULL, 0);
-		//get the current time
-		gettimeofday(&currTime,NULL);
-	
-		if(recvStringLen == 0)
-		{
-			// Don't know why this would happen, just ignore this case.
-			continue;
-		}
+        /* Receive a broadcast message or timeout */
+        recvStringLen = recvfrom(receiveSocket, recvString, MAXRECVSTRING, 0, NULL, 0);
+        //get the current time
+        gettimeofday(&currTime, NULL);
 
-		//check for socket error
-		else if(recvStringLen < 0)
-		{
-			if (!(errno == EAGAIN || errno == EWOULDBLOCK))
-			{
-				logger->critical("recv() error, errno: {}", errno);
-				break;
-			}
-		}
-		else //we received a message
-		{
-			broadcastPB.ParseFromArray(recvString,recvStringLen);
-			//printByteBuffer(recvString,recvStringLen);
+        if (recvStringLen == 0)
+        {
+            // Don't know why this would happen, just ignore this case.
+            continue;
+        }
 
-			//Log a warning if we received the same domain from a different url
-			if((ourDomain.compare(broadcastPB.domain())==0) && ourUrl.compare(broadcastPB.url())!=0)
-			{
-				logger->warn("Duplicate Domain: {}, {}",ourDomain,broadcastPB.url());
-			}
-			
-			//ignore messages from our domain name or invalid domains
-			if((ourDomain.compare(broadcastPB.domain())!=0) && isValidDomain(broadcastPB.domain()))
-			{
-				//logger->trace("Received UDP Broadcast Message for Domain: {}",broadcastPB.domain());
+        //check for socket error
+        else if (recvStringLen < 0)
+        {
+            if (!(errno == EAGAIN || errno == EWOULDBLOCK))
+            {
+                logger->critical("recv() error, errno: {}", errno);
+                break;
+            }
+        }
+        else  //we received a message
+        {
+            broadcastPB.ParseFromArray(recvString, recvStringLen);
+            //printByteBuffer(recvString,recvStringLen);
 
-				//if first time seeing domain
-				if(receivedCountMap.find(broadcastPB.domain())==receivedCountMap.end())
-				{
-					receivedCountMap[broadcastPB.domain()]=1;
-					broadcastRateMap[broadcastPB.domain()]=broadcastPB.rate();
-				}
-				else
-				{
-					unsigned int count = receivedCountMap.at(broadcastPB.domain());
-					count++;
+            //Log a warning if we received the same domain from a different url
+            if ((ourDomain.compare(broadcastPB.domain()) == 0) && ourUrl.compare(broadcastPB.url()) != 0)
+            {
+                logger->warn("Duplicate Domain: {}, {}", ourDomain, broadcastPB.url());
+            }
 
-					//if enough broadcasts have been seen
-					if(count >= (unsigned int) MAX_RECEIVE_COUNT)
-					{
-						//cap the count
-						count = MAX_RECEIVE_COUNT;
+            //ignore messages from our domain name or invalid domains
+            if ((ourDomain.compare(broadcastPB.domain()) != 0) && isValidDomain(broadcastPB.domain()))
+            {
+                //logger->trace("Received UDP Broadcast Message for Domain: {}",broadcastPB.domain());
 
-						//check whether we have already connected with this domain
-						if (connectedDomainMap.find(broadcastPB.domain()) == connectedDomainMap.end())
-						{
-							// add domain to the connected list
-							connectedDomainMap[broadcastPB.domain()] = broadcastPB.starttime();
-							
-							// Inform SD of new connection
-							logger->trace("Sending domain Add command to synchronizer thread");
-							sendStringMessage(domainSocket,"Add",ZMQ_SNDMORE);
-							sendStringMessage(domainSocket,broadcastPB.domain(),ZMQ_SNDMORE);
-							sendStringMessage(domainSocket,broadcastPB.url(),ZMQ_DONTWAIT);
-						}
-						else if (connectedDomainMap[broadcastPB.domain()] != broadcastPB.starttime())
-						{
-							// update domain time
-							connectedDomainMap[broadcastPB.domain()] = broadcastPB.starttime();
+                //if first time seeing domain
+                if (receivedCountMap.find(broadcastPB.domain()) == receivedCountMap.end())
+                {
+                    receivedCountMap[broadcastPB.domain()] = 1;
+                    broadcastRateMap[broadcastPB.domain()] = broadcastPB.rate();
+                }
+                else
+                {
+                    unsigned int count = receivedCountMap.at(broadcastPB.domain());
+                    count++;
 
-							// Inform SD of updated connection
-							logger->trace("Sending domain Update command to synchronizer thread");
-							sendStringMessage(domainSocket, "Update", ZMQ_SNDMORE);
-							sendStringMessage(domainSocket, broadcastPB.domain(), ZMQ_SNDMORE);
-							sendStringMessage(domainSocket, broadcastPB.url(), ZMQ_DONTWAIT);
-						}
-					}
-					//update count for domain
-					receivedCountMap[broadcastPB.domain()]=count; 
-				}
-				//insert new expected time for domain
-				expectedMsgTimeMap[broadcastPB.domain()]=addTime(&currTime,broadcastPB.rate());
-			}
-		}
+                    //if enough broadcasts have been seen
+                    if (count >= (unsigned int)MAX_RECEIVE_COUNT)
+                    {
+                        //cap the count
+                        count = MAX_RECEIVE_COUNT;
 
-		timeout.tv_sec=0;
-		timeout.tv_usec=0;
-		
-		set<string>removeSet;
-		for(map<string,struct timeval>::iterator iter=expectedMsgTimeMap.begin();iter != expectedMsgTimeMap.end();++iter)
-		{
-			bool removed = false;
-			//check if we missed a message
-			if(timevalcmp(&(iter->second),&currTime) <= 0)
-			{
-				int count = receivedCountMap.at(iter->first);
-				count--;
-				//if we have missed enough messages
-				if(count <=0)
-				{
-					//check whether we have already connected with this domain
-					if (connectedDomainMap.find(iter->first) != connectedDomainMap.end())
-					{
-						// inform Service Directory to remove domain
-						sendStringMessage(domainSocket,"Remove",ZMQ_SNDMORE);
-						sendStringMessage(domainSocket,iter->first,ZMQ_DONTWAIT);
-						connectedDomainMap.erase(iter->first);
-					}
+                        //check whether we have already connected with this domain
+                        if (connectedDomainMap.find(broadcastPB.domain()) == connectedDomainMap.end())
+                        {
+                            // add domain to the connected list
+                            connectedDomainMap[broadcastPB.domain()] = broadcastPB.starttime();
 
-					// remove domain from data sets
-					receivedCountMap.erase(iter->first);
-					broadcastRateMap.erase(iter->first);
-					removeSet.insert(iter->first);
-					removed = true;
-				}
-				else
-				{
-					//set new expected message time for missed doamin
-					expectedMsgTimeMap[iter->first]=addTime(&(iter->second),broadcastRateMap.at(iter->first));
-					receivedCountMap[iter->first]=count;
-				}
-			}
+                            // Inform SD of new connection
+                            logger->trace("Sending domain Add command to synchronizer thread");
+                            sendStringMessage(domainSocket, "Add", ZMQ_SNDMORE);
+                            sendStringMessage(domainSocket, broadcastPB.domain(), ZMQ_SNDMORE);
+                            sendStringMessage(domainSocket, broadcastPB.url(), ZMQ_DONTWAIT);
+                        }
+                        else if (connectedDomainMap[broadcastPB.domain()] != broadcastPB.starttime())
+                        {
+                            // update domain time
+                            connectedDomainMap[broadcastPB.domain()] = broadcastPB.starttime();
 
-			if(!removed)
-			{
-				struct timeval* nextTime = &(iter->second);
+                            // Inform SD of updated connection
+                            logger->trace("Sending domain Update command to synchronizer thread");
+                            sendStringMessage(domainSocket, "Update", ZMQ_SNDMORE);
+                            sendStringMessage(domainSocket, broadcastPB.domain(), ZMQ_SNDMORE);
+                            sendStringMessage(domainSocket, broadcastPB.url(), ZMQ_DONTWAIT);
+                        }
+                    }
+                    //update count for domain
+                    receivedCountMap[broadcastPB.domain()] = count;
+                }
+                //insert new expected time for domain
+                expectedMsgTimeMap[broadcastPB.domain()] = addTime(&currTime, broadcastPB.rate());
+            }
+        }
 
-				struct timeval timeToWait = subtractTime(nextTime,&currTime);
-				struct timeval zeroTime;
-				zeroTime.tv_sec=0;
-				zeroTime.tv_usec=0;
-				//if the time to wait is less then the current timeout
-				if((timevalcmp(&zeroTime,&timeout)==0) || (timevalcmp(&timeToWait,&timeout) < 0))
-				{
-					timeout=timeToWait;
-				}
-			}
-		}
+        timeout.tv_sec = 0;
+        timeout.tv_usec = 0;
 
-		//remove any leftover domains from the expected message time map
-		for(set<string>::iterator iter = removeSet.begin(); iter != removeSet.end(); ++iter)
-		{
-			expectedMsgTimeMap.erase(*iter);
-		}
+        set<string> removeSet;
+        for (map<string, struct timeval>::iterator iter = expectedMsgTimeMap.begin(); iter != expectedMsgTimeMap.end();
+             ++iter)
+        {
+            bool removed = false;
+            //check if we missed a message
+            if (timevalcmp(&(iter->second), &currTime) <= 0)
+            {
+                int count = receivedCountMap.at(iter->first);
+                count--;
+                //if we have missed enough messages
+                if (count <= 0)
+                {
+                    //check whether we have already connected with this domain
+                    if (connectedDomainMap.find(iter->first) != connectedDomainMap.end())
+                    {
+                        // inform Service Directory to remove domain
+                        sendStringMessage(domainSocket, "Remove", ZMQ_SNDMORE);
+                        sendStringMessage(domainSocket, iter->first, ZMQ_DONTWAIT);
+                        connectedDomainMap.erase(iter->first);
+                    }
+
+                    // remove domain from data sets
+                    receivedCountMap.erase(iter->first);
+                    broadcastRateMap.erase(iter->first);
+                    removeSet.insert(iter->first);
+                    removed = true;
+                }
+                else
+                {
+                    //set new expected message time for missed doamin
+                    expectedMsgTimeMap[iter->first] = addTime(&(iter->second), broadcastRateMap.at(iter->first));
+                    receivedCountMap[iter->first] = count;
+                }
+            }
+
+            if (!removed)
+            {
+                struct timeval* nextTime = &(iter->second);
+
+                struct timeval timeToWait = subtractTime(nextTime, &currTime);
+                struct timeval zeroTime;
+                zeroTime.tv_sec = 0;
+                zeroTime.tv_usec = 0;
+                //if the time to wait is less then the current timeout
+                if ((timevalcmp(&zeroTime, &timeout) == 0) || (timevalcmp(&timeToWait, &timeout) < 0))
+                {
+                    timeout = timeToWait;
+                }
+            }
+        }
+
+        //remove any leftover domains from the expected message time map
+        for (set<string>::iterator iter = removeSet.begin(); iter != removeSet.end(); ++iter)
+        {
+            expectedMsgTimeMap.erase(*iter);
+        }
 
 #ifdef _WIN32
-		//select(receiveSocket,&fds,NULL,NULL,&timeout);
-		timeout_int = timevalToMilliSeconds(&timeout);
-		setsockopt(receiveSocket,SOL_SOCKET,SO_RCVTIMEO,(const char*)&timeout_int,sizeof(unsigned int));
+        //select(receiveSocket,&fds,NULL,NULL,&timeout);
+        timeout_int = timevalToMilliSeconds(&timeout);
+        setsockopt(receiveSocket, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout_int, sizeof(unsigned int));
 #else
-		//set socket to block until the timeout
-		setsockopt(receiveSocket,SOL_SOCKET,SO_RCVTIMEO,(char*)&timeout,sizeof(struct timeval));
+        //set socket to block until the timeout
+        setsockopt(receiveSocket, SOL_SOCKET, SO_RCVTIMEO, (char*)&timeout, sizeof(struct timeval));
 #endif
-	}
+    }
 
-	#ifdef _WIN32
-	closesocket(receiveSocket);
-	#else
-	close(receiveSocket);
-	#endif
-	zmq_close(sdSocket);
+#ifdef _WIN32
+    closesocket(receiveSocket);
+#else
+    close(receiveSocket);
+#endif
+    zmq_close(sdSocket);
 }
 
 void ServiceDirectoryUDPReceiver::receiveReceiverParameters()
 {
-	ourDomain = readStringMessage(sdSocket);
-	ourUrl = readStringMessage(sdSocket);
+    ourDomain = readStringMessage(sdSocket);
+    ourUrl = readStringMessage(sdSocket);
 
-	//receive port
-	zmq_msg_t msg;
-	zmq_msg_init(&msg);
-	zmq_recvmsg(sdSocket,&msg,ZMQ_DONTWAIT);
-	std::memcpy(&port,zmq_msg_data(&msg),sizeof(unsigned int));
-	zmq_msg_close(&msg);
+    //receive port
+    zmq_msg_t msg;
+    zmq_msg_init(&msg);
+    zmq_recvmsg(sdSocket, &msg, ZMQ_DONTWAIT);
+    std::memcpy(&port, zmq_msg_data(&msg), sizeof(unsigned int));
+    zmq_msg_close(&msg);
 
-	//receive number of valid domains
-	unsigned int numDomains = 0;
-	zmq_msg_t msg2;
-	zmq_msg_init(&msg2);
-	zmq_recvmsg(sdSocket,&msg2,ZMQ_DONTWAIT);
-	std::memcpy(&numDomains,zmq_msg_data(&msg2),sizeof(unsigned int));
-	zmq_msg_close(&msg2);
+    //receive number of valid domains
+    unsigned int numDomains = 0;
+    zmq_msg_t msg2;
+    zmq_msg_init(&msg2);
+    zmq_recvmsg(sdSocket, &msg2, ZMQ_DONTWAIT);
+    std::memcpy(&numDomains, zmq_msg_data(&msg2), sizeof(unsigned int));
+    zmq_msg_close(&msg2);
 
-	//recieve csv list of domains
-	zmq_msg_t msg3;
-	zmq_msg_init(&msg3);
-	zmq_recvmsg(sdSocket,&msg3,ZMQ_DONTWAIT);
-	int size = zmq_msg_size(&msg3);
-	char* domains = (char*) malloc(size+1);
-	std::memcpy(domains,zmq_msg_data(&msg3),size);
-	domains[size]=0;
-	string domainsString;
-	domainsString.assign(domains);
-	std::free(domains);
+    //recieve csv list of domains
+    zmq_msg_t msg3;
+    zmq_msg_init(&msg3);
+    zmq_recvmsg(sdSocket, &msg3, ZMQ_DONTWAIT);
+    int size = zmq_msg_size(&msg3);
+    char* domains = (char*)malloc(size + 1);
+    std::memcpy(domains, zmq_msg_data(&msg3), size);
+    domains[size] = 0;
+    string domainsString;
+    domainsString.assign(domains);
+    std::free(domains);
 
-	parseValidDomains(domainsString,numDomains);
+    parseValidDomains(domainsString, numDomains);
 
-	sendStringMessage(sdSocket,"ACK",ZMQ_DONTWAIT);
-
+    sendStringMessage(sdSocket, "ACK", ZMQ_DONTWAIT);
 }
 
 int ServiceDirectoryUDPReceiver::initReceiveSocket()
-{                     
-	/* Socket */
+{
+    /* Socket */
     struct sockaddr_in broadcastAddr; /* Broadcast Address */
 
     /* Create a best-effort datagram socket using UDP */
     if ((receiveSocket = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0)
     {
-		logger->critical("Receiver: socket() failed");
-		return receiveSocket;
+        logger->critical("Receiver: socket() failed");
+        return receiveSocket;
     }
 
-	//set socket to be re-usable. Must be set for all other listeners for this port
-	int one = 1;
-	setsockopt(receiveSocket,SOL_SOCKET,SO_REUSEADDR,(const char*)&one,sizeof(one));
+    //set socket to be re-usable. Must be set for all other listeners for this port
+    int one = 1;
+    setsockopt(receiveSocket, SOL_SOCKET, SO_REUSEADDR, (const char*)&one, sizeof(one));
 
     /* Construct bind structure */
-    memset(&broadcastAddr, 0, sizeof(broadcastAddr));   /* Zero out structure */
-    broadcastAddr.sin_family = AF_INET;                 /* Internet address family */
-    broadcastAddr.sin_addr.s_addr = htonl(INADDR_ANY);  /* Any incoming interface */
-    broadcastAddr.sin_port = htons(port);      /* Broadcast port */                                                                                                                                                     
+    memset(&broadcastAddr, 0, sizeof(broadcastAddr));  /* Zero out structure */
+    broadcastAddr.sin_family = AF_INET;                /* Internet address family */
+    broadcastAddr.sin_addr.s_addr = htonl(INADDR_ANY); /* Any incoming interface */
+    broadcastAddr.sin_port = htons(port);              /* Broadcast port */
 
     /* Bind to the broadcast port */
 #ifdef _WIN32
-	int rc = bind((SOCKET)receiveSocket, (const struct sockaddr *) &broadcastAddr, (int)sizeof(broadcastAddr));
+    int rc = bind((SOCKET)receiveSocket, (const struct sockaddr*)&broadcastAddr, (int)sizeof(broadcastAddr));
 #else
-	int rc = bind(receiveSocket, (struct sockaddr *) &broadcastAddr, sizeof(broadcastAddr));
+    int rc = bind(receiveSocket, (struct sockaddr*)&broadcastAddr, sizeof(broadcastAddr));
 #endif
-	if (rc < 0)
+    if (rc < 0)
     {
-		logger->critical("Receiver: bind() failed");
-		return rc;
+        logger->critical("Receiver: bind() failed");
+        return rc;
     }
 
-	return receiveSocket;
+    return receiveSocket;
 }
 
-
-void ServiceDirectoryUDPReceiver::parseValidDomains(string domainString,unsigned int numDomains)
+void ServiceDirectoryUDPReceiver::parseValidDomains(string domainString, unsigned int numDomains)
 {
-	int start=0;
-	unsigned int end = domainString.find(",",start);
+    int start = 0;
+    unsigned int end = domainString.find(",", start);
 
-	for(unsigned int i = 0; i < numDomains; i++)
-	{
-		if(end == string::npos)
-		{
-			end = domainString.length();
-		}
-		string sub = domainString.substr(start,end-start);
-		validDomains.push_back(sub);
+    for (unsigned int i = 0; i < numDomains; i++)
+    {
+        if (end == string::npos)
+        {
+            end = domainString.length();
+        }
+        string sub = domainString.substr(start, end - start);
+        validDomains.push_back(sub);
 
-		start=end+1;
-		end = domainString.find(",",start);
-	}
+        start = end + 1;
+        end = domainString.find(",", start);
+    }
 }
 
 bool ServiceDirectoryUDPReceiver::isValidDomain(string domain)
 {
-	for(vector<string>::iterator iter = validDomains.begin();iter!=validDomains.end();++iter)
-	{
-		if((domain.compare(*iter)==0)||((*iter).compare("*")==0))
-		{
-			return true;
-		}
-	}
+    for (vector<string>::iterator iter = validDomains.begin(); iter != validDomains.end(); ++iter)
+    {
+        if ((domain.compare(*iter) == 0) || ((*iter).compare("*") == 0))
+        {
+            return true;
+        }
+    }
 
-	return false;
+    return false;
 }
 
-}/*namespace gravity*/
+} /*namespace gravity*/

--- a/src/components/cpp/ServiceDirectory/ServiceDirectoryUDPReceiver.h
+++ b/src/components/cpp/ServiceDirectory/ServiceDirectoryUDPReceiver.h
@@ -37,31 +37,30 @@ namespace gravity
 class ServiceDirectoryUDPReceiver
 {
 private:
-	static const int MAX_RECEIVE_COUNT = 3;
+    static const int MAX_RECEIVE_COUNT = 3;
 
-	void* context;
-	void* sdSocket;
-	std::string ourDomain;
-	std::string ourUrl;
-	unsigned int port;
-	int receiveSocket;
+    void* context;
+    void* sdSocket;
+    std::string ourDomain;
+    std::string ourUrl;
+    unsigned int port;
+    int receiveSocket;
 
-	std::vector<std::string> validDomains;
+    std::vector<std::string> validDomains;
 
-	void receiveReceiverParameters();
-	int initReceiveSocket();
-	void parseValidDomains(std::string domainString,unsigned int num);
-	bool isValidDomain(std::string domain);
+    void receiveReceiverParameters();
+    int initReceiveSocket();
+    void parseValidDomains(std::string domainString, unsigned int num);
+    bool isValidDomain(std::string domain);
 
-	std::shared_ptr<spdlog::logger> logger;
+    std::shared_ptr<spdlog::logger> logger;
 
 public:
-	ServiceDirectoryUDPReceiver(void* context);
+    ServiceDirectoryUDPReceiver(void* context);
 
-	virtual ~ServiceDirectoryUDPReceiver();
+    virtual ~ServiceDirectoryUDPReceiver();
 
-	void start();
-
+    void start();
 };
 } /*namespace gravity*/
-#endif //SERVICEDIRECTORYUDPRECEIVER__H__
+#endif  //SERVICEDIRECTORYUDPRECEIVER__H__

--- a/src/keyvalue_parser/keyvalue_parser.h
+++ b/src/keyvalue_parser/keyvalue_parser.h
@@ -20,37 +20,38 @@
 #define __KEYVALUE_PARSER_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #ifdef WIN32
-#   ifdef LIBKEYVALUE_PARSER_EXPORTS
-#        define KEYVALUE_API __declspec(dllexport)
-#   else
-#        define KEYVALUE_API __declspec(dllimport)
-#   endif
+#ifdef LIBKEYVALUE_PARSER_EXPORTS
+#define KEYVALUE_API __declspec(dllexport)
 #else
-#   define KEYVALUE_API
+#define KEYVALUE_API __declspec(dllimport)
+#endif
+#else
+#define KEYVALUE_API
 #endif
 
-typedef void* keyvalue_handle_t;
-typedef void keyvalue_type_t;
+    typedef void* keyvalue_handle_t;
+    typedef void keyvalue_type_t;
 
-/* Open a keyvalue file and return a handle to it
+    /* Open a keyvalue file and return a handle to it
  */
-KEYVALUE_API keyvalue_handle_t keyvalue_open(const char *fn, const char* const sections[] );
+    KEYVALUE_API keyvalue_handle_t keyvalue_open(const char* fn, const char* const sections[]);
 
-/* Get all the keys parsed
+    /* Get all the keys parsed
  */
-KEYVALUE_API const char**  keyvalue_getkeys(keyvalue_handle_t kv_handle );
+    KEYVALUE_API const char** keyvalue_getkeys(keyvalue_handle_t kv_handle);
 
-/* Get a value given a key
+    /* Get a value given a key
  */
-KEYVALUE_API const char* keyvalue_getstring(keyvalue_handle_t kv_handle, const char *key);
+    KEYVALUE_API const char* keyvalue_getstring(keyvalue_handle_t kv_handle, const char* key);
 
-/* Close a keyvalue file handle
+    /* Close a keyvalue file handle
  */
-KEYVALUE_API void keyvalue_close(keyvalue_handle_t kv_handle);
+    KEYVALUE_API void keyvalue_close(keyvalue_handle_t kv_handle);
 
 #ifdef __cplusplus
 }

--- a/src/keyvalue_parser/params.h
+++ b/src/keyvalue_parser/params.h
@@ -21,8 +21,7 @@
 
 typedef struct _var_el
 {
-    char *key,
-         *val;
+    char *key, *val;
     struct _var_el *next, *prev;
 } var_el_t, *pvar_el_t;
 
@@ -32,13 +31,13 @@ typedef struct _var_list
     int len;
 } var_list_t, *pvar_list_t;
 
-var_el_t *var_list_find(pvar_list_t pvar_list, const char* key );
+var_el_t *var_list_find(pvar_list_t pvar_list, const char *key);
 void free_var_list(pvar_list_t pvar_list);
-int var_list_length( pvar_list_t pvar_list );
-pvar_el_t var_list_first( pvar_list_t pvar_list );
-void var_list_remove( pvar_list_t pvar_list, pvar_el_t pvar_el );
-void var_list_insert( pvar_list_t pvar_list, pvar_el_t pvar_el );
-unsigned int get_bucket_idx( const char *key );
+int var_list_length(pvar_list_t pvar_list);
+pvar_el_t var_list_first(pvar_list_t pvar_list);
+void var_list_remove(pvar_list_t pvar_list, pvar_el_t pvar_el);
+void var_list_insert(pvar_list_t pvar_list, pvar_el_t pvar_el);
+unsigned int get_bucket_idx(const char *key);
 
 /* Must be a pow2
  */

--- a/test/GravityTest.h
+++ b/test/GravityTest.h
@@ -22,22 +22,25 @@
 #include <sstream>
 #include <ostream>
 
-#define GRAVITY_TEST_EQUALS(a,b) do { \
-    if ( !( (a) == (b) ) ) \
-    { \
-        std::cerr << "Gravity assertion failed, " << a << " != " << b << " at " << __FILE__ << ":" << __LINE__ << std::endl; \
-        exit(1); \
-    } \
-} while (0)
+#define GRAVITY_TEST_EQUALS(a, b)                                                                                  \
+    do                                                                                                             \
+    {                                                                                                              \
+        if (!((a) == (b)))                                                                                         \
+        {                                                                                                          \
+            std::cerr << "Gravity assertion failed, " << a << " != " << b << " at " << __FILE__ << ":" << __LINE__ \
+                      << std::endl;                                                                                \
+            exit(1);                                                                                               \
+        }                                                                                                          \
+    } while (0)
 
-#define GRAVITY_TEST(a) do { \
-    if ( !( a ) ) \
-    { \
-        std::cerr << "Gravity assertion failed at " << __FILE__ << ":" << __LINE__ << std::endl; \
-        exit(1); \
-    } \
-} while (0)
-
-
+#define GRAVITY_TEST(a)                                                                              \
+    do                                                                                               \
+    {                                                                                                \
+        if (!(a))                                                                                    \
+        {                                                                                            \
+            std::cerr << "Gravity assertion failed at " << __FILE__ << ":" << __LINE__ << std::endl; \
+            exit(1);                                                                                 \
+        }                                                                                            \
+    } while (0)
 
 #endif

--- a/test/api/cpp/doctest.h
+++ b/test/api/cpp/doctest.h
@@ -50,8 +50,7 @@
 #define DOCTEST_VERSION_PATCH 2
 #define DOCTEST_VERSION_STR "2.2.2"
 
-#define DOCTEST_VERSION                                                                            \
-    (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
+#define DOCTEST_VERSION (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
 
 // =================================================================================================
 // == COMPILER VERSION =============================================================================
@@ -65,27 +64,25 @@
 #if defined(_MSC_VER) && defined(_MSC_FULL_VER)
 #if _MSC_VER == _MSC_FULL_VER / 10000
 #define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, _MSC_VER % 100, _MSC_FULL_VER % 10000)
-#else // MSVC
-#define DOCTEST_MSVC                                                                               \
-    DOCTEST_COMPILER(_MSC_VER / 100, (_MSC_FULL_VER / 100000) % 100, _MSC_FULL_VER % 100000)
-#endif // MSVC
-#endif // MSVC
+#else  // MSVC
+#define DOCTEST_MSVC DOCTEST_COMPILER(_MSC_VER / 100, (_MSC_FULL_VER / 100000) % 100, _MSC_FULL_VER % 100000)
+#endif  // MSVC
+#endif  // MSVC
 #if defined(__clang__) && defined(__clang_minor__)
 #define DOCTEST_CLANG DOCTEST_COMPILER(__clang_major__, __clang_minor__, __clang_patchlevel__)
-#elif defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__) &&              \
-        !defined(__INTEL_COMPILER)
+#elif defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__) && !defined(__INTEL_COMPILER)
 #define DOCTEST_GCC DOCTEST_COMPILER(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
-#endif // GCC
+#endif  // GCC
 
 #ifndef DOCTEST_MSVC
 #define DOCTEST_MSVC 0
-#endif // DOCTEST_MSVC
+#endif  // DOCTEST_MSVC
 #ifndef DOCTEST_CLANG
 #define DOCTEST_CLANG 0
-#endif // DOCTEST_CLANG
+#endif  // DOCTEST_CLANG
 #ifndef DOCTEST_GCC
 #define DOCTEST_GCC 0
-#endif // DOCTEST_GCC
+#endif  // DOCTEST_GCC
 
 // =================================================================================================
 // == COMPILER WARNINGS HELPERS ====================================================================
@@ -96,41 +93,39 @@
 #define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH _Pragma("clang diagnostic push")
 #define DOCTEST_CLANG_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(clang diagnostic ignored w)
 #define DOCTEST_CLANG_SUPPRESS_WARNING_POP _Pragma("clang diagnostic pop")
-#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)                                                \
+#define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w) \
     DOCTEST_CLANG_SUPPRESS_WARNING_PUSH DOCTEST_CLANG_SUPPRESS_WARNING(w)
-#else // DOCTEST_CLANG
+#else  // DOCTEST_CLANG
 #define DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
 #define DOCTEST_CLANG_SUPPRESS_WARNING(w)
 #define DOCTEST_CLANG_SUPPRESS_WARNING_POP
 #define DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH(w)
-#endif // DOCTEST_CLANG
+#endif  // DOCTEST_CLANG
 
 #if DOCTEST_GCC
 #define DOCTEST_PRAGMA_TO_STR(x) _Pragma(#x)
 #define DOCTEST_GCC_SUPPRESS_WARNING_PUSH _Pragma("GCC diagnostic push")
 #define DOCTEST_GCC_SUPPRESS_WARNING(w) DOCTEST_PRAGMA_TO_STR(GCC diagnostic ignored w)
 #define DOCTEST_GCC_SUPPRESS_WARNING_POP _Pragma("GCC diagnostic pop")
-#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)                                                  \
-    DOCTEST_GCC_SUPPRESS_WARNING_PUSH DOCTEST_GCC_SUPPRESS_WARNING(w)
-#else // DOCTEST_GCC
+#define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w) DOCTEST_GCC_SUPPRESS_WARNING_PUSH DOCTEST_GCC_SUPPRESS_WARNING(w)
+#else  // DOCTEST_GCC
 #define DOCTEST_GCC_SUPPRESS_WARNING_PUSH
 #define DOCTEST_GCC_SUPPRESS_WARNING(w)
 #define DOCTEST_GCC_SUPPRESS_WARNING_POP
 #define DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH(w)
-#endif // DOCTEST_GCC
+#endif  // DOCTEST_GCC
 
 #if DOCTEST_MSVC
 #define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH __pragma(warning(push))
 #define DOCTEST_MSVC_SUPPRESS_WARNING(w) __pragma(warning(disable : w))
 #define DOCTEST_MSVC_SUPPRESS_WARNING_POP __pragma(warning(pop))
-#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)                                                 \
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH DOCTEST_MSVC_SUPPRESS_WARNING(w)
-#else // DOCTEST_MSVC
+#define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w) DOCTEST_MSVC_SUPPRESS_WARNING_PUSH DOCTEST_MSVC_SUPPRESS_WARNING(w)
+#else  // DOCTEST_MSVC
 #define DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
 #define DOCTEST_MSVC_SUPPRESS_WARNING(w)
 #define DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #define DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(w)
-#endif // DOCTEST_MSVC
+#endif  // DOCTEST_MSVC
 
 // =================================================================================================
 // == COMPILER WARNINGS ============================================================================
@@ -161,24 +156,24 @@ DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-local-typedefs")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")
 
 DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-DOCTEST_MSVC_SUPPRESS_WARNING(4616) // invalid compiler warning
-DOCTEST_MSVC_SUPPRESS_WARNING(4619) // invalid compiler warning
-DOCTEST_MSVC_SUPPRESS_WARNING(4996) // The compiler encountered a deprecated declaration
-DOCTEST_MSVC_SUPPRESS_WARNING(4706) // assignment within conditional expression
-DOCTEST_MSVC_SUPPRESS_WARNING(4512) // 'class' : assignment operator could not be generated
-DOCTEST_MSVC_SUPPRESS_WARNING(4127) // conditional expression is constant
-DOCTEST_MSVC_SUPPRESS_WARNING(4820) // padding
-DOCTEST_MSVC_SUPPRESS_WARNING(4625) // copy constructor was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(4626) // assignment operator was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(5027) // move assignment operator was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(5026) // move constructor was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(4623) // default constructor was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is not thread-safe
+DOCTEST_MSVC_SUPPRESS_WARNING(4616)  // invalid compiler warning
+DOCTEST_MSVC_SUPPRESS_WARNING(4619)  // invalid compiler warning
+DOCTEST_MSVC_SUPPRESS_WARNING(4996)  // The compiler encountered a deprecated declaration
+DOCTEST_MSVC_SUPPRESS_WARNING(4706)  // assignment within conditional expression
+DOCTEST_MSVC_SUPPRESS_WARNING(4512)  // 'class' : assignment operator could not be generated
+DOCTEST_MSVC_SUPPRESS_WARNING(4127)  // conditional expression is constant
+DOCTEST_MSVC_SUPPRESS_WARNING(4820)  // padding
+DOCTEST_MSVC_SUPPRESS_WARNING(4625)  // copy constructor was implicitly defined as deleted
+DOCTEST_MSVC_SUPPRESS_WARNING(4626)  // assignment operator was implicitly defined as deleted
+DOCTEST_MSVC_SUPPRESS_WARNING(5027)  // move assignment operator was implicitly defined as deleted
+DOCTEST_MSVC_SUPPRESS_WARNING(5026)  // move constructor was implicitly defined as deleted
+DOCTEST_MSVC_SUPPRESS_WARNING(4623)  // default constructor was implicitly defined as deleted
+DOCTEST_MSVC_SUPPRESS_WARNING(4640)  // construction of local static object is not thread-safe
 // static analysis
-DOCTEST_MSVC_SUPPRESS_WARNING(26439) // This kind of function may not throw. Declare it 'noexcept'
-DOCTEST_MSVC_SUPPRESS_WARNING(26495) // Always initialize a member variable
-DOCTEST_MSVC_SUPPRESS_WARNING(26451) // Arithmetic overflow ...
-DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom construction and dtr...
+DOCTEST_MSVC_SUPPRESS_WARNING(26439)  // This kind of function may not throw. Declare it 'noexcept'
+DOCTEST_MSVC_SUPPRESS_WARNING(26495)  // Always initialize a member variable
+DOCTEST_MSVC_SUPPRESS_WARNING(26451)  // Arithmetic overflow ...
+DOCTEST_MSVC_SUPPRESS_WARNING(26444)  // Avoid unnamed objects with custom construction and dtr...
 
 // 4548 - expression before comma has no effect; expected expression with side - effect
 // 4265 - class has virtual functions, but destructor is not virtual
@@ -195,21 +190,21 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 // - 4710 # function not inlined
 // - 4711 # function 'x' selected for automatic inline expansion
 
-#define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN                                 \
-    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4548)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4265)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4986)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4350)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4668)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4365)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4774)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4820)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4625)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4626)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5027)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5026)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4623)                                                            \
+#define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN \
+    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                             \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4548)                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4265)                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4986)                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4350)                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4668)                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4365)                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4774)                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4820)                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4625)                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4626)                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5027)                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5026)                            \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4623)                            \
     DOCTEST_MSVC_SUPPRESS_WARNING(5039)
 
 #define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END DOCTEST_MSVC_SUPPRESS_WARNING_POP
@@ -232,77 +227,77 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 
 #if DOCTEST_MSVC && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
 #define DOCTEST_CONFIG_WINDOWS_SEH
-#endif // MSVC
+#endif  // MSVC
 #if defined(DOCTEST_CONFIG_NO_WINDOWS_SEH) && defined(DOCTEST_CONFIG_WINDOWS_SEH)
 #undef DOCTEST_CONFIG_WINDOWS_SEH
-#endif // DOCTEST_CONFIG_NO_WINDOWS_SEH
+#endif  // DOCTEST_CONFIG_NO_WINDOWS_SEH
 
 #if !defined(_WIN32) && !defined(__QNX__) && !defined(DOCTEST_CONFIG_POSIX_SIGNALS)
 #define DOCTEST_CONFIG_POSIX_SIGNALS
-#endif // _WIN32
+#endif  // _WIN32
 #if defined(DOCTEST_CONFIG_NO_POSIX_SIGNALS) && defined(DOCTEST_CONFIG_POSIX_SIGNALS)
 #undef DOCTEST_CONFIG_POSIX_SIGNALS
-#endif // DOCTEST_CONFIG_NO_POSIX_SIGNALS
+#endif  // DOCTEST_CONFIG_NO_POSIX_SIGNALS
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-#if(DOCTEST_GCC || (DOCTEST_CLANG && !DOCTEST_MSVC)) && !defined(__EXCEPTIONS)
+#if (DOCTEST_GCC || (DOCTEST_CLANG && !DOCTEST_MSVC)) && !defined(__EXCEPTIONS)
 #define DOCTEST_CONFIG_NO_EXCEPTIONS
-#endif // clang and gcc
+#endif  // clang and gcc
 #if DOCTEST_MSVC && (defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS == 0)
 #define DOCTEST_CONFIG_NO_EXCEPTIONS
-#endif // MSVC
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+#endif  // MSVC
+#endif  // DOCTEST_CONFIG_NO_EXCEPTIONS
 
 #ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
 #define DOCTEST_CONFIG_NO_EXCEPTIONS
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#endif  // DOCTEST_CONFIG_NO_EXCEPTIONS
+#endif  // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
 #if defined(DOCTEST_CONFIG_NO_EXCEPTIONS) && !defined(DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS)
 #define DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS && !DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#endif  // DOCTEST_CONFIG_NO_EXCEPTIONS && !DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 
 #if defined(DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN) && !defined(DOCTEST_CONFIG_IMPLEMENT)
 #define DOCTEST_CONFIG_IMPLEMENT
-#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#endif  // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #if DOCTEST_MSVC
 #define DOCTEST_SYMBOL_EXPORT __declspec(dllexport)
 #define DOCTEST_SYMBOL_IMPORT __declspec(dllimport)
-#else // MSVC
+#else  // MSVC
 #define DOCTEST_SYMBOL_EXPORT __attribute__((dllexport))
 #define DOCTEST_SYMBOL_IMPORT __attribute__((dllimport))
-#endif // MSVC
-#else  // _WIN32
+#endif  // MSVC
+#else   // _WIN32
 #define DOCTEST_SYMBOL_EXPORT __attribute__((visibility("default")))
 #define DOCTEST_SYMBOL_IMPORT
-#endif // _WIN32
+#endif  // _WIN32
 
 #ifdef DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
 #ifdef DOCTEST_CONFIG_IMPLEMENT
 #define DOCTEST_INTERFACE DOCTEST_SYMBOL_EXPORT
-#else // DOCTEST_CONFIG_IMPLEMENT
+#else  // DOCTEST_CONFIG_IMPLEMENT
 #define DOCTEST_INTERFACE DOCTEST_SYMBOL_IMPORT
-#endif // DOCTEST_CONFIG_IMPLEMENT
-#else  // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#endif  // DOCTEST_CONFIG_IMPLEMENT
+#else   // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
 #define DOCTEST_INTERFACE
-#endif // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
+#endif  // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
 
 #if DOCTEST_MSVC
 #define DOCTEST_NOINLINE __declspec(noinline)
 #define DOCTEST_UNUSED
 #define DOCTEST_ALIGNMENT(x)
-#else // MSVC
+#else  // MSVC
 #define DOCTEST_NOINLINE __attribute__((noinline))
 #define DOCTEST_UNUSED __attribute__((unused))
 #define DOCTEST_ALIGNMENT(x) __attribute__((aligned(x)))
-#endif // MSVC
+#endif  // MSVC
 
 #ifndef DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK
 #define DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK 5
-#endif // DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK
+#endif  // DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK
 
 // =================================================================================================
 // == FEATURE DETECTION END ========================================================================
@@ -311,17 +306,17 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 // internal macros for string concatenation and anonymous variable name generation
 #define DOCTEST_CAT_IMPL(s1, s2) s1##s2
 #define DOCTEST_CAT(s1, s2) DOCTEST_CAT_IMPL(s1, s2)
-#ifdef __COUNTER__ // not standard and may be missing for some compilers
+#ifdef __COUNTER__  // not standard and may be missing for some compilers
 #define DOCTEST_ANONYMOUS(x) DOCTEST_CAT(x, __COUNTER__)
-#else // __COUNTER__
+#else  // __COUNTER__
 #define DOCTEST_ANONYMOUS(x) DOCTEST_CAT(x, __LINE__)
-#endif // __COUNTER__
+#endif  // __COUNTER__
 
 #ifndef DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
 #define DOCTEST_REF_WRAP(x) x&
-#else // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
+#else  // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
 #define DOCTEST_REF_WRAP(x) x
-#endif // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
+#endif  // DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
 
 // not using __APPLE__ because... this is how Catch does it
 #ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
@@ -330,9 +325,9 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #define DOCTEST_PLATFORM_IPHONE
 #elif defined(_WIN32)
 #define DOCTEST_PLATFORM_WINDOWS
-#else // DOCTEST_PLATFORM
+#else  // DOCTEST_PLATFORM
 #define DOCTEST_PLATFORM_LINUX
-#endif // DOCTEST_PLATFORM
+#endif  // DOCTEST_PLATFORM
 
 // clang-format off
 #define DOCTEST_DELETE_COPIES(type)     type(const type&) = delete; type& operator=(const type&) = delete
@@ -342,9 +337,9 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #define DOCTEST_DEFINE_DEFAULTS(type)   type::type()  = default; type::~type() = default
 // clang-format on
 
-#define DOCTEST_GLOBAL_NO_WARNINGS(var)                                                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                              \
-    static int var DOCTEST_UNUSED // NOLINT(fuchsia-statically-constructed-objects,cert-err58-cpp)
+#define DOCTEST_GLOBAL_NO_WARNINGS(var)                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors") \
+    static int var DOCTEST_UNUSED  // NOLINT(fuchsia-statically-constructed-objects,cert-err58-cpp)
 #define DOCTEST_GLOBAL_NO_WARNINGS_END() DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
 // should probably take a look at https://github.com/scottt/debugbreak
@@ -355,14 +350,14 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #elif defined(__MINGW32__)
 extern "C" __declspec(dllimport) void __stdcall DebugBreak();
 #define DOCTEST_BREAK_INTO_DEBUGGER() ::DebugBreak()
-#else // linux
+#else  // linux
 #define DOCTEST_BREAK_INTO_DEBUGGER() ((void)0)
-#endif // linux
+#endif  // linux
 
 #if DOCTEST_CLANG
 // to detect if libc++ is being used with clang (the _LIBCPP_VERSION identifier)
 #include <ciso646>
-#endif // clang
+#endif  // clang
 
 // Forward declaring 'X' in namespace std is not permitted by the C++ Standard.
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4643)
@@ -371,8 +366,9 @@ DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4643)
 // not forward declaring ostream for libc++ because I had some problems (inline namespaces vs c++98)
 // so the <iosfwd> header is used - also it is very light and doesn't drag a ton of stuff
 #include <iosfwd>
-#else  // _LIBCPP_VERSION
-namespace std {
+#else   // _LIBCPP_VERSION
+namespace std
+{
 template <class charT>
 struct char_traits;
 template <>
@@ -380,24 +376,26 @@ struct char_traits<char>;
 template <class charT, class traits>
 class basic_ostream;
 typedef basic_ostream<char, char_traits<char> > ostream;
-} // namespace std
-#endif // _LIBCPP_VERSION || DOCTEST_CONFIG_USE_IOSFWD
+}  // namespace std
+#endif  // _LIBCPP_VERSION || DOCTEST_CONFIG_USE_IOSFWD
 
 #ifdef _LIBCPP_VERSION
 #include <cstddef>
-#else  // _LIBCPP_VERSION
-namespace std {
+#else   // _LIBCPP_VERSION
+namespace std
+{
 typedef decltype(nullptr) nullptr_t;
 }
-#endif // _LIBCPP_VERSION
+#endif  // _LIBCPP_VERSION
 
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #include <type_traits>
-#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#endif  // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
-namespace doctest {
+namespace doctest
+{
 
 DOCTEST_INTERFACE extern bool is_running_in_test;
 
@@ -423,12 +421,12 @@ DOCTEST_INTERFACE extern bool is_running_in_test;
 // - relational operators as free functions - taking const char* as one of the params
 class DOCTEST_INTERFACE String
 {
-    static const unsigned len  = 24;      //!OCLINT avoid private static members
-    static const unsigned last = len - 1; //!OCLINT avoid private static members
+    static const unsigned len = 24;        //!OCLINT avoid private static members
+    static const unsigned last = len - 1;  //!OCLINT avoid private static members
 
-    struct view // len should be more than sizeof(view) - because of the final byte for flags
+    struct view  // len should be more than sizeof(view) - because of the final byte for flags
     {
-        char*    ptr;
+        char* ptr;
         unsigned size;
         unsigned capacity;
     };
@@ -456,19 +454,19 @@ public:
     String& operator=(const String& other);
 
     String& operator+=(const String& other);
-    String  operator+(const String& other) const;
+    String operator+(const String& other) const;
 
     String(String&& other);
     String& operator=(String&& other);
 
-    char  operator[](unsigned i) const;
+    char operator[](unsigned i) const;
     char& operator[](unsigned i);
 
     // the only functions I'm willing to leave in the interface - available for inlining
-    const char* c_str() const { return const_cast<String*>(this)->c_str(); } // NOLINT
-    char*       c_str() {
-        if(isOnStack())
-            return reinterpret_cast<char*>(buf);
+    const char* c_str() const { return const_cast<String*>(this)->c_str(); }  // NOLINT
+    char* c_str()
+    {
+        if (isOnStack()) return reinterpret_cast<char*>(buf);
         return data.ptr;
     }
 
@@ -488,7 +486,8 @@ DOCTEST_INTERFACE bool operator>=(const String& lhs, const String& rhs);
 
 DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, const String& in);
 
-namespace Color {
+namespace Color
+{
     enum Enum
     {
         None = 0,
@@ -502,32 +501,33 @@ namespace Color {
 
         Bright = 0x10,
 
-        BrightRed   = Bright | Red,
+        BrightRed = Bright | Red,
         BrightGreen = Bright | Green,
-        LightGrey   = Bright | Grey,
+        LightGrey = Bright | Grey,
         BrightWhite = Bright | White
     };
 
     DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, Color::Enum code);
-} // namespace Color
+}  // namespace Color
 
-namespace assertType {
+namespace assertType
+{
     enum Enum
     {
         // macro traits
 
-        is_warn    = 1,
-        is_check   = 2 * is_warn,
+        is_warn = 1,
+        is_check = 2 * is_warn,
         is_require = 2 * is_check,
 
-        is_normal      = 2 * is_require,
-        is_throws      = 2 * is_normal,
-        is_throws_as   = 2 * is_throws,
+        is_normal = 2 * is_require,
+        is_throws = 2 * is_normal,
+        is_throws_as = 2 * is_throws,
         is_throws_with = 2 * is_throws_as,
-        is_nothrow     = 2 * is_throws_with,
+        is_nothrow = 2 * is_throws_with,
 
         is_false = 2 * is_nothrow,
-        is_unary = 2 * is_false, // not checked anywhere - used just to distinguish the types
+        is_unary = 2 * is_false,  // not checked anywhere - used just to distinguish the types
 
         is_eq = 2 * is_unary,
         is_ne = 2 * is_eq,
@@ -540,63 +540,63 @@ namespace assertType {
 
         // macro types
 
-        DT_WARN    = is_normal | is_warn,
-        DT_CHECK   = is_normal | is_check,
+        DT_WARN = is_normal | is_warn,
+        DT_CHECK = is_normal | is_check,
         DT_REQUIRE = is_normal | is_require,
 
-        DT_WARN_FALSE    = is_normal | is_false | is_warn,
-        DT_CHECK_FALSE   = is_normal | is_false | is_check,
+        DT_WARN_FALSE = is_normal | is_false | is_warn,
+        DT_CHECK_FALSE = is_normal | is_false | is_check,
         DT_REQUIRE_FALSE = is_normal | is_false | is_require,
 
-        DT_WARN_THROWS    = is_throws | is_warn,
-        DT_CHECK_THROWS   = is_throws | is_check,
+        DT_WARN_THROWS = is_throws | is_warn,
+        DT_CHECK_THROWS = is_throws | is_check,
         DT_REQUIRE_THROWS = is_throws | is_require,
 
-        DT_WARN_THROWS_AS    = is_throws_as | is_warn,
-        DT_CHECK_THROWS_AS   = is_throws_as | is_check,
+        DT_WARN_THROWS_AS = is_throws_as | is_warn,
+        DT_CHECK_THROWS_AS = is_throws_as | is_check,
         DT_REQUIRE_THROWS_AS = is_throws_as | is_require,
 
-        DT_WARN_THROWS_WITH    = is_throws_with | is_warn,
-        DT_CHECK_THROWS_WITH   = is_throws_with | is_check,
+        DT_WARN_THROWS_WITH = is_throws_with | is_warn,
+        DT_CHECK_THROWS_WITH = is_throws_with | is_check,
         DT_REQUIRE_THROWS_WITH = is_throws_with | is_require,
 
-        DT_WARN_NOTHROW    = is_nothrow | is_warn,
-        DT_CHECK_NOTHROW   = is_nothrow | is_check,
+        DT_WARN_NOTHROW = is_nothrow | is_warn,
+        DT_CHECK_NOTHROW = is_nothrow | is_check,
         DT_REQUIRE_NOTHROW = is_nothrow | is_require,
 
-        DT_WARN_EQ    = is_normal | is_eq | is_warn,
-        DT_CHECK_EQ   = is_normal | is_eq | is_check,
+        DT_WARN_EQ = is_normal | is_eq | is_warn,
+        DT_CHECK_EQ = is_normal | is_eq | is_check,
         DT_REQUIRE_EQ = is_normal | is_eq | is_require,
 
-        DT_WARN_NE    = is_normal | is_ne | is_warn,
-        DT_CHECK_NE   = is_normal | is_ne | is_check,
+        DT_WARN_NE = is_normal | is_ne | is_warn,
+        DT_CHECK_NE = is_normal | is_ne | is_check,
         DT_REQUIRE_NE = is_normal | is_ne | is_require,
 
-        DT_WARN_GT    = is_normal | is_gt | is_warn,
-        DT_CHECK_GT   = is_normal | is_gt | is_check,
+        DT_WARN_GT = is_normal | is_gt | is_warn,
+        DT_CHECK_GT = is_normal | is_gt | is_check,
         DT_REQUIRE_GT = is_normal | is_gt | is_require,
 
-        DT_WARN_LT    = is_normal | is_lt | is_warn,
-        DT_CHECK_LT   = is_normal | is_lt | is_check,
+        DT_WARN_LT = is_normal | is_lt | is_warn,
+        DT_CHECK_LT = is_normal | is_lt | is_check,
         DT_REQUIRE_LT = is_normal | is_lt | is_require,
 
-        DT_WARN_GE    = is_normal | is_ge | is_warn,
-        DT_CHECK_GE   = is_normal | is_ge | is_check,
+        DT_WARN_GE = is_normal | is_ge | is_warn,
+        DT_CHECK_GE = is_normal | is_ge | is_check,
         DT_REQUIRE_GE = is_normal | is_ge | is_require,
 
-        DT_WARN_LE    = is_normal | is_le | is_warn,
-        DT_CHECK_LE   = is_normal | is_le | is_check,
+        DT_WARN_LE = is_normal | is_le | is_warn,
+        DT_CHECK_LE = is_normal | is_le | is_check,
         DT_REQUIRE_LE = is_normal | is_le | is_require,
 
-        DT_WARN_UNARY    = is_normal | is_unary | is_warn,
-        DT_CHECK_UNARY   = is_normal | is_unary | is_check,
+        DT_WARN_UNARY = is_normal | is_unary | is_warn,
+        DT_CHECK_UNARY = is_normal | is_unary | is_check,
         DT_REQUIRE_UNARY = is_normal | is_unary | is_require,
 
-        DT_WARN_UNARY_FALSE    = is_normal | is_false | is_unary | is_warn,
-        DT_CHECK_UNARY_FALSE   = is_normal | is_false | is_unary | is_check,
+        DT_WARN_UNARY_FALSE = is_normal | is_false | is_unary | is_warn,
+        DT_CHECK_UNARY_FALSE = is_normal | is_false | is_unary | is_check,
         DT_REQUIRE_UNARY_FALSE = is_normal | is_false | is_unary | is_require,
     };
-} // namespace assertType
+}  // namespace assertType
 
 DOCTEST_INTERFACE const char* assertString(assertType::Enum at);
 DOCTEST_INTERFACE const char* failureString(assertType::Enum at);
@@ -604,16 +604,16 @@ DOCTEST_INTERFACE const char* removePathFromFilename(const char* file);
 
 struct DOCTEST_INTERFACE TestCaseData
 {
-    const char* m_file;       // the file in which the test was registered
-    unsigned    m_line;       // the line where the test was registered
-    const char* m_name;       // name of the test case
-    const char* m_test_suite; // the test suite in which the test was added
+    const char* m_file;        // the file in which the test was registered
+    unsigned m_line;           // the line where the test was registered
+    const char* m_name;        // name of the test case
+    const char* m_test_suite;  // the test suite in which the test was added
     const char* m_description;
-    bool        m_skip;
-    bool        m_may_fail;
-    bool        m_should_fail;
-    int         m_expected_failures;
-    double      m_timeout;
+    bool m_skip;
+    bool m_may_fail;
+    bool m_should_fail;
+    int m_expected_failures;
+    double m_timeout;
 
     DOCTEST_DECLARE_DEFAULTS(TestCaseData);
     DOCTEST_DECLARE_COPIES(TestCaseData);
@@ -623,21 +623,21 @@ struct DOCTEST_INTERFACE AssertData
 {
     // common - for all asserts
     const TestCaseData* m_test_case;
-    assertType::Enum    m_at;
-    const char*         m_file;
-    int                 m_line;
-    const char*         m_expr;
-    bool                m_failed;
+    assertType::Enum m_at;
+    const char* m_file;
+    int m_line;
+    const char* m_expr;
+    bool m_failed;
 
     // exception-related - for all asserts
-    bool   m_threw;
+    bool m_threw;
     String m_exception;
 
     // for normal asserts
     String m_decomp;
 
     // for specific exception-related asserts
-    bool        m_threw_as;
+    bool m_threw_as;
     const char* m_exception_type;
 
     DOCTEST_DECLARE_DEFAULTS(AssertData);
@@ -646,9 +646,9 @@ struct DOCTEST_INTERFACE AssertData
 
 struct DOCTEST_INTERFACE MessageData
 {
-    String           m_string;
-    const char*      m_file;
-    int              m_line;
+    String m_string;
+    const char* m_file;
+    int m_line;
     assertType::Enum m_severity;
 
     DOCTEST_DECLARE_DEFAULTS(MessageData);
@@ -659,7 +659,7 @@ struct DOCTEST_INTERFACE SubcaseSignature
 {
     const char* m_name;
     const char* m_file;
-    int         m_line;
+    int m_line;
 
     SubcaseSignature(const char* name, const char* file, int line);
 
@@ -678,56 +678,60 @@ struct DOCTEST_INTERFACE IContextScope
     virtual void stringify(std::ostream*) const = 0;
 };
 
-struct ContextOptions //!OCLINT too many fields
+struct ContextOptions  //!OCLINT too many fields
 {
     // == parameters from the command line
-    String   order_by;  // how tests should be ordered
-    unsigned rand_seed; // the seed for rand ordering
+    String order_by;     // how tests should be ordered
+    unsigned rand_seed;  // the seed for rand ordering
 
-    unsigned first; // the first (matching) test to be executed
-    unsigned last;  // the last (matching) test to be executed
+    unsigned first;  // the first (matching) test to be executed
+    unsigned last;   // the last (matching) test to be executed
 
-    int abort_after;           // stop tests after this many failed assertions
-    int subcase_filter_levels; // apply the subcase filters for the first N levels
+    int abort_after;            // stop tests after this many failed assertions
+    int subcase_filter_levels;  // apply the subcase filters for the first N levels
 
-    bool success;              // include successful assertions in output
-    bool case_sensitive;       // if filtering should be case sensitive
-    bool exit;                 // if the program should be exited after the tests are ran/whatever
-    bool duration;             // print the time duration of each test case
-    bool no_throw;             // to skip exceptions-related assertion macros
-    bool no_exitcode;          // if the framework should return 0 as the exitcode
-    bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
-    bool no_version;           // to not print the version of the framework
-    bool no_colors;            // if output to the console should be colorized
-    bool force_colors;         // forces the use of colors even when a tty cannot be detected
-    bool no_breaks;            // to not break into the debugger
-    bool no_skip;              // don't skip test cases which are marked to be skipped
-    bool gnu_file_line;        // if line numbers should be surrounded with :x: and not (x):
-    bool no_path_in_filenames; // if the path to files should be removed from the output
-    bool no_line_numbers;      // if source code line numbers should be omitted from the output
-    bool no_skipped_summary;   // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
+    bool success;               // include successful assertions in output
+    bool case_sensitive;        // if filtering should be case sensitive
+    bool exit;                  // if the program should be exited after the tests are ran/whatever
+    bool duration;              // print the time duration of each test case
+    bool no_throw;              // to skip exceptions-related assertion macros
+    bool no_exitcode;           // if the framework should return 0 as the exitcode
+    bool no_run;                // to not run the tests at all (can be done with an "*" exclude)
+    bool no_version;            // to not print the version of the framework
+    bool no_colors;             // if output to the console should be colorized
+    bool force_colors;          // forces the use of colors even when a tty cannot be detected
+    bool no_breaks;             // to not break into the debugger
+    bool no_skip;               // don't skip test cases which are marked to be skipped
+    bool gnu_file_line;         // if line numbers should be surrounded with :x: and not (x):
+    bool no_path_in_filenames;  // if the path to files should be removed from the output
+    bool no_line_numbers;       // if source code line numbers should be omitted from the output
+    bool no_skipped_summary;    // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
 
-    bool help;             // to print the help
-    bool version;          // to print the version
-    bool count;            // if only the count of matching tests is to be retreived
-    bool list_test_cases;  // to list all tests matching the filters
-    bool list_test_suites; // to list all suites matching the filters
-    bool list_reporters;   // lists all registered reporters
+    bool help;              // to print the help
+    bool version;           // to print the version
+    bool count;             // if only the count of matching tests is to be retreived
+    bool list_test_cases;   // to list all tests matching the filters
+    bool list_test_suites;  // to list all suites matching the filters
+    bool list_reporters;    // lists all registered reporters
 
     DOCTEST_DECLARE_DEFAULTS(ContextOptions);
     DOCTEST_DELETE_COPIES(ContextOptions);
 };
 
-namespace detail {
+namespace detail
+{
 #if defined(DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING) || defined(DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS)
     template <bool CONDITION, typename TYPE = void>
     struct enable_if
-    {};
+    {
+    };
 
     template <typename TYPE>
     struct enable_if<true, TYPE>
-    { typedef TYPE type; };
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING) || DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+    {
+        typedef TYPE type;
+    };
+#endif  // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING) || DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
     // clang-format off
     template<class T> struct remove_reference      { typedef T type; };
@@ -741,9 +745,12 @@ namespace detail {
     template <typename T>
     struct deferred_false
     // cppcheck-suppress unusedStructMember
-    { static const bool value = false; };
+    {
+        static const bool value = false;
+    };
 
-    namespace has_insertion_operator_impl {
+    namespace has_insertion_operator_impl
+    {
         typedef char no;
         typedef char yes[2];
 
@@ -755,7 +762,7 @@ namespace detail {
         };
 
         yes& testStreamable(std::ostream&);
-        no   testStreamable(no);
+        no testStreamable(no);
 
         no operator<<(const std::ostream&, const any_t&);
 
@@ -766,22 +773,24 @@ namespace detail {
             static const DOCTEST_REF_WRAP(T) t;
             static const bool value = sizeof(testStreamable(s << t)) == sizeof(yes);
         };
-    } // namespace has_insertion_operator_impl
+    }  // namespace has_insertion_operator_impl
 
     template <typename T>
     struct has_insertion_operator : has_insertion_operator_impl::has_insertion_operator<T>
-    {};
+    {
+    };
 
     DOCTEST_INTERFACE void my_memcpy(void* dest, const void* src, unsigned num);
 
-    DOCTEST_INTERFACE std::ostream* getTlsOss(); // returns a thread-local ostringstream
+    DOCTEST_INTERFACE std::ostream* getTlsOss();  // returns a thread-local ostringstream
     DOCTEST_INTERFACE String getTlsOssResult();
 
     template <bool C>
     struct StringMakerBase
     {
         template <typename T>
-        static String convert(const DOCTEST_REF_WRAP(T)) {
+        static String convert(const DOCTEST_REF_WRAP(T))
+        {
             return "{?}";
         }
     };
@@ -790,7 +799,8 @@ namespace detail {
     struct StringMakerBase<true>
     {
         template <typename T>
-        static String convert(const DOCTEST_REF_WRAP(T) in) {
+        static String convert(const DOCTEST_REF_WRAP(T) in)
+        {
             *getTlsOss() << in;
             return getTlsOssResult();
         }
@@ -799,27 +809,30 @@ namespace detail {
     DOCTEST_INTERFACE String rawMemoryToString(const void* object, unsigned size);
 
     template <typename T>
-    String rawMemoryToString(const DOCTEST_REF_WRAP(T) object) {
+    String rawMemoryToString(const DOCTEST_REF_WRAP(T) object)
+    {
         return rawMemoryToString(&object, sizeof(object));
     }
 
     template <typename T>
-    const char* type_to_string() {
+    const char* type_to_string()
+    {
         return "<>";
     }
-} // namespace detail
+}  // namespace detail
 
 template <typename T>
 struct StringMaker : public detail::StringMakerBase<detail::has_insertion_operator<T>::value>
-{};
+{
+};
 
 template <typename T>
 struct StringMaker<T*>
 {
     template <typename U>
-    static String convert(U* p) {
-        if(p)
-            return detail::rawMemoryToString(p);
+    static String convert(U* p)
+    {
+        if (p) return detail::rawMemoryToString(p);
         return "NULL";
     }
 };
@@ -827,22 +840,23 @@ struct StringMaker<T*>
 template <typename R, typename C>
 struct StringMaker<R C::*>
 {
-    static String convert(R C::*p) {
-        if(p)
-            return detail::rawMemoryToString(p);
+    static String convert(R C::*p)
+    {
+        if (p) return detail::rawMemoryToString(p);
         return "NULL";
     }
 };
 
 template <typename T>
-String toString(const DOCTEST_REF_WRAP(T) value) {
+String toString(const DOCTEST_REF_WRAP(T) value)
+{
     return StringMaker<T>::convert(value);
 }
 
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 DOCTEST_INTERFACE String toString(char* in);
 DOCTEST_INTERFACE String toString(const char* in);
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#endif  // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 DOCTEST_INTERFACE String toString(bool in);
 DOCTEST_INTERFACE String toString(float in);
 DOCTEST_INTERFACE String toString(double in);
@@ -872,34 +886,34 @@ public:
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
-    explicit Approx(const T& value,
-                    typename detail::enable_if<std::is_constructible<double, T>::value>::type* =
-                            static_cast<T*>(nullptr)) {
+    explicit Approx(const T& value, typename detail::enable_if<std::is_constructible<double, T>::value>::type* =
+                                        static_cast<T*>(nullptr))
+    {
         *this = Approx(static_cast<double>(value));
     }
-#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#endif  // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
     Approx& epsilon(double newEpsilon);
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
-    typename detail::enable_if<std::is_constructible<double, T>::value, Approx&>::type epsilon(
-            const T& newEpsilon) {
+    typename detail::enable_if<std::is_constructible<double, T>::value, Approx&>::type epsilon(const T& newEpsilon)
+    {
         m_epsilon = static_cast<double>(newEpsilon);
         return *this;
     }
-#endif //  DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#endif  //  DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
     Approx& scale(double newScale);
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
-    typename detail::enable_if<std::is_constructible<double, T>::value, Approx&>::type scale(
-            const T& newScale) {
+    typename detail::enable_if<std::is_constructible<double, T>::value, Approx&>::type scale(const T& newScale)
+    {
         m_scale = static_cast<double>(newScale);
         return *this;
     }
-#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#endif  // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
     // clang-format off
     DOCTEST_INTERFACE friend bool operator==(double lhs, const Approx & rhs);
@@ -950,7 +964,8 @@ DOCTEST_INTERFACE const ContextOptions* getContextOptions();
 
 #if !defined(DOCTEST_CONFIG_DISABLE)
 
-namespace detail {
+namespace detail
+{
     // clang-format off
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
     template<class T>               struct decay_array       { typedef T type; };
@@ -977,7 +992,7 @@ namespace detail {
     struct DOCTEST_INTERFACE Subcase
     {
         SubcaseSignature m_signature;
-        bool             m_entered = false;
+        bool m_entered = false;
 
         Subcase(const char* name, const char* file, int line);
         ~Subcase();
@@ -988,33 +1003,32 @@ namespace detail {
     };
 
     template <typename L, typename R>
-    String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char* op,
-                               const DOCTEST_REF_WRAP(R) rhs) {
+    String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char* op, const DOCTEST_REF_WRAP(R) rhs)
+    {
         return toString(lhs) + op + toString(rhs);
     }
 
-#define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
-    template <typename R>                                                                          \
-    DOCTEST_NOINLINE Result operator op(const DOCTEST_REF_WRAP(R) rhs) {                           \
-        bool res = op_macro(lhs, rhs);                                                             \
-        if(m_at & assertType::is_false)                                                            \
-            res = !res;                                                                            \
-        if(!res || doctest::getContextOptions()->success)                                          \
-            return Result(res, stringifyBinaryExpr(lhs, op_str, rhs));                             \
-        return Result(res);                                                                        \
+#define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                                                 \
+    template <typename R>                                                                                             \
+    DOCTEST_NOINLINE Result operator op(const DOCTEST_REF_WRAP(R) rhs)                                                \
+    {                                                                                                                 \
+        bool res = op_macro(lhs, rhs);                                                                                \
+        if (m_at & assertType::is_false) res = !res;                                                                  \
+        if (!res || doctest::getContextOptions()->success) return Result(res, stringifyBinaryExpr(lhs, op_str, rhs)); \
+        return Result(res);                                                                                           \
     }
 
-#define DOCTEST_FORBIT_EXPRESSION(rt, op)                                                          \
-    template <typename R>                                                                          \
-    rt& operator op(const R&) {                                                                    \
-        static_assert(deferred_false<R>::value,                                                    \
-                      "Expression Too Complex Please Rewrite As Binary Comparison!");              \
-        return *this;                                                                              \
+#define DOCTEST_FORBIT_EXPRESSION(rt, op)                                                                       \
+    template <typename R>                                                                                       \
+    rt& operator op(const R&)                                                                                   \
+    {                                                                                                           \
+        static_assert(deferred_false<R>::value, "Expression Too Complex Please Rewrite As Binary Comparison!"); \
+        return *this;                                                                                           \
     }
 
     struct DOCTEST_INTERFACE Result
     {
-        bool   m_passed;
+        bool m_passed;
         String m_decomp;
 
         Result(bool passed, const String& decomposition = String());
@@ -1065,12 +1079,12 @@ namespace detail {
 
     DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
     // http://stackoverflow.com/questions/39479163 what's the difference between 4018 and 4389
-    DOCTEST_MSVC_SUPPRESS_WARNING(4388) // signed/unsigned mismatch
-    DOCTEST_MSVC_SUPPRESS_WARNING(4389) // 'operator' : signed/unsigned mismatch
-    DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
+    DOCTEST_MSVC_SUPPRESS_WARNING(4388)  // signed/unsigned mismatch
+    DOCTEST_MSVC_SUPPRESS_WARNING(4389)  // 'operator' : signed/unsigned mismatch
+    DOCTEST_MSVC_SUPPRESS_WARNING(4018)  // 'expression' : signed/unsigned mismatch
     //DOCTEST_MSVC_SUPPRESS_WARNING(4805) // 'operation' : unsafe mix of type 'type' and type 'type' in operation
 
-#endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+#endif  // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
     // clang-format off
 #ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
@@ -1086,11 +1100,11 @@ namespace detail {
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
     // clang-format on
 
-#define DOCTEST_RELATIONAL_OP(name, op)                                                            \
-    template <typename L, typename R>                                                              \
-    DOCTEST_COMPARISON_RETURN_TYPE name(const DOCTEST_REF_WRAP(L) lhs,                             \
-                                        const DOCTEST_REF_WRAP(R) rhs) {                           \
-        return lhs op rhs;                                                                         \
+#define DOCTEST_RELATIONAL_OP(name, op)                                                               \
+    template <typename L, typename R>                                                                 \
+    DOCTEST_COMPARISON_RETURN_TYPE name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) \
+    {                                                                                                 \
+        return lhs op rhs;                                                                            \
     }
 
     DOCTEST_RELATIONAL_OP(eq, ==)
@@ -1107,33 +1121,31 @@ namespace detail {
 #define DOCTEST_CMP_LT(l, r) l < r
 #define DOCTEST_CMP_GE(l, r) l >= r
 #define DOCTEST_CMP_LE(l, r) l <= r
-#else // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#else  // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 #define DOCTEST_CMP_EQ(l, r) eq(l, r)
 #define DOCTEST_CMP_NE(l, r) ne(l, r)
 #define DOCTEST_CMP_GT(l, r) gt(l, r)
 #define DOCTEST_CMP_LT(l, r) lt(l, r)
 #define DOCTEST_CMP_GE(l, r) ge(l, r)
 #define DOCTEST_CMP_LE(l, r) le(l, r)
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#endif  // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 
     template <typename L>
     // cppcheck-suppress copyCtorAndEqOperator
     struct Expression_lhs
     {
-        L                lhs;
+        L lhs;
         assertType::Enum m_at;
 
-        explicit Expression_lhs(L in, assertType::Enum at)
-                : lhs(in)
-                , m_at(at) {}
+        explicit Expression_lhs(L in, assertType::Enum at) : lhs(in), m_at(at) {}
 
-        DOCTEST_NOINLINE operator Result() {
+        DOCTEST_NOINLINE operator Result()
+        {
             bool res = !!lhs;
-            if(m_at & assertType::is_false) //!OCLINT bitwise operator in conditional
+            if (m_at & assertType::is_false)  //!OCLINT bitwise operator in conditional
                 res = !res;
 
-            if(!res || getContextOptions()->success)
-                return Result(res, toString(lhs));
+            if (!res || getContextOptions()->success) return Result(res, toString(lhs));
             return Result(res);
         }
 
@@ -1175,7 +1187,7 @@ namespace detail {
     DOCTEST_MSVC_SUPPRESS_WARNING_POP
     DOCTEST_GCC_SUPPRESS_WARNING_POP
 
-#endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
+#endif  // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
     struct DOCTEST_INTERFACE ExpressionDecomposer
     {
@@ -1191,7 +1203,8 @@ namespace detail {
         // https://github.com/philsquared/Catch/issues/870
         // https://github.com/philsquared/Catch/issues/565
         template <typename L>
-        Expression_lhs<const DOCTEST_REF_WRAP(L)> operator<<(const DOCTEST_REF_WRAP(L) operand) {
+        Expression_lhs<const DOCTEST_REF_WRAP(L)> operator<<(const DOCTEST_REF_WRAP(L) operand)
+        {
             return Expression_lhs<const DOCTEST_REF_WRAP(L)>(operand, m_at);
         }
     };
@@ -1200,11 +1213,11 @@ namespace detail {
     {
         const char* m_test_suite;
         const char* m_description;
-        bool        m_skip;
-        bool        m_may_fail;
-        bool        m_should_fail;
-        int         m_expected_failures;
-        double      m_timeout;
+        bool m_skip;
+        bool m_may_fail;
+        bool m_should_fail;
+        int m_expected_failures;
+        double m_timeout;
 
         DOCTEST_DECLARE_DEFAULTS(TestSuite);
         DOCTEST_DECLARE_COPIES(TestSuite);
@@ -1212,7 +1225,8 @@ namespace detail {
         TestSuite& operator*(const char* in);
 
         template <typename T>
-        TestSuite& operator*(const T& in) {
+        TestSuite& operator*(const T& in)
+        {
             in.fill(*this);
             return *this;
         }
@@ -1222,27 +1236,28 @@ namespace detail {
 
     struct DOCTEST_INTERFACE TestCase : public TestCaseData
     {
-        funcType m_test; // a function pointer to the test case
+        funcType m_test;  // a function pointer to the test case
 
-        const char* m_type; // for templated test cases - gets appended to the real name
-        int m_template_id; // an ID used to distinguish between the different versions of a templated test case
-        String m_full_name; // contains the name (only for templated test cases!) + the template type
+        const char* m_type;  // for templated test cases - gets appended to the real name
+        int m_template_id;   // an ID used to distinguish between the different versions of a templated test case
+        String m_full_name;  // contains the name (only for templated test cases!) + the template type
 
-        TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                 const char* type = "", int template_id = -1);
+        TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite, const char* type = "",
+                 int template_id = -1);
 
         DOCTEST_DECLARE_DEFAULTS(TestCase);
 
         TestCase(const TestCase& other);
 
-        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
+        DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434)  // hides a non-virtual function
         TestCase& operator=(const TestCase& other);
         DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
         TestCase& operator*(const char* in);
 
         template <typename T>
-        TestCase& operator*(const T& in) {
+        TestCase& operator*(const T& in)
+        {
             in.fill(*this);
             return *this;
         }
@@ -1251,11 +1266,12 @@ namespace detail {
     };
 
     // forward declarations of functions used by the macros
-    DOCTEST_INTERFACE int  regTest(const TestCase& tc);
-    DOCTEST_INTERFACE int  setTestSuite(const TestSuite& ts);
+    DOCTEST_INTERFACE int regTest(const TestCase& tc);
+    DOCTEST_INTERFACE int setTestSuite(const TestSuite& ts);
     DOCTEST_INTERFACE bool isDebuggerActive();
 
-    namespace binaryAssertComparison {
+    namespace binaryAssertComparison
+    {
         enum Enum
         {
             eq = 0,
@@ -1265,7 +1281,7 @@ namespace detail {
             ge,
             le
         };
-    } // namespace binaryAssertComparison
+    }  // namespace binaryAssertComparison
 
     // clang-format off
     template <int, class L, class R> struct RelationalComparator     { bool operator()(const DOCTEST_REF_WRAP(L),     const DOCTEST_REF_WRAP(R)    ) const { return false;        } };
@@ -1292,22 +1308,21 @@ namespace detail {
         void setResult(const Result& res);
 
         template <int comparison, typename L, typename R>
-        DOCTEST_NOINLINE void binary_assert(const DOCTEST_REF_WRAP(L) lhs,
-                                            const DOCTEST_REF_WRAP(R) rhs) {
+        DOCTEST_NOINLINE void binary_assert(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs)
+        {
             m_failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
-            if(m_failed || getContextOptions()->success)
-                m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
+            if (m_failed || getContextOptions()->success) m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
         }
 
         template <typename L>
-        DOCTEST_NOINLINE void unary_assert(const DOCTEST_REF_WRAP(L) val) {
+        DOCTEST_NOINLINE void unary_assert(const DOCTEST_REF_WRAP(L) val)
+        {
             m_failed = !val;
 
-            if(m_at & assertType::is_false) //!OCLINT bitwise operator in conditional
+            if (m_at & assertType::is_false)  //!OCLINT bitwise operator in conditional
                 m_failed = !m_failed;
 
-            if(m_failed || getContextOptions()->success)
-                m_decomp = toString(val);
+            if (m_failed || getContextOptions()->success) m_decomp = toString(val);
         }
 
         void translateException();
@@ -1316,51 +1331,50 @@ namespace detail {
         void react() const;
     };
 
-    namespace assertAction {
+    namespace assertAction
+    {
         enum Enum
         {
-            nothing     = 0,
-            dbgbreak    = 1,
+            nothing = 0,
+            dbgbreak = 1,
             shouldthrow = 2
         };
-    } // namespace assertAction
+    }  // namespace assertAction
 
     DOCTEST_INTERFACE void failed_out_of_a_testing_context(const AssertData& ad);
 
-    DOCTEST_INTERFACE void decomp_assert(assertType::Enum at, const char* file, int line,
-                                         const char* expr, Result result);
+    DOCTEST_INTERFACE void decomp_assert(assertType::Enum at, const char* file, int line, const char* expr,
+                                         Result result);
 
-#define DOCTEST_ASSERT_OUT_OF_TESTS(decomp)                                                        \
-    do {                                                                                           \
-        if(!is_running_in_test) {                                                                  \
-            if(failed) {                                                                           \
-                ResultBuilder rb(at, file, line, expr);                                            \
-                rb.m_failed = failed;                                                              \
-                rb.m_decomp = decomp;                                                              \
-                failed_out_of_a_testing_context(rb);                                               \
-                if(isDebuggerActive() && !getContextOptions()->no_breaks)                          \
-                    DOCTEST_BREAK_INTO_DEBUGGER();                                                 \
-                if(checkIfShouldThrow(at))                                                         \
-                    throwException();                                                              \
-            }                                                                                      \
-            return;                                                                                \
-        }                                                                                          \
-    } while(false)
+#define DOCTEST_ASSERT_OUT_OF_TESTS(decomp)                                                               \
+    do                                                                                                    \
+    {                                                                                                     \
+        if (!is_running_in_test)                                                                          \
+        {                                                                                                 \
+            if (failed)                                                                                   \
+            {                                                                                             \
+                ResultBuilder rb(at, file, line, expr);                                                   \
+                rb.m_failed = failed;                                                                     \
+                rb.m_decomp = decomp;                                                                     \
+                failed_out_of_a_testing_context(rb);                                                      \
+                if (isDebuggerActive() && !getContextOptions()->no_breaks) DOCTEST_BREAK_INTO_DEBUGGER(); \
+                if (checkIfShouldThrow(at)) throwException();                                             \
+            }                                                                                             \
+            return;                                                                                       \
+        }                                                                                                 \
+    } while (false)
 
-#define DOCTEST_ASSERT_IN_TESTS(decomp)                                                            \
-    ResultBuilder rb(at, file, line, expr);                                                        \
-    rb.m_failed = failed;                                                                          \
-    if(rb.m_failed || getContextOptions()->success)                                                \
-        rb.m_decomp = decomp;                                                                      \
-    if(rb.log())                                                                                   \
-        DOCTEST_BREAK_INTO_DEBUGGER();                                                             \
-    if(rb.m_failed && checkIfShouldThrow(at))                                                      \
-    throwException()
+#define DOCTEST_ASSERT_IN_TESTS(decomp)                                    \
+    ResultBuilder rb(at, file, line, expr);                                \
+    rb.m_failed = failed;                                                  \
+    if (rb.m_failed || getContextOptions()->success) rb.m_decomp = decomp; \
+    if (rb.log()) DOCTEST_BREAK_INTO_DEBUGGER();                           \
+    if (rb.m_failed && checkIfShouldThrow(at)) throwException()
 
     template <int comparison, typename L, typename R>
-    DOCTEST_NOINLINE void binary_assert(assertType::Enum at, const char* file, int line,
-                                        const char* expr, const DOCTEST_REF_WRAP(L) lhs,
-                                        const DOCTEST_REF_WRAP(R) rhs) {
+    DOCTEST_NOINLINE void binary_assert(assertType::Enum at, const char* file, int line, const char* expr,
+                                        const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs)
+    {
         bool failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
 
         // ###################################################################################
@@ -1372,11 +1386,12 @@ namespace detail {
     }
 
     template <typename L>
-    DOCTEST_NOINLINE void unary_assert(assertType::Enum at, const char* file, int line,
-                                       const char* expr, const DOCTEST_REF_WRAP(L) val) {
+    DOCTEST_NOINLINE void unary_assert(assertType::Enum at, const char* file, int line, const char* expr,
+                                       const DOCTEST_REF_WRAP(L) val)
+    {
         bool failed = !val;
 
-        if(at & assertType::is_false) //!OCLINT bitwise operator in conditional
+        if (at & assertType::is_false)  //!OCLINT bitwise operator in conditional
             failed = !failed;
 
         // ###################################################################################
@@ -1397,23 +1412,29 @@ namespace detail {
     };
 
     template <typename T>
-    class ExceptionTranslator : public IExceptionTranslator //!OCLINT destructor of virtual class
+    class ExceptionTranslator : public IExceptionTranslator  //!OCLINT destructor of virtual class
     {
     public:
-        explicit ExceptionTranslator(String (*translateFunction)(T))
-                : m_translateFunction(translateFunction) {}
+        explicit ExceptionTranslator(String (*translateFunction)(T)) : m_translateFunction(translateFunction) {}
 
-        bool translate(String& res) const {
+        bool translate(String& res) const
+        {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-            try {
+            try
+            {
                 throw;
                 // cppcheck-suppress catchExceptionByValue
-            } catch(T ex) {                    // NOLINT
-                res = m_translateFunction(ex); //!OCLINT parameter reassignment
+            }
+            catch (T ex)
+            {                                   // NOLINT
+                res = m_translateFunction(ex);  //!OCLINT parameter reassignment
                 return true;
-            } catch(...) {} //!OCLINT -  empty catch statement
-#endif                      // DOCTEST_CONFIG_NO_EXCEPTIONS
-            ((void)res);    // to silence -Wunused-parameter
+            }
+            catch (...)
+            {
+            }             //!OCLINT -  empty catch statement
+#endif                    // DOCTEST_CONFIG_NO_EXCEPTIONS
+            ((void)res);  // to silence -Wunused-parameter
             return false;
         }
 
@@ -1431,7 +1452,8 @@ namespace detail {
     struct StringStreamBase
     {
         template <typename T>
-        static void convert(std::ostream* s, const T& in) {
+        static void convert(std::ostream* s, const T& in)
+        {
             writeStringToStream(s, toString(in));
         }
 
@@ -1444,24 +1466,27 @@ namespace detail {
     struct StringStreamBase<true>
     {
         template <typename T>
-        static void convert(std::ostream* s, const T& in) {
+        static void convert(std::ostream* s, const T& in)
+        {
             *s << in;
         }
     };
 
     template <typename T>
     struct StringStream : public StringStreamBase<has_insertion_operator<T>::value>
-    {};
+    {
+    };
 
     template <typename T>
-    void toStream(std::ostream* s, const T& value) {
+    void toStream(std::ostream* s, const T& value)
+    {
         StringStream<T>::convert(s, value);
     }
 
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
     DOCTEST_INTERFACE void toStream(std::ostream* s, char* in);
     DOCTEST_INTERFACE void toStream(std::ostream* s, const char* in);
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#endif  // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
     DOCTEST_INTERFACE void toStream(std::ostream* s, bool in);
     DOCTEST_INTERFACE void toStream(std::ostream* s, float in);
     DOCTEST_INTERFACE void toStream(std::ostream* s, double in);
@@ -1492,19 +1517,17 @@ namespace detail {
         };
 
         template <typename T>
-        struct Capture : public ICapture //!OCLINT destructor of virtual class
+        struct Capture : public ICapture  //!OCLINT destructor of virtual class
         {
             const T* capture;
 
-            explicit Capture(const T* in)
-                    : capture(in) {}
+            explicit Capture(const T* in) : capture(in) {}
             void toStream(std::ostream* s) const override { detail::toStream(s, *capture); }
         };
 
         struct DOCTEST_INTERFACE Chunk
         {
-            char buf[sizeof(Capture<char>)] DOCTEST_ALIGNMENT(
-                    2 * sizeof(void*)); // place to construct a Capture<T>
+            char buf[sizeof(Capture<char>)] DOCTEST_ALIGNMENT(2 * sizeof(void*));  // place to construct a Capture<T>
 
             DOCTEST_DECLARE_DEFAULTS(Chunk);
             DOCTEST_DELETE_COPIES(Chunk);
@@ -1520,9 +1543,9 @@ namespace detail {
         };
 
         Chunk stackChunks[DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK];
-        int   numCaptures = 0;
-        Node* head        = nullptr;
-        Node* tail        = nullptr;
+        int numCaptures = 0;
+        Node* head = nullptr;
+        Node* tail = nullptr;
 
         ContextBuilder(ContextBuilder& other);
 
@@ -1535,21 +1558,28 @@ namespace detail {
         ~ContextBuilder();
 
         template <typename T>
-        DOCTEST_NOINLINE ContextBuilder& operator<<(T& in) {
+        DOCTEST_NOINLINE ContextBuilder& operator<<(T& in)
+        {
             Capture<T> temp(&in);
 
             // construct either on stack or on heap
             // copy the bytes for the whole object - including the vtable because we cant construct
             // the object directly in the buffer using placement new - need the <new> header...
-            if(numCaptures < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK) {
+            if (numCaptures < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK)
+            {
                 my_memcpy(stackChunks[numCaptures].buf, &temp, sizeof(Chunk));
-            } else {
-                auto curr  = new Node;
+            }
+            else
+            {
+                auto curr = new Node;
                 curr->next = nullptr;
-                if(tail) {
+                if (tail)
+                {
                     tail->next = curr;
-                    tail       = curr;
-                } else {
+                    tail = curr;
+                }
+                else
+                {
                     head = tail = curr;
                 }
 
@@ -1560,7 +1590,8 @@ namespace detail {
         }
 
         template <typename T>
-        ContextBuilder& operator<<(const T&&) {
+        ContextBuilder& operator<<(const T&&)
+        {
             static_assert(deferred_false<T>::value,
                           "Cannot pass temporaries or rvalues to the streaming operator because it "
                           "caches pointers to the passed objects for lazy evaluation!");
@@ -1593,7 +1624,8 @@ namespace detail {
         DOCTEST_DELETE_COPIES(MessageBuilder);
 
         template <typename T>
-        MessageBuilder& operator<<(const T& in) {
+        MessageBuilder& operator<<(const T& in)
+        {
             toStream(m_stream, in);
             return *this;
         }
@@ -1601,16 +1633,15 @@ namespace detail {
         bool log();
         void react();
     };
-} // namespace detail
+}  // namespace detail
 
-#define DOCTEST_DEFINE_DECORATOR(name, type, def)                                                  \
-    struct name                                                                                    \
-    {                                                                                              \
-        type data;                                                                                 \
-        name(type in = def)                                                                        \
-                : data(in) {}                                                                      \
-        void fill(detail::TestCase& state) const { state.DOCTEST_CAT(m_, name) = data; }           \
-        void fill(detail::TestSuite& state) const { state.DOCTEST_CAT(m_, name) = data; }          \
+#define DOCTEST_DEFINE_DECORATOR(name, type, def)                                         \
+    struct name                                                                           \
+    {                                                                                     \
+        type data;                                                                        \
+        name(type in = def) : data(in) {}                                                 \
+        void fill(detail::TestCase& state) const { state.DOCTEST_CAT(m_, name) = data; }  \
+        void fill(detail::TestSuite& state) const { state.DOCTEST_CAT(m_, name) = data; } \
     }
 
 DOCTEST_DEFINE_DECORATOR(test_suite, const char*, "");
@@ -1622,7 +1653,8 @@ DOCTEST_DEFINE_DECORATOR(should_fail, bool, true);
 DOCTEST_DEFINE_DECORATOR(expected_failures, int, 0);
 
 template <typename T>
-int registerExceptionTranslator(String (*translateFunction)(T)) {
+int registerExceptionTranslator(String (*translateFunction)(T))
+{
     DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")
     static detail::ExceptionTranslator<T> exceptionTranslator(translateFunction);
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
@@ -1630,26 +1662,30 @@ int registerExceptionTranslator(String (*translateFunction)(T)) {
     return 0;
 }
 
-} // namespace doctest
+}  // namespace doctest
 
 // in a separate namespace outside of doctest because the DOCTEST_TEST_SUITE macro
 // introduces an anonymous namespace in which getCurrentTestSuite gets overridden
-namespace doctest_detail_test_suite_ns {
+namespace doctest_detail_test_suite_ns
+{
 DOCTEST_INTERFACE doctest::detail::TestSuite& getCurrentTestSuite();
-} // namespace doctest_detail_test_suite_ns
+}  // namespace doctest_detail_test_suite_ns
 
-namespace doctest {
-#else  // DOCTEST_CONFIG_DISABLE
+namespace doctest
+{
+#else   // DOCTEST_CONFIG_DISABLE
 template <typename T>
-int registerExceptionTranslator(String (*)(T)) {
+int registerExceptionTranslator(String (*)(T))
+{
     return 0;
 }
-#endif // DOCTEST_CONFIG_DISABLE
+#endif  // DOCTEST_CONFIG_DISABLE
 
-namespace detail {
+namespace detail
+{
     typedef void (*assert_handler)(const AssertData&);
     struct ContextState;
-} // namespace detail
+}  // namespace detail
 
 class DOCTEST_INTERFACE Context
 {
@@ -1680,31 +1716,32 @@ public:
     int run();
 };
 
-namespace TestCaseFailureReason {
+namespace TestCaseFailureReason
+{
     enum Enum
     {
-        None                     = 0,
-        AssertFailure            = 1,   // an assertion has failed in the test case
-        Exception                = 2,   // test case threw an exception
-        Crash                    = 4,   // a crash...
-        TooManyFailedAsserts     = 8,   // the abort-after option
-        Timeout                  = 16,  // see the timeout decorator
-        ShouldHaveFailedButDidnt = 32,  // see the should_fail decorator
-        ShouldHaveFailedAndDid   = 64,  // see the should_fail decorator
-        DidntFailExactlyNumTimes = 128, // see the expected_failures decorator
-        FailedExactlyNumTimes    = 256, // see the expected_failures decorator
-        CouldHaveFailedAndDid    = 512  // see the may_fail decorator
+        None = 0,
+        AssertFailure = 1,               // an assertion has failed in the test case
+        Exception = 2,                   // test case threw an exception
+        Crash = 4,                       // a crash...
+        TooManyFailedAsserts = 8,        // the abort-after option
+        Timeout = 16,                    // see the timeout decorator
+        ShouldHaveFailedButDidnt = 32,   // see the should_fail decorator
+        ShouldHaveFailedAndDid = 64,     // see the should_fail decorator
+        DidntFailExactlyNumTimes = 128,  // see the expected_failures decorator
+        FailedExactlyNumTimes = 256,     // see the expected_failures decorator
+        CouldHaveFailedAndDid = 512      // see the may_fail decorator
     };
-} // namespace TestCaseFailureReason
+}  // namespace TestCaseFailureReason
 
 struct DOCTEST_INTERFACE CurrentTestCaseStats
 {
-    int    numAssertsForCurrentTestCase;
-    int    numAssertsFailedForCurrentTestCase;
+    int numAssertsForCurrentTestCase;
+    int numAssertsFailedForCurrentTestCase;
     double seconds_so_far;
-    int    failure_flags; // use TestCaseFailureReason::Enum
+    int failure_flags;  // use TestCaseFailureReason::Enum
     String error_string;
-    bool   should_reenter; // means we are not done with the test case because of subcases
+    bool should_reenter;  // means we are not done with the test case because of subcases
 
     DOCTEST_DECLARE_DEFAULTS(CurrentTestCaseStats);
     DOCTEST_DELETE_COPIES(CurrentTestCaseStats);
@@ -1716,8 +1753,8 @@ struct DOCTEST_INTERFACE TestRunStats
     unsigned numTestCasesPassingFilters;
     unsigned numTestSuitesPassingFilters;
     unsigned numTestCasesFailed;
-    int      numAsserts;
-    int      numAssertsFailed;
+    int numAsserts;
+    int numAssertsFailed;
 
     DOCTEST_DECLARE_DEFAULTS(TestRunStats);
     DOCTEST_DELETE_COPIES(TestRunStats);
@@ -1754,214 +1791,226 @@ struct DOCTEST_INTERFACE IReporter
     virtual ~IReporter();
 
     // can obtain all currently active contexts and stringify them if one wishes to do so
-    static int                         get_num_active_contexts();
+    static int get_num_active_contexts();
     static const IContextScope* const* get_active_contexts();
 
     // can iterate through contexts which have been stringified automatically in their destructors when an exception has been thrown
-    static int           get_num_stringified_contexts();
+    static int get_num_stringified_contexts();
     static const String* get_stringified_contexts();
 };
 
 int registerReporter(const char* name, int priority, IReporter& r);
 
-} // namespace doctest
+}  // namespace doctest
 
 // if registering is not disabled
 #if !defined(DOCTEST_CONFIG_DISABLE)
 
 // common code in asserts - for convenience
-#define DOCTEST_ASSERT_LOG_AND_REACT(b)                                                            \
-    if(b.log())                                                                                    \
-        DOCTEST_BREAK_INTO_DEBUGGER();                                                             \
+#define DOCTEST_ASSERT_LOG_AND_REACT(b)         \
+    if (b.log()) DOCTEST_BREAK_INTO_DEBUGGER(); \
     b.react()
 
 #ifdef DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 #define DOCTEST_WRAP_IN_TRY(x) x;
-#else // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
-#define DOCTEST_WRAP_IN_TRY(x)                                                                     \
-    try {                                                                                          \
-        x;                                                                                         \
-    } catch(...) { _DOCTEST_RB.translateException(); }
-#endif // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#else  // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+#define DOCTEST_WRAP_IN_TRY(x)            \
+    try                                   \
+    {                                     \
+        x;                                \
+    }                                     \
+    catch (...)                           \
+    {                                     \
+        _DOCTEST_RB.translateException(); \
+    }
+#endif  // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 
 // registers the test by initializing a dummy var with a function
-#define DOCTEST_REGISTER_FUNCTION(f, decorators)                                                   \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) = doctest::detail::regTest(  \
-            doctest::detail::TestCase(f, __FILE__, __LINE__,                                       \
-                                      doctest_detail_test_suite_ns::getCurrentTestSuite()) *       \
-            decorators);                                                                           \
+#define DOCTEST_REGISTER_FUNCTION(f, decorators)                                                                \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) = doctest::detail::regTest(               \
+        doctest::detail::TestCase(f, __FILE__, __LINE__, doctest_detail_test_suite_ns::getCurrentTestSuite()) * \
+        decorators);                                                                                            \
     DOCTEST_GLOBAL_NO_WARNINGS_END()
 
-#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, decorators)                                     \
-    namespace {                                                                                    \
-        struct der : public base                                                                   \
-        {                                                                                          \
-            void f();                                                                              \
-        };                                                                                         \
-        static void func() {                                                                       \
-            der v;                                                                                 \
-            v.f();                                                                                 \
-        }                                                                                          \
-        DOCTEST_REGISTER_FUNCTION(func, decorators)                                                \
-    }                                                                                              \
+#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, decorators) \
+    namespace                                                  \
+    {                                                          \
+        struct der : public base                               \
+        {                                                      \
+            void f();                                          \
+        };                                                     \
+        static void func()                                     \
+        {                                                      \
+            der v;                                             \
+            v.f();                                             \
+        }                                                      \
+        DOCTEST_REGISTER_FUNCTION(func, decorators)            \
+    }                                                          \
     inline DOCTEST_NOINLINE void der::f()
 
-#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators)                                        \
-    static void f();                                                                               \
-    DOCTEST_REGISTER_FUNCTION(f, decorators)                                                       \
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators) \
+    static void f();                                        \
+    DOCTEST_REGISTER_FUNCTION(f, decorators)                \
     static void f()
 
 // for registering tests
-#define DOCTEST_TEST_CASE(decorators)                                                              \
+#define DOCTEST_TEST_CASE(decorators) \
     DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), decorators)
 
 // for registering tests with a fixture
-#define DOCTEST_TEST_CASE_FIXTURE(c, decorators)                                                   \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), c,                          \
-                              DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), decorators)
+#define DOCTEST_TEST_CASE_FIXTURE(c, decorators)                                                                  \
+    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), c, DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), \
+                              decorators)
 
 // for converting types to strings without the <typeinfo> header and demangling
-#define DOCTEST_TYPE_TO_STRING_IMPL(...)                                                           \
-    template <>                                                                                    \
-    inline const char* type_to_string<__VA_ARGS__>() {                                             \
-        return "<" #__VA_ARGS__ ">";                                                               \
+#define DOCTEST_TYPE_TO_STRING_IMPL(...)             \
+    template <>                                      \
+    inline const char* type_to_string<__VA_ARGS__>() \
+    {                                                \
+        return "<" #__VA_ARGS__ ">";                 \
     }
-#define DOCTEST_TYPE_TO_STRING(...)                                                                \
-    namespace doctest { namespace detail {                                                         \
-            DOCTEST_TYPE_TO_STRING_IMPL(__VA_ARGS__)                                               \
-        }                                                                                          \
-    }                                                                                              \
+#define DOCTEST_TYPE_TO_STRING(...)                  \
+    namespace doctest                                \
+    {                                                \
+        namespace detail                             \
+        {                                            \
+            DOCTEST_TYPE_TO_STRING_IMPL(__VA_ARGS__) \
+        }                                            \
+    }                                                \
     typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 // for typed tests
-#define DOCTEST_REGISTER_TYPED_TEST_CASE_IMPL(func, type, decorators, idx)                         \
-    doctest::detail::regTest(                                                                      \
-            doctest::detail::TestCase(func, __FILE__, __LINE__,                                    \
-                                      doctest_detail_test_suite_ns::getCurrentTestSuite(),         \
-                                      doctest::detail::type_to_string<type>(), idx) *              \
-            decorators)
+#define DOCTEST_REGISTER_TYPED_TEST_CASE_IMPL(func, type, decorators, idx)                                  \
+    doctest::detail::regTest(doctest::detail::TestCase(func, __FILE__, __LINE__,                            \
+                                                       doctest_detail_test_suite_ns::getCurrentTestSuite(), \
+                                                       doctest::detail::type_to_string<type>(), idx) *      \
+                             decorators)
 
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, id, anon)                                   \
-    template <typename T>                                                                          \
-    inline void anon();                                                                            \
-    template <typename Type, typename... Rest>                                                     \
-    struct DOCTEST_CAT(id, ITERATOR)                                                               \
-    {                                                                                              \
-        DOCTEST_CAT(id, ITERATOR)(int line, int index) {                                           \
-            DOCTEST_REGISTER_TYPED_TEST_CASE_IMPL(anon<Type>, Type, dec, line * 1000 + index);     \
-            DOCTEST_CAT(id, ITERATOR)<Rest...>(line, index + 1);                                   \
-        }                                                                                          \
-    };                                                                                             \
-    template <typename Type>                                                                       \
-    struct DOCTEST_CAT(id, ITERATOR)<Type>                                                         \
-    {                                                                                              \
-        DOCTEST_CAT(id, ITERATOR)(int line, int index) {                                           \
-            DOCTEST_REGISTER_TYPED_TEST_CASE_IMPL(anon<Type>, Type, dec, line * 1000 + index);     \
-        }                                                                                          \
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, id, anon)                               \
+    template <typename T>                                                                      \
+    inline void anon();                                                                        \
+    template <typename Type, typename... Rest>                                                 \
+    struct DOCTEST_CAT(id, ITERATOR)                                                           \
+    {                                                                                          \
+        DOCTEST_CAT(id, ITERATOR)(int line, int index)                                         \
+        {                                                                                      \
+            DOCTEST_REGISTER_TYPED_TEST_CASE_IMPL(anon<Type>, Type, dec, line * 1000 + index); \
+            DOCTEST_CAT(id, ITERATOR)<Rest...>(line, index + 1);                               \
+        }                                                                                      \
+    };                                                                                         \
+    template <typename Type>                                                                   \
+    struct DOCTEST_CAT(id, ITERATOR)<Type>                                                     \
+    {                                                                                          \
+        DOCTEST_CAT(id, ITERATOR)(int line, int index)                                         \
+        {                                                                                      \
+            DOCTEST_REGISTER_TYPED_TEST_CASE_IMPL(anon<Type>, Type, dec, line * 1000 + index); \
+        }                                                                                      \
     }
 
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL_PROXY(dec, T, id, anon)                             \
-    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, id, anon);                                      \
-    template <typename T>                                                                          \
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL_PROXY(dec, T, id, anon) \
+    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, id, anon);          \
+    template <typename T>                                              \
     inline void anon()
 
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(dec, T, id)                                              \
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(dec, T, id) \
     DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL_PROXY(dec, T, id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
 
-#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, anon, ...)                                 \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) = []() {                                  \
-        DOCTEST_CAT(id, ITERATOR)<__VA_ARGS__> DOCTEST_UNUSED DOCTEST_CAT(anon, inner_dummy)(      \
-                __LINE__, 0);                                                                      \
-        return 0;                                                                                  \
-    }();                                                                                           \
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, anon, ...)                                         \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) = []()                                            \
+    {                                                                                                      \
+        DOCTEST_CAT(id, ITERATOR)<__VA_ARGS__> DOCTEST_UNUSED DOCTEST_CAT(anon, inner_dummy)(__LINE__, 0); \
+        return 0;                                                                                          \
+    }();                                                                                                   \
     DOCTEST_GLOBAL_NO_WARNINGS_END()
 
-#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...)                                            \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_),         \
-                                                __VA_ARGS__)                                       \
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...)                                                 \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), __VA_ARGS__) \
     typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
-#define DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, anon, ...)                                         \
-    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL_PROXY(dec, T, anon, anon);                              \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(anon, anon, __VA_ARGS__)                           \
-    template <typename T>                                                                          \
+#define DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, anon, ...)               \
+    DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL_PROXY(dec, T, anon, anon);    \
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(anon, anon, __VA_ARGS__) \
+    template <typename T>                                                \
     inline void anon()
 
-#define DOCTEST_TEST_CASE_TEMPLATE(dec, T, ...)                                                    \
+#define DOCTEST_TEST_CASE_TEMPLATE(dec, T, ...) \
     DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), __VA_ARGS__)
 
 // for subcases
-#define DOCTEST_SUBCASE(name)                                                                      \
-    if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED = \
-               doctest::detail::Subcase(name, __FILE__, __LINE__))
+#define DOCTEST_SUBCASE(name)                                                                       \
+    if (const doctest::detail::Subcase & DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED = \
+            doctest::detail::Subcase(name, __FILE__, __LINE__))
 
 // for grouping tests in test suites by using code blocks
-#define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                               \
-    namespace ns_name { namespace doctest_detail_test_suite_ns {                                   \
-            static DOCTEST_NOINLINE doctest::detail::TestSuite& getCurrentTestSuite() {            \
-                DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4640)                                      \
-                DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")                \
-                static doctest::detail::TestSuite data;                                            \
-                static bool                       inited = false;                                  \
-                DOCTEST_MSVC_SUPPRESS_WARNING_POP                                                  \
-                DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                 \
-                if(!inited) {                                                                      \
-                    data* decorators;                                                              \
-                    inited = true;                                                                 \
-                }                                                                                  \
-                return data;                                                                       \
-            }                                                                                      \
-        }                                                                                          \
-    }                                                                                              \
+#define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                  \
+    namespace ns_name                                                                 \
+    {                                                                                 \
+        namespace doctest_detail_test_suite_ns                                        \
+        {                                                                             \
+            static DOCTEST_NOINLINE doctest::detail::TestSuite& getCurrentTestSuite() \
+            {                                                                         \
+                DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4640)                         \
+                DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")   \
+                static doctest::detail::TestSuite data;                               \
+                static bool inited = false;                                           \
+                DOCTEST_MSVC_SUPPRESS_WARNING_POP                                     \
+                DOCTEST_CLANG_SUPPRESS_WARNING_POP                                    \
+                if (!inited)                                                          \
+                {                                                                     \
+                    data* decorators;                                                 \
+                    inited = true;                                                    \
+                }                                                                     \
+                return data;                                                          \
+            }                                                                         \
+        }                                                                             \
+    }                                                                                 \
     namespace ns_name
 
-#define DOCTEST_TEST_SUITE(decorators)                                                             \
-    DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUITE_))
+#define DOCTEST_TEST_SUITE(decorators) DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUITE_))
 
 // for starting a testsuite block
-#define DOCTEST_TEST_SUITE_BEGIN(decorators)                                                       \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =                            \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators);              \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
+#define DOCTEST_TEST_SUITE_BEGIN(decorators)                                      \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =           \
+        doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators); \
+    DOCTEST_GLOBAL_NO_WARNINGS_END()                                              \
     typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 // for ending a testsuite block
-#define DOCTEST_TEST_SUITE_END                                                                     \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =                            \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * "");                      \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
+#define DOCTEST_TEST_SUITE_END                                            \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =   \
+        doctest::detail::setTestSuite(doctest::detail::TestSuite() * ""); \
+    DOCTEST_GLOBAL_NO_WARNINGS_END()                                      \
     typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 // for registering exception translators
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature)                      \
-    inline doctest::String translatorName(signature);                                              \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_)) =                     \
-            doctest::registerExceptionTranslator(translatorName);                                  \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature)  \
+    inline doctest::String translatorName(signature);                          \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_)) = \
+        doctest::registerExceptionTranslator(translatorName);                  \
+    DOCTEST_GLOBAL_NO_WARNINGS_END()                                           \
     doctest::String translatorName(signature)
 
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
-    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_),       \
-                                               signature)
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature) \
+    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_), signature)
 
 // for registering
-#define DOCTEST_REGISTER_REPORTER(name, priority, reporter)                                        \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_REPORTER_)) =                       \
-            doctest::registerReporter(name, priority, reporter);                                   \
+#define DOCTEST_REGISTER_REPORTER(name, priority, reporter)                  \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_REPORTER_)) = \
+        doctest::registerReporter(name, priority, reporter);                 \
     DOCTEST_GLOBAL_NO_WARNINGS_END() typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 // for logging
-#define DOCTEST_INFO(x)                                                                            \
-    doctest::detail::ContextScope DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_)(                            \
-            doctest::detail::ContextBuilder() << x)
+#define DOCTEST_INFO(x) \
+    doctest::detail::ContextScope DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_)(doctest::detail::ContextBuilder() << x)
 #define DOCTEST_CAPTURE(x) DOCTEST_INFO(#x " := " << x)
 
-#define DOCTEST_ADD_AT_IMPL(type, file, line, mb, x)                                               \
-    do {                                                                                           \
-        doctest::detail::MessageBuilder mb(file, line, doctest::assertType::type);                 \
-        mb << x;                                                                                   \
-        DOCTEST_ASSERT_LOG_AND_REACT(mb);                                                          \
-    } while((void)0, 0)
+#define DOCTEST_ADD_AT_IMPL(type, file, line, mb, x)                               \
+    do                                                                             \
+    {                                                                              \
+        doctest::detail::MessageBuilder mb(file, line, doctest::assertType::type); \
+        mb << x;                                                                   \
+        DOCTEST_ASSERT_LOG_AND_REACT(mb);                                          \
+    } while ((void)0, 0)
 
 // clang-format off
 #define DOCTEST_ADD_MESSAGE_AT(file, line, x) DOCTEST_ADD_AT_IMPL(is_warn, file, line, DOCTEST_ANONYMOUS(_DOCTEST_MESSAGE_), x)
@@ -1978,37 +2027,35 @@ int registerReporter(const char* name, int priority, IReporter& r);
 template <class T, T x>
 constexpr T to_lvalue = x;
 #define DOCTEST_TO_LVALUE(...) to_lvalue<decltype(__VA_ARGS__), __VA_ARGS__>
-#else // TO_LVALUE
+#else  // TO_LVALUE
 #define DOCTEST_TO_LVALUE(...) TO_LVALUE_CAN_BE_USED_ONLY_IN_CPP14_MODE_OR_WITH_VS_2017_OR_NEWER
-#endif // TO_LVALUE
+#endif  // TO_LVALUE
 
 #ifndef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
-#define DOCTEST_ASSERT_IMPLEMENT_2(assert_type, ...)                                               \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                  \
-    doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__,         \
-                                               __LINE__, #__VA_ARGS__);                            \
-    DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.setResult(                                                     \
-            doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type)                \
-            << __VA_ARGS__))                                                                       \
-    DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB)                                                      \
+#define DOCTEST_ASSERT_IMPLEMENT_2(assert_type, ...)                                                                   \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                                      \
+    doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__);    \
+    DOCTEST_WRAP_IN_TRY(                                                                                               \
+        _DOCTEST_RB.setResult(doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type) << __VA_ARGS__)) \
+    DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB)                                                                          \
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
-#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                               \
-    do {                                                                                           \
-        DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__);                                      \
-    } while((void)0, 0)
+#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)          \
+    do                                                        \
+    {                                                         \
+        DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__); \
+    } while ((void)0, 0)
 
-#else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#else  // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
-#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                               \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                  \
-    doctest::detail::decomp_assert(                                                                \
-            doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__,                    \
-            doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type)                \
-                    << __VA_ARGS__) DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                          \
+    doctest::detail::decomp_assert(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__,     \
+                                   doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type) \
+                                       << __VA_ARGS__) DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
-#endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#endif  // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
 #define DOCTEST_WARN(...) DOCTEST_ASSERT_IMPLEMENT_1(DT_WARN, __VA_ARGS__)
 #define DOCTEST_CHECK(...) DOCTEST_ASSERT_IMPLEMENT_1(DT_CHECK, __VA_ARGS__)
@@ -2026,55 +2073,81 @@ constexpr T to_lvalue = x;
 #define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, msg) do { DOCTEST_INFO(msg); DOCTEST_ASSERT_IMPLEMENT_2(DT_REQUIRE_FALSE, cond); } while((void)0, 0)
 // clang-format on
 
-#define DOCTEST_ASSERT_THROWS(expr, assert_type)                                                   \
-    do {                                                                                           \
-        if(!doctest::getContextOptions()->no_throw) {                                              \
-            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, \
-                                                       __LINE__, #expr);                           \
-            try {                                                                                  \
-                expr;                                                                              \
-            } catch(...) { _DOCTEST_RB.m_threw = true; }                                           \
-            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                             \
-        }                                                                                          \
-    } while((void)0, 0)
+#define DOCTEST_ASSERT_THROWS(expr, assert_type)                                                                     \
+    do                                                                                                               \
+    {                                                                                                                \
+        if (!doctest::getContextOptions()->no_throw)                                                                 \
+        {                                                                                                            \
+            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #expr); \
+            try                                                                                                      \
+            {                                                                                                        \
+                expr;                                                                                                \
+            }                                                                                                        \
+            catch (...)                                                                                              \
+            {                                                                                                        \
+                _DOCTEST_RB.m_threw = true;                                                                          \
+            }                                                                                                        \
+            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
+        }                                                                                                            \
+    } while ((void)0, 0)
 
-#define DOCTEST_ASSERT_THROWS_AS(expr, assert_type, ...)                                           \
-    do {                                                                                           \
-        if(!doctest::getContextOptions()->no_throw) {                                              \
-            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, \
-                                                       __LINE__, #expr, #__VA_ARGS__);             \
-            try {                                                                                  \
-                expr;                                                                              \
-            } catch(const doctest::detail::remove_const<                                           \
-                    doctest::detail::remove_reference<__VA_ARGS__>::type>::type&) {                \
-                _DOCTEST_RB.m_threw    = true;                                                     \
-                _DOCTEST_RB.m_threw_as = true;                                                     \
-            } catch(...) { _DOCTEST_RB.translateException(); }                                     \
-            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                             \
-        }                                                                                          \
-    } while((void)0, 0)
+#define DOCTEST_ASSERT_THROWS_AS(expr, assert_type, ...)                                                             \
+    do                                                                                                               \
+    {                                                                                                                \
+        if (!doctest::getContextOptions()->no_throw)                                                                 \
+        {                                                                                                            \
+            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #expr,  \
+                                                       #__VA_ARGS__);                                                \
+            try                                                                                                      \
+            {                                                                                                        \
+                expr;                                                                                                \
+            }                                                                                                        \
+            catch (const doctest::detail::remove_const<doctest::detail::remove_reference<__VA_ARGS__>::type>::type&) \
+            {                                                                                                        \
+                _DOCTEST_RB.m_threw = true;                                                                          \
+                _DOCTEST_RB.m_threw_as = true;                                                                       \
+            }                                                                                                        \
+            catch (...)                                                                                              \
+            {                                                                                                        \
+                _DOCTEST_RB.translateException();                                                                    \
+            }                                                                                                        \
+            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
+        }                                                                                                            \
+    } while ((void)0, 0)
 
-#define DOCTEST_ASSERT_THROWS_WITH(expr, assert_type, ...)                                         \
-    do {                                                                                           \
-        if(!doctest::getContextOptions()->no_throw) {                                              \
-            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, \
-                                                       __LINE__, #expr, __VA_ARGS__);              \
-            try {                                                                                  \
-                expr;                                                                              \
-            } catch(...) { _DOCTEST_RB.translateException(); }                                     \
-            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                             \
-        }                                                                                          \
-    } while((void)0, 0)
+#define DOCTEST_ASSERT_THROWS_WITH(expr, assert_type, ...)                                                          \
+    do                                                                                                              \
+    {                                                                                                               \
+        if (!doctest::getContextOptions()->no_throw)                                                                \
+        {                                                                                                           \
+            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #expr, \
+                                                       __VA_ARGS__);                                                \
+            try                                                                                                     \
+            {                                                                                                       \
+                expr;                                                                                               \
+            }                                                                                                       \
+            catch (...)                                                                                             \
+            {                                                                                                       \
+                _DOCTEST_RB.translateException();                                                                   \
+            }                                                                                                       \
+            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                              \
+        }                                                                                                           \
+    } while ((void)0, 0)
 
-#define DOCTEST_ASSERT_NOTHROW(expr, assert_type)                                                  \
-    do {                                                                                           \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__,     \
-                                                   __LINE__, #expr);                               \
-        try {                                                                                      \
-            expr;                                                                                  \
-        } catch(...) { _DOCTEST_RB.translateException(); }                                         \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
-    } while((void)0, 0)
+#define DOCTEST_ASSERT_NOTHROW(expr, assert_type)                                                                \
+    do                                                                                                           \
+    {                                                                                                            \
+        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, #expr); \
+        try                                                                                                      \
+        {                                                                                                        \
+            expr;                                                                                                \
+        }                                                                                                        \
+        catch (...)                                                                                              \
+        {                                                                                                        \
+            _DOCTEST_RB.translateException();                                                                    \
+        }                                                                                                        \
+        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                               \
+    } while ((void)0, 0)
 
 // clang-format off
 #define DOCTEST_WARN_THROWS(expr) DOCTEST_ASSERT_THROWS(expr, DT_WARN_THROWS)
@@ -2109,35 +2182,34 @@ constexpr T to_lvalue = x;
 
 #ifndef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
-#define DOCTEST_BINARY_ASSERT(assert_type, comp, ...)                                              \
-    do {                                                                                           \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__,     \
-                                                   __LINE__, #__VA_ARGS__);                        \
-        DOCTEST_WRAP_IN_TRY(                                                                       \
-                _DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(          \
-                        __VA_ARGS__))                                                              \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
-    } while((void)0, 0)
+#define DOCTEST_BINARY_ASSERT(assert_type, comp, ...)                                                              \
+    do                                                                                                             \
+    {                                                                                                              \
+        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__,           \
+                                                   #__VA_ARGS__);                                                  \
+        DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(__VA_ARGS__)) \
+        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                                 \
+    } while ((void)0, 0)
 
-#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
-    do {                                                                                           \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__,     \
-                                                   __LINE__, #__VA_ARGS__);                        \
-        DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.unary_assert(__VA_ARGS__))                                 \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
-    } while((void)0, 0)
+#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                           \
+    do                                                                                                   \
+    {                                                                                                    \
+        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, __LINE__, \
+                                                   #__VA_ARGS__);                                        \
+        DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.unary_assert(__VA_ARGS__))                                       \
+        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                       \
+    } while ((void)0, 0)
 
-#else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#else  // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
-#define DOCTEST_BINARY_ASSERT(assert_type, comparison, ...)                                        \
-    doctest::detail::binary_assert<doctest::detail::binaryAssertComparison::comparison>(           \
-            doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__)
+#define DOCTEST_BINARY_ASSERT(assert_type, comparison, ...)                              \
+    doctest::detail::binary_assert<doctest::detail::binaryAssertComparison::comparison>( \
+        doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__)
 
-#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
-    doctest::detail::unary_assert(doctest::assertType::assert_type, __FILE__, __LINE__,            \
-                                  #__VA_ARGS__, __VA_ARGS__)
+#define DOCTEST_UNARY_ASSERT(assert_type, ...) \
+    doctest::detail::unary_assert(doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__)
 
-#endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+#endif  // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
 #define DOCTEST_WARN_EQ(...) DOCTEST_BINARY_ASSERT(DT_WARN_EQ, eq, __VA_ARGS__)
 #define DOCTEST_CHECK_EQ(...) DOCTEST_BINARY_ASSERT(DT_CHECK_EQ, eq, __VA_ARGS__)
@@ -2221,7 +2293,7 @@ constexpr T to_lvalue = x;
 #define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) ((void)0)
 #define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) ((void)0)
 
-#else // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#else  // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
 #undef DOCTEST_REQUIRE
 #undef DOCTEST_REQUIRE_FALSE
@@ -2236,53 +2308,53 @@ constexpr T to_lvalue = x;
 #undef DOCTEST_REQUIRE_UNARY
 #undef DOCTEST_REQUIRE_UNARY_FALSE
 
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#endif  // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+#endif  // DOCTEST_CONFIG_NO_EXCEPTIONS
 
 // =================================================================================================
 // == WHAT FOLLOWS IS VERSIONS OF THE MACROS THAT DO NOT DO ANY REGISTERING!                      ==
 // == THIS CAN BE ENABLED BY DEFINING DOCTEST_CONFIG_DISABLE GLOBALLY!                            ==
 // =================================================================================================
-#else // DOCTEST_CONFIG_DISABLE
+#else  // DOCTEST_CONFIG_DISABLE
 
-#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name)                                           \
-    namespace {                                                                                    \
-        template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                           \
-        struct der : public base                                                                   \
-        { void f(); };                                                                             \
-    }                                                                                              \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name) \
+    namespace                                            \
+    {                                                    \
+        template <typename DOCTEST_UNUSED_TEMPLATE_TYPE> \
+        struct der : public base                         \
+        {                                                \
+            void f();                                    \
+        };                                               \
+    }                                                    \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>     \
     inline void der<DOCTEST_UNUSED_TEMPLATE_TYPE>::f()
 
-#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name)                                              \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name) \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>  \
     static inline void f()
 
 // for registering tests
-#define DOCTEST_TEST_CASE(name)                                                                    \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
+#define DOCTEST_TEST_CASE(name) DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
 
 // for registering tests with a fixture
-#define DOCTEST_TEST_CASE_FIXTURE(x, name)                                                         \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), x,                          \
-                              DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
+#define DOCTEST_TEST_CASE_FIXTURE(x, name) \
+    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), x, DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
 
 // for converting types to strings without the <typeinfo> header and demangling
 #define DOCTEST_TYPE_TO_STRING(...) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 #define DOCTEST_TYPE_TO_STRING_IMPL(...)
 
 // for typed tests
-#define DOCTEST_TEST_CASE_TEMPLATE(name, type, ...)                                                \
-    template <typename type>                                                                       \
+#define DOCTEST_TEST_CASE_TEMPLATE(name, type, ...) \
+    template <typename type>                        \
     inline void DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_)()
 
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id)                                          \
-    template <typename type>                                                                       \
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id) \
+    template <typename type>                              \
     inline void DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_)()
 
-#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...)                                            \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
 // for subcases
 #define DOCTEST_SUBCASE(name)
@@ -2296,8 +2368,8 @@ constexpr T to_lvalue = x;
 // for ending a testsuite block
 #define DOCTEST_TEST_SUITE_END typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
 
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature) \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>     \
     static inline doctest::String DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_)(signature)
 
 #define DOCTEST_REGISTER_REPORTER(name, priority, reporter)
@@ -2377,7 +2449,7 @@ constexpr T to_lvalue = x;
 #define DOCTEST_CHECK_UNARY_FALSE(...) ((void)0)
 #define DOCTEST_REQUIRE_UNARY_FALSE(...) ((void)0)
 
-#endif // DOCTEST_CONFIG_DISABLE
+#endif  // DOCTEST_CONFIG_DISABLE
 
 // clang-format off
 // KEPT FOR BACKWARDS COMPATIBILITY - FORWARDING TO THE RIGHT MACROS
@@ -2544,7 +2616,7 @@ constexpr T to_lvalue = x;
 #define FAST_CHECK_UNARY_FALSE DOCTEST_FAST_CHECK_UNARY_FALSE
 #define FAST_REQUIRE_UNARY_FALSE DOCTEST_FAST_REQUIRE_UNARY_FALSE
 
-#endif // DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
+#endif  // DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
 
 #if !defined(DOCTEST_CONFIG_DISABLE)
 
@@ -2552,7 +2624,10 @@ constexpr T to_lvalue = x;
 DOCTEST_TEST_SUITE_END();
 
 // add stringification for primitive/fundamental types
-namespace doctest { namespace detail {
+namespace doctest
+{
+namespace detail
+{
     DOCTEST_TYPE_TO_STRING_IMPL(bool)
     DOCTEST_TYPE_TO_STRING_IMPL(float)
     DOCTEST_TYPE_TO_STRING_IMPL(double)
@@ -2569,19 +2644,20 @@ namespace doctest { namespace detail {
     DOCTEST_TYPE_TO_STRING_IMPL(unsigned long int)
     DOCTEST_TYPE_TO_STRING_IMPL(long long int)
     DOCTEST_TYPE_TO_STRING_IMPL(unsigned long long int)
-}} // namespace doctest::detail
+}  // namespace detail
+}  // namespace doctest
 
-#endif // DOCTEST_CONFIG_DISABLE
+#endif  // DOCTEST_CONFIG_DISABLE
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_GCC_SUPPRESS_WARNING_POP
 
-#endif // DOCTEST_LIBRARY_INCLUDED
+#endif  // DOCTEST_LIBRARY_INCLUDED
 
 #ifndef DOCTEST_SINGLE_HEADER
 #define DOCTEST_SINGLE_HEADER
-#endif // DOCTEST_SINGLE_HEADER
+#endif  // DOCTEST_SINGLE_HEADER
 
 #if defined(DOCTEST_CONFIG_IMPLEMENT) || !defined(DOCTEST_SINGLE_HEADER)
 #ifndef DOCTEST_LIBRARY_IMPLEMENTATION
@@ -2589,7 +2665,7 @@ DOCTEST_GCC_SUPPRESS_WARNING_POP
 
 #ifndef DOCTEST_SINGLE_HEADER
 #include "doctest_fwd.h"
-#endif // DOCTEST_SINGLE_HEADER
+#endif  // DOCTEST_SINGLE_HEADER
 
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")
@@ -2633,31 +2709,31 @@ DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-local-typedefs")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")
 
 DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-DOCTEST_MSVC_SUPPRESS_WARNING(4616) // invalid compiler warning
-DOCTEST_MSVC_SUPPRESS_WARNING(4619) // invalid compiler warning
-DOCTEST_MSVC_SUPPRESS_WARNING(4996) // The compiler encountered a deprecated declaration
-DOCTEST_MSVC_SUPPRESS_WARNING(4267) // 'var' : conversion from 'x' to 'y', possible loss of data
-DOCTEST_MSVC_SUPPRESS_WARNING(4706) // assignment within conditional expression
-DOCTEST_MSVC_SUPPRESS_WARNING(4512) // 'class' : assignment operator could not be generated
-DOCTEST_MSVC_SUPPRESS_WARNING(4127) // conditional expression is constant
-DOCTEST_MSVC_SUPPRESS_WARNING(4530) // C++ exception handler used, but unwind semantics not enabled
-DOCTEST_MSVC_SUPPRESS_WARNING(4577) // 'noexcept' used with no exception handling mode specified
-DOCTEST_MSVC_SUPPRESS_WARNING(4774) // format string expected in argument is not a string literal
-DOCTEST_MSVC_SUPPRESS_WARNING(4365) // conversion from 'int' to 'unsigned', signed/unsigned mismatch
-DOCTEST_MSVC_SUPPRESS_WARNING(4820) // padding in structs
-DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is not thread-safe
-DOCTEST_MSVC_SUPPRESS_WARNING(5039) // pointer to potentially throwing function passed to extern C
-DOCTEST_MSVC_SUPPRESS_WARNING(5045) // Spectre mitigation stuff
-DOCTEST_MSVC_SUPPRESS_WARNING(4626) // assignment operator was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(5027) // move assignment operator was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(5026) // move constructor was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(4625) // copy constructor was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(4800) // forcing value to bool 'true' or 'false' (performance warning)
+DOCTEST_MSVC_SUPPRESS_WARNING(4616)  // invalid compiler warning
+DOCTEST_MSVC_SUPPRESS_WARNING(4619)  // invalid compiler warning
+DOCTEST_MSVC_SUPPRESS_WARNING(4996)  // The compiler encountered a deprecated declaration
+DOCTEST_MSVC_SUPPRESS_WARNING(4267)  // 'var' : conversion from 'x' to 'y', possible loss of data
+DOCTEST_MSVC_SUPPRESS_WARNING(4706)  // assignment within conditional expression
+DOCTEST_MSVC_SUPPRESS_WARNING(4512)  // 'class' : assignment operator could not be generated
+DOCTEST_MSVC_SUPPRESS_WARNING(4127)  // conditional expression is constant
+DOCTEST_MSVC_SUPPRESS_WARNING(4530)  // C++ exception handler used, but unwind semantics not enabled
+DOCTEST_MSVC_SUPPRESS_WARNING(4577)  // 'noexcept' used with no exception handling mode specified
+DOCTEST_MSVC_SUPPRESS_WARNING(4774)  // format string expected in argument is not a string literal
+DOCTEST_MSVC_SUPPRESS_WARNING(4365)  // conversion from 'int' to 'unsigned', signed/unsigned mismatch
+DOCTEST_MSVC_SUPPRESS_WARNING(4820)  // padding in structs
+DOCTEST_MSVC_SUPPRESS_WARNING(4640)  // construction of local static object is not thread-safe
+DOCTEST_MSVC_SUPPRESS_WARNING(5039)  // pointer to potentially throwing function passed to extern C
+DOCTEST_MSVC_SUPPRESS_WARNING(5045)  // Spectre mitigation stuff
+DOCTEST_MSVC_SUPPRESS_WARNING(4626)  // assignment operator was implicitly defined as deleted
+DOCTEST_MSVC_SUPPRESS_WARNING(5027)  // move assignment operator was implicitly defined as deleted
+DOCTEST_MSVC_SUPPRESS_WARNING(5026)  // move constructor was implicitly defined as deleted
+DOCTEST_MSVC_SUPPRESS_WARNING(4625)  // copy constructor was implicitly defined as deleted
+DOCTEST_MSVC_SUPPRESS_WARNING(4800)  // forcing value to bool 'true' or 'false' (performance warning)
 // static analysis
-DOCTEST_MSVC_SUPPRESS_WARNING(26439) // This kind of function may not throw. Declare it 'noexcept'
-DOCTEST_MSVC_SUPPRESS_WARNING(26495) // Always initialize a member variable
-DOCTEST_MSVC_SUPPRESS_WARNING(26451) // Arithmetic overflow ...
-DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom construction and dtor...
+DOCTEST_MSVC_SUPPRESS_WARNING(26439)  // This kind of function may not throw. Declare it 'noexcept'
+DOCTEST_MSVC_SUPPRESS_WARNING(26495)  // Always initialize a member variable
+DOCTEST_MSVC_SUPPRESS_WARNING(26451)  // Arithmetic overflow ...
+DOCTEST_MSVC_SUPPRESS_WARNING(26444)  // Avoid unnamed objects with custom construction and dtor...
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 
@@ -2668,7 +2744,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 // borland (Embarcadero) compiler requires math.h and not cmath - https://github.com/onqtam/doctest/pull/37
 #ifdef __BORLANDC__
 #include <math.h>
-#endif // __BORLANDC__
+#endif  // __BORLANDC__
 #include <new>
 #include <cstdio>
 #include <cstdlib>
@@ -2688,7 +2764,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <stdexcept>
 #ifdef DOCTEST_CONFIG_POSIX_SIGNALS
 #include <csignal>
-#endif // DOCTEST_CONFIG_POSIX_SIGNALS
+#endif  // DOCTEST_CONFIG_POSIX_SIGNALS
 #include <cfloat>
 #include <cctype>
 #include <cstdint>
@@ -2697,7 +2773,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <sys/types.h>
 #include <unistd.h>
 #include <sys/sysctl.h>
-#endif // DOCTEST_PLATFORM_MAC
+#endif  // DOCTEST_PLATFORM_MAC
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
@@ -2706,9 +2782,9 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
 #ifdef DOCTEST_CONFIG_DISABLE
 #define DOCTEST_BRANCH_ON_DISABLED(if_disabled, if_not_disabled) if_disabled
-#else // DOCTEST_CONFIG_DISABLE
+#else  // DOCTEST_CONFIG_DISABLE
 #define DOCTEST_BRANCH_ON_DISABLED(if_disabled, if_not_disabled) if_not_disabled
-#endif // DOCTEST_CONFIG_DISABLE
+#endif  // DOCTEST_CONFIG_DISABLE
 
 #ifndef DOCTEST_CONFIG_OPTIONS_PREFIX
 #define DOCTEST_CONFIG_OPTIONS_PREFIX "dt-"
@@ -2724,30 +2800,34 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #define DOCTEST_OPTIONS_PREFIX_DISPLAY ""
 #endif
 
-namespace doctest {
+namespace doctest
+{
 
 bool is_running_in_test = false;
 
-namespace {
+namespace
+{
     using namespace detail;
     // case insensitive strcmp
-    int stricmp(const char* a, const char* b) {
-        for(;; a++, b++) {
+    int stricmp(const char* a, const char* b)
+    {
+        for (;; a++, b++)
+        {
             const int d = tolower(*a) - tolower(*b);
-            if(d != 0 || !*a)
-                return d;
+            if (d != 0 || !*a) return d;
         }
     }
 
     template <typename T>
-    String fpToString(T value, int precision) {
+    String fpToString(T value, int precision)
+    {
         std::ostringstream oss;
         oss << std::setprecision(precision) << std::fixed << value;
         std::string d = oss.str();
-        size_t      i = d.find_last_not_of('0');
-        if(i != std::string::npos && i != d.size() - 1) {
-            if(d[i] == '.')
-                i++;
+        size_t i = d.find_last_not_of('0');
+        if (i != std::string::npos && i != d.size() - 1)
+        {
+            if (d[i] == '.') i++;
             d = d.substr(0, i + 1);
         }
         return d.c_str();
@@ -2761,48 +2841,53 @@ namespace {
             Little
         };
 
-        static Arch which() {
+        static Arch which()
+        {
             union _
             {
-                int  asInt;
+                int asInt;
                 char asChar[sizeof(int)];
             } u;
 
-            u.asInt = 1;                                            // NOLINT
-            return (u.asChar[sizeof(int) - 1] == 1) ? Big : Little; // NOLINT
+            u.asInt = 1;                                             // NOLINT
+            return (u.asChar[sizeof(int) - 1] == 1) ? Big : Little;  // NOLINT
         }
     };
-} // namespace
+}  // namespace
 
-namespace detail {
+namespace detail
+{
     void my_memcpy(void* dest, const void* src, unsigned num) { memcpy(dest, src, num); }
 
-    String rawMemoryToString(const void* object, unsigned size) {
+    String rawMemoryToString(const void* object, unsigned size)
+    {
         // Reverse order for little endian architectures
         int i = 0, end = static_cast<int>(size), inc = 1;
-        if(Endianness::which() == Endianness::Little) {
-            i   = end - 1;
+        if (Endianness::which() == Endianness::Little)
+        {
+            i = end - 1;
             end = inc = -1;
         }
 
         unsigned const char* bytes = static_cast<unsigned const char*>(object);
-        std::ostringstream   oss;
+        std::ostringstream oss;
         oss << "0x" << std::setfill('0') << std::hex;
-        for(; i != end; i += inc)
-            oss << std::setw(2) << static_cast<unsigned>(bytes[i]);
+        for (; i != end; i += inc) oss << std::setw(2) << static_cast<unsigned>(bytes[i]);
         return oss.str().c_str();
     }
 
     DOCTEST_THREAD_LOCAL std::ostringstream g_oss;
 
-    std::ostream* getTlsOss() {
-        g_oss.clear(); // there shouldn't be anything worth clearing in the flags
-        g_oss.str(""); // the slow way of resetting a string stream
+    std::ostream* getTlsOss()
+    {
+        g_oss.clear();  // there shouldn't be anything worth clearing in the flags
+        g_oss.str("");  // the slow way of resetting a string stream
         //g_oss.seekp(0); // optimal reset - as seen here: https://stackoverflow.com/a/624291/3162383
         return &g_oss;
     }
 
-    String getTlsOssResult() {
+    String getTlsOssResult()
+    {
         //g_oss << std::ends; // needed - as shown here: https://stackoverflow.com/a/624291/3162383
         return g_oss.str().c_str();
     }
@@ -2814,7 +2899,7 @@ namespace detail {
         std::atomic<int> numAssertsForCurrentTestCase_atomic;
         std::atomic<int> numAssertsFailedForCurrentTestCase_atomic;
 
-        std::vector<std::vector<String> > filters = decltype(filters)(9); // 9 different filters
+        std::vector<std::vector<String> > filters = decltype(filters)(9);  // 9 different filters
 
         std::vector<IReporter*> reporters_currently_used;
 
@@ -2822,76 +2907,86 @@ namespace detail {
 
         assert_handler ah = nullptr;
 
-        std::vector<String> stringifiedContexts; // logging from INFO() due to an exception
+        std::vector<String> stringifiedContexts;  // logging from INFO() due to an exception
 
         // stuff for subcases
         std::set<SubcaseSignature> subcasesPassed;
-        std::set<int>              subcasesEnteredLevels;
-        int                        subcasesCurrentLevel;
+        std::set<int> subcasesEnteredLevels;
+        int subcasesCurrentLevel;
 
-        void resetRunData() {
-            numTestCases                = 0;
-            numTestCasesPassingFilters  = 0;
+        void resetRunData()
+        {
+            numTestCases = 0;
+            numTestCasesPassingFilters = 0;
             numTestSuitesPassingFilters = 0;
-            numTestCasesFailed          = 0;
-            numAsserts                  = 0;
-            numAssertsFailed            = 0;
+            numTestCasesFailed = 0;
+            numAsserts = 0;
+            numAssertsFailed = 0;
         }
     };
 
-    ContextState*             g_cs = nullptr;
-    DOCTEST_THREAD_LOCAL bool g_no_colors; // used to avoid locks for the debug output
+    ContextState* g_cs = nullptr;
+    DOCTEST_THREAD_LOCAL bool g_no_colors;  // used to avoid locks for the debug output
 
-#endif // DOCTEST_CONFIG_DISABLE
-} // namespace detail
+#endif  // DOCTEST_CONFIG_DISABLE
+}  // namespace detail
 
 void String::setOnHeap() { *reinterpret_cast<unsigned char*>(&buf[last]) = 128; }
 void String::setLast(unsigned in) { buf[last] = char(in); }
 
-void String::copy(const String& other) {
-    if(other.isOnStack()) {
+void String::copy(const String& other)
+{
+    if (other.isOnStack())
+    {
         memcpy(buf, other.buf, len);
-    } else {
+    }
+    else
+    {
         setOnHeap();
-        data.size     = other.data.size;
+        data.size = other.data.size;
         data.capacity = data.size + 1;
-        data.ptr      = new char[data.capacity];
+        data.ptr = new char[data.capacity];
         memcpy(data.ptr, other.data.ptr, data.size + 1);
     }
 }
 
-String::String() {
+String::String()
+{
     buf[0] = '\0';
     setLast();
 }
 
-String::~String() {
-    if(!isOnStack())
-        delete[] data.ptr;
+String::~String()
+{
+    if (!isOnStack()) delete[] data.ptr;
 }
 
-String::String(const char* in)
-        : String(in, strlen(in)) {}
+String::String(const char* in) : String(in, strlen(in)) {}
 
-String::String(const char* in, unsigned in_size) {
-    if(in_size <= last) {
+String::String(const char* in, unsigned in_size)
+{
+    if (in_size <= last)
+    {
         memcpy(buf, in, in_size + 1);
         setLast(last - in_size);
-    } else {
+    }
+    else
+    {
         setOnHeap();
-        data.size     = in_size;
+        data.size = in_size;
         data.capacity = data.size + 1;
-        data.ptr      = new char[data.capacity];
+        data.ptr = new char[data.capacity];
         memcpy(data.ptr, in, in_size + 1);
     }
 }
 
 String::String(const String& other) { copy(other); }
 
-String& String::operator=(const String& other) {
-    if(this != &other) {
-        if(!isOnStack())
-            delete[] data.ptr;
+String& String::operator=(const String& other)
+{
+    if (this != &other)
+    {
+        if (!isOnStack()) delete[] data.ptr;
 
         copy(other);
     }
@@ -2899,47 +2994,56 @@ String& String::operator=(const String& other) {
     return *this;
 }
 
-String& String::operator+=(const String& other) {
+String& String::operator+=(const String& other)
+{
     const unsigned my_old_size = size();
-    const unsigned other_size  = other.size();
-    const unsigned total_size  = my_old_size + other_size;
-    if(isOnStack()) {
-        if(total_size < len) {
+    const unsigned other_size = other.size();
+    const unsigned total_size = my_old_size + other_size;
+    if (isOnStack())
+    {
+        if (total_size < len)
+        {
             // append to the current stack space
             memcpy(buf + my_old_size, other.c_str(), other_size + 1);
             setLast(last - total_size);
-        } else {
+        }
+        else
+        {
             // alloc new chunk
             char* temp = new char[total_size + 1];
             // copy current data to new location before writing in the union
-            memcpy(temp, buf, my_old_size); // skip the +1 ('\0') for speed
+            memcpy(temp, buf, my_old_size);  // skip the +1 ('\0') for speed
             // update data in union
             setOnHeap();
-            data.size     = total_size;
+            data.size = total_size;
             data.capacity = data.size + 1;
-            data.ptr      = temp;
+            data.ptr = temp;
             // transfer the rest of the data
             memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
         }
-    } else {
-        if(data.capacity > total_size) {
+    }
+    else
+    {
+        if (data.capacity > total_size)
+        {
             // append to the current heap block
             data.size = total_size;
             memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
-        } else {
+        }
+        else
+        {
             // resize
             data.capacity *= 2;
-            if(data.capacity <= total_size)
-                data.capacity = total_size + 1;
+            if (data.capacity <= total_size) data.capacity = total_size + 1;
             // alloc new chunk
             char* temp = new char[data.capacity];
             // copy current data to new location before releasing it
-            memcpy(temp, data.ptr, my_old_size); // skip the +1 ('\0') for speed
+            memcpy(temp, data.ptr, my_old_size);  // skip the +1 ('\0') for speed
             // release old chunk
             delete[] data.ptr;
             // update the rest of the union members
             data.size = total_size;
-            data.ptr  = temp;
+            data.ptr = temp;
             // transfer the rest of the data
             memcpy(data.ptr + my_old_size, other.c_str(), other_size + 1);
         }
@@ -2950,16 +3054,18 @@ String& String::operator+=(const String& other) {
 
 String String::operator+(const String& other) const { return String(*this) += other; }
 
-String::String(String&& other) {
+String::String(String&& other)
+{
     memcpy(buf, other.buf, len);
     other.buf[0] = '\0';
     other.setLast();
 }
 
-String& String::operator=(String&& other) {
-    if(this != &other) {
-        if(!isOnStack())
-            delete[] data.ptr;
+String& String::operator=(String&& other)
+{
+    if (this != &other)
+    {
+        if (!isOnStack()) delete[] data.ptr;
         memcpy(buf, other.buf, len);
         other.buf[0] = '\0';
         other.setLast();
@@ -2967,39 +3073,38 @@ String& String::operator=(String&& other) {
     return *this;
 }
 
-char String::operator[](unsigned i) const {
-    return const_cast<String*>(this)->operator[](i); // NOLINT
+char String::operator[](unsigned i) const
+{
+    return const_cast<String*>(this)->operator[](i);  // NOLINT
 }
 
-char& String::operator[](unsigned i) {
-    if(isOnStack())
-        return reinterpret_cast<char*>(buf)[i];
+char& String::operator[](unsigned i)
+{
+    if (isOnStack()) return reinterpret_cast<char*>(buf)[i];
     return data.ptr[i];
 }
 
 DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmaybe-uninitialized")
-unsigned String::size() const {
-    if(isOnStack())
-        return last - (unsigned(buf[last]) & 31); // using "last" would work only if "len" is 32
+unsigned String::size() const
+{
+    if (isOnStack()) return last - (unsigned(buf[last]) & 31);  // using "last" would work only if "len" is 32
     return data.size;
 }
 DOCTEST_GCC_SUPPRESS_WARNING_POP
 
-unsigned String::capacity() const {
-    if(isOnStack())
-        return len;
+unsigned String::capacity() const
+{
+    if (isOnStack()) return len;
     return data.capacity;
 }
 
-int String::compare(const char* other, bool no_case) const {
-    if(no_case)
-        return stricmp(c_str(), other);
+int String::compare(const char* other, bool no_case) const
+{
+    if (no_case) return stricmp(c_str(), other);
     return std::strcmp(c_str(), other);
 }
 
-int String::compare(const String& other, bool no_case) const {
-    return compare(other.c_str(), no_case);
-}
+int String::compare(const String& other, bool no_case) const { return compare(other.c_str(), no_case); }
 
 // clang-format off
 bool operator==(const String& lhs, const String& rhs) { return lhs.compare(rhs) == 0; }
@@ -3012,16 +3117,19 @@ bool operator>=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lh
 
 std::ostream& operator<<(std::ostream& s, const String& in) { return s << in.c_str(); }
 
-namespace {
+namespace
+{
     void color_to_stream(std::ostream&, Color::Enum) DOCTEST_BRANCH_ON_DISABLED({}, ;)
-} // namespace
+}  // namespace
 
-namespace Color {
-    std::ostream& operator<<(std::ostream& s, Color::Enum code) {
+namespace Color
+{
+    std::ostream& operator<<(std::ostream& s, Color::Enum code)
+    {
         color_to_stream(s, code);
         return s;
     }
-} // namespace Color
+}  // namespace Color
 
 // clang-format off
 const char* assertString(assertType::Enum at) {
@@ -3082,12 +3190,13 @@ const char* assertString(assertType::Enum at) {
 }
 // clang-format on
 
-const char* failureString(assertType::Enum at) {
-    if(at & assertType::is_warn) //!OCLINT bitwise operator in conditional
+const char* failureString(assertType::Enum at)
+{
+    if (at & assertType::is_warn)  //!OCLINT bitwise operator in conditional
         return "WARNING: ";
-    if(at & assertType::is_check) //!OCLINT bitwise operator in conditional
+    if (at & assertType::is_check)  //!OCLINT bitwise operator in conditional
         return "ERROR: ";
-    if(at & assertType::is_require) //!OCLINT bitwise operator in conditional
+    if (at & assertType::is_require)  //!OCLINT bitwise operator in conditional
         return "FATAL ERROR: ";
     return "";
 }
@@ -3095,13 +3204,15 @@ const char* failureString(assertType::Enum at) {
 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
 DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
 // depending on the current options this will remove the path of filenames
-const char* removePathFromFilename(const char* file) {
-    if(getContextOptions()->no_path_in_filenames) {
-        auto back    = std::strrchr(file, '\\');
+const char* removePathFromFilename(const char* file)
+{
+    if (getContextOptions()->no_path_in_filenames)
+    {
+        auto back = std::strrchr(file, '\\');
         auto forward = std::strrchr(file, '/');
-        if(back || forward) {
-            if(back > forward)
-                forward = back;
+        if (back || forward)
+        {
+            if (back > forward) forward = back;
             return forward + 1;
         }
     }
@@ -3118,22 +3229,21 @@ DOCTEST_DEFINE_DEFAULTS(AssertData);
 DOCTEST_DEFINE_DEFAULTS(MessageData);
 
 SubcaseSignature::SubcaseSignature(const char* name, const char* file, int line)
-        : m_name(name)
-        , m_file(file)
-        , m_line(line) {}
+    : m_name(name), m_file(file), m_line(line)
+{
+}
 
 DOCTEST_DEFINE_DEFAULTS(SubcaseSignature);
 DOCTEST_DEFINE_COPIES(SubcaseSignature);
 
-bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
-    if(m_line != other.m_line)
-        return m_line < other.m_line;
-    if(std::strcmp(m_file, other.m_file) != 0)
-        return std::strcmp(m_file, other.m_file) < 0;
+bool SubcaseSignature::operator<(const SubcaseSignature& other) const
+{
+    if (m_line != other.m_line) return m_line < other.m_line;
+    if (std::strcmp(m_file, other.m_file) != 0) return std::strcmp(m_file, other.m_file) < 0;
     return std::strcmp(m_name, other.m_name) < 0;
 }
 
-IContextScope::IContextScope()  = default;
+IContextScope::IContextScope() = default;
 IContextScope::~IContextScope() = default;
 
 DOCTEST_DEFINE_DEFAULTS(ContextOptions);
@@ -3141,17 +3251,18 @@ DOCTEST_DEFINE_DEFAULTS(ContextOptions);
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 String toString(char* in) { return toString(static_cast<const char*>(in)); }
 String toString(const char* in) { return String("\"") + (in ? in : "{null string}") + "\""; }
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#endif  // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 String toString(bool in) { return in ? "true" : "false"; }
 String toString(float in) { return fpToString(in, 5) + "f"; }
 String toString(double in) { return fpToString(in, 10); }
 String toString(double long in) { return fpToString(in, 15); }
 
-#define DOCTEST_TO_STRING_OVERLOAD(type, fmt)                                                      \
-    String toString(type in) {                                                                     \
-        char buf[64];                                                                              \
-        std::sprintf(buf, fmt, in);                                                                \
-        return buf;                                                                                \
+#define DOCTEST_TO_STRING_OVERLOAD(type, fmt) \
+    String toString(type in)                  \
+    {                                         \
+        char buf[64];                         \
+        std::sprintf(buf, fmt, in);           \
+        return buf;                           \
     }
 
 DOCTEST_TO_STRING_OVERLOAD(char, "%d")
@@ -3169,29 +3280,33 @@ DOCTEST_TO_STRING_OVERLOAD(int long long unsigned, "%llu")
 String toString(std::nullptr_t) { return "NULL"; }
 
 Approx::Approx(double value)
-        : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100)
-        , m_scale(1.0)
-        , m_value(value) {}
+    : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100), m_scale(1.0), m_value(value)
+{
+}
 
 DOCTEST_DEFINE_COPIES(Approx);
 
-Approx Approx::operator()(double value) const {
+Approx Approx::operator()(double value) const
+{
     Approx approx(value);
     approx.epsilon(m_epsilon);
     approx.scale(m_scale);
     return approx;
 }
 
-Approx& Approx::epsilon(double newEpsilon) {
+Approx& Approx::epsilon(double newEpsilon)
+{
     m_epsilon = newEpsilon;
     return *this;
 }
-Approx& Approx::scale(double newScale) {
+Approx& Approx::scale(double newScale)
+{
     m_scale = newScale;
     return *this;
 }
 
-bool operator==(double lhs, const Approx& rhs) {
+bool operator==(double lhs, const Approx& rhs)
+{
     // Thanks to Richard Harris for his help refining this formula
     return std::fabs(lhs - rhs.m_value) <
            rhs.m_epsilon * (rhs.m_scale + std::max(std::fabs(lhs), std::fabs(rhs.m_value)));
@@ -3208,15 +3323,14 @@ bool operator<(const Approx& lhs, double rhs) { return lhs.m_value < rhs && lhs 
 bool operator>(double lhs, const Approx& rhs) { return lhs > rhs.m_value && lhs != rhs; }
 bool operator>(const Approx& lhs, double rhs) { return lhs.m_value > rhs && lhs != rhs; }
 
-String toString(const Approx& in) {
-    return String("Approx( ") + doctest::toString(in.m_value) + " )";
-}
+String toString(const Approx& in) { return String("Approx( ") + doctest::toString(in.m_value) + " )"; }
 const ContextOptions* getContextOptions() { return DOCTEST_BRANCH_ON_DISABLED(nullptr, g_cs); }
 
-} // namespace doctest
+}  // namespace doctest
 
 #ifdef DOCTEST_CONFIG_DISABLE
-namespace doctest {
+namespace doctest
+{
 Context::Context(int, const char* const*) {}
 Context::~Context() = default;
 void Context::applyCommandLine(int, const char* const*) {}
@@ -3227,7 +3341,7 @@ void Context::setOption(const char*, const char*) {}
 bool Context::shouldExit() { return false; }
 void Context::setAsDefaultForAssertsOutOfTestCases() {}
 void Context::setAssertHandler(detail::assert_handler) {}
-int  Context::run() { return 0; }
+int Context::run() { return 0; }
 
 DOCTEST_DEFINE_DEFAULTS(CurrentTestCaseStats);
 
@@ -3235,53 +3349,52 @@ DOCTEST_DEFINE_DEFAULTS(TestRunStats);
 
 IReporter::~IReporter() = default;
 
-int                         IReporter::get_num_active_contexts() { return 0; }
+int IReporter::get_num_active_contexts() { return 0; }
 const IContextScope* const* IReporter::get_active_contexts() { return nullptr; }
-int                         IReporter::get_num_stringified_contexts() { return 0; }
-const String*               IReporter::get_stringified_contexts() { return nullptr; }
+int IReporter::get_num_stringified_contexts() { return 0; }
+const String* IReporter::get_stringified_contexts() { return nullptr; }
 
 int registerReporter(const char*, int, IReporter*) { return 0; }
 
-} // namespace doctest
-#else // DOCTEST_CONFIG_DISABLE
+}  // namespace doctest
+#else  // DOCTEST_CONFIG_DISABLE
 
 #if !defined(DOCTEST_CONFIG_COLORS_NONE)
 #if !defined(DOCTEST_CONFIG_COLORS_WINDOWS) && !defined(DOCTEST_CONFIG_COLORS_ANSI)
 #ifdef DOCTEST_PLATFORM_WINDOWS
 #define DOCTEST_CONFIG_COLORS_WINDOWS
-#else // linux
+#else  // linux
 #define DOCTEST_CONFIG_COLORS_ANSI
-#endif // platform
-#endif // DOCTEST_CONFIG_COLORS_WINDOWS && DOCTEST_CONFIG_COLORS_ANSI
-#endif // DOCTEST_CONFIG_COLORS_NONE
+#endif  // platform
+#endif  // DOCTEST_CONFIG_COLORS_WINDOWS && DOCTEST_CONFIG_COLORS_ANSI
+#endif  // DOCTEST_CONFIG_COLORS_NONE
 
 #if DOCTEST_MSVC || defined(__MINGW32__)
 #if DOCTEST_MSVC
 #define DOCTEST_WINDOWS_SAL_IN_OPT _In_opt_
-#else // MSVC
+#else  // MSVC
 #define DOCTEST_WINDOWS_SAL_IN_OPT
-#endif // MSVC
-extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(
-        DOCTEST_WINDOWS_SAL_IN_OPT const char*);
+#endif  // MSVC
+extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(DOCTEST_WINDOWS_SAL_IN_OPT const char*);
 extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
-#endif // MSVC || __MINGW32__
+#endif  // MSVC || __MINGW32__
 
 #ifdef DOCTEST_CONFIG_COLORS_ANSI
 #include <unistd.h>
-#endif // DOCTEST_CONFIG_COLORS_ANSI
+#endif  // DOCTEST_CONFIG_COLORS_ANSI
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
 
 // defines for a leaner windows.h
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
-#endif // WIN32_LEAN_AND_MEAN
+#endif  // WIN32_LEAN_AND_MEAN
 #ifndef VC_EXTRA_LEAN
 #define VC_EXTRA_LEAN
-#endif // VC_EXTRA_LEAN
+#endif  // VC_EXTRA_LEAN
 #ifndef NOMINMAX
 #define NOMINMAX
-#endif // NOMINMAX
+#endif  // NOMINMAX
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 
@@ -3295,91 +3408,108 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
-#else // DOCTEST_PLATFORM_WINDOWS
+#else  // DOCTEST_PLATFORM_WINDOWS
 
 #include <sys/time.h>
 
-#endif // DOCTEST_PLATFORM_WINDOWS
+#endif  // DOCTEST_PLATFORM_WINDOWS
 
-namespace doctest_detail_test_suite_ns {
+namespace doctest_detail_test_suite_ns
+{
 // holds the current test suite
-doctest::detail::TestSuite& getCurrentTestSuite() {
+doctest::detail::TestSuite& getCurrentTestSuite()
+{
     static doctest::detail::TestSuite data;
     return data;
 }
-} // namespace doctest_detail_test_suite_ns
+}  // namespace doctest_detail_test_suite_ns
 
-namespace doctest {
-namespace {
+namespace doctest
+{
+namespace
+{
     using namespace detail;
     typedef std::map<std::pair<int, String>, IReporter*> reporterMap;
-    reporterMap&                                         getReporters() {
+    reporterMap& getReporters()
+    {
         static reporterMap data;
         return data;
     }
-} // namespace
-namespace detail {
-#define DOCTEST_ITERATE_THROUGH_REPORTERS(function, ...)                                           \
-    for(auto& curr_rep : g_cs->reporters_currently_used)                                           \
-    curr_rep->function(__VA_ARGS__)
+}  // namespace
+namespace detail
+{
+#define DOCTEST_ITERATE_THROUGH_REPORTERS(function, ...) \
+    for (auto& curr_rep : g_cs->reporters_currently_used) curr_rep->function(__VA_ARGS__)
 
     DOCTEST_DEFINE_DEFAULTS(TestFailureException);
     DOCTEST_DEFINE_COPIES(TestFailureException);
-    bool checkIfShouldThrow(assertType::Enum at) {
-        if(at & assertType::is_require) //!OCLINT bitwise operator in conditional
+    bool checkIfShouldThrow(assertType::Enum at)
+    {
+        if (at & assertType::is_require)  //!OCLINT bitwise operator in conditional
             return true;
 
-        if((at & assertType::is_check) //!OCLINT bitwise operator in conditional
-           && getContextOptions()->abort_after > 0 &&
-           (g_cs->numAssertsFailed + g_cs->numAssertsFailedForCurrentTestCase_atomic) >=
-                   getContextOptions()->abort_after)
+        if ((at & assertType::is_check)  //!OCLINT bitwise operator in conditional
+            && getContextOptions()->abort_after > 0 &&
+            (g_cs->numAssertsFailed + g_cs->numAssertsFailedForCurrentTestCase_atomic) >=
+                getContextOptions()->abort_after)
             return true;
 
         return false;
     }
 
-    void throwException() {
+    void throwException()
+    {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
         throw TestFailureException();
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+#endif  // DOCTEST_CONFIG_NO_EXCEPTIONS
     }
-} // namespace detail
+}  // namespace detail
 
-namespace {
+namespace
+{
     using namespace detail;
     // matching of a string against a wildcard mask (case sensitivity configurable) taken from
     // https://www.codeproject.com/Articles/1088/Wildcard-string-compare-globbing
-    int wildcmp(const char* str, const char* wild, bool caseSensitive) {
+    int wildcmp(const char* str, const char* wild, bool caseSensitive)
+    {
         const char* cp = nullptr;
         const char* mp = nullptr;
 
-        while((*str) && (*wild != '*')) {
-            if((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) &&
-               (*wild != '?')) {
+        while ((*str) && (*wild != '*'))
+        {
+            if ((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) && (*wild != '?'))
+            {
                 return 0;
             }
             wild++;
             str++;
         }
 
-        while(*str) {
-            if(*wild == '*') {
-                if(!*++wild) {
+        while (*str)
+        {
+            if (*wild == '*')
+            {
+                if (!*++wild)
+                {
                     return 1;
                 }
                 mp = wild;
                 cp = str + 1;
-            } else if((caseSensitive ? (*wild == *str) : (tolower(*wild) == tolower(*str))) ||
-                      (*wild == '?')) {
+            }
+            else if ((caseSensitive ? (*wild == *str) : (tolower(*wild) == tolower(*str))) || (*wild == '?'))
+            {
                 wild++;
                 str++;
-            } else {
+            }
+            else
+            {
                 wild = mp;   //!OCLINT parameter reassignment
-                str  = cp++; //!OCLINT parameter reassignment
+                str = cp++;  //!OCLINT parameter reassignment
             }
         }
 
-        while(*wild == '*') {
+        while (*wild == '*')
+        {
             wild++;
         }
         return !*wild;
@@ -3395,24 +3525,24 @@ namespace {
     //}
 
     // checks if the name matches any of the filters (and can be configured what to do when empty)
-    bool matchesAny(const char* name, const std::vector<String>& filters, bool matchEmpty,
-                    bool caseSensitive) {
-        if(filters.empty() && matchEmpty)
-            return true;
-        for(auto& curr : filters)
-            if(wildcmp(name, curr.c_str(), caseSensitive))
-                return true;
+    bool matchesAny(const char* name, const std::vector<String>& filters, bool matchEmpty, bool caseSensitive)
+    {
+        if (filters.empty() && matchEmpty) return true;
+        for (auto& curr : filters)
+            if (wildcmp(name, curr.c_str(), caseSensitive)) return true;
         return false;
     }
 
     typedef uint64_t UInt64;
 
 #ifdef DOCTEST_CONFIG_GETCURRENTTICKS
-    UInt64           getCurrentTicks() { return DOCTEST_CONFIG_GETCURRENTTICKS(); }
+    UInt64 getCurrentTicks() { return DOCTEST_CONFIG_GETCURRENTTICKS(); }
 #elif defined(DOCTEST_PLATFORM_WINDOWS)
-    UInt64 getCurrentTicks() {
+    UInt64 getCurrentTicks()
+    {
         static UInt64 hz = 0, hzo = 0;
-        if(!hz) {
+        if (!hz)
+        {
             QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(&hz));
             QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER*>(&hzo));
         }
@@ -3420,20 +3550,19 @@ namespace {
         QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER*>(&t));
         return ((t - hzo) * 1000000) / hz;
     }
-#else  // DOCTEST_PLATFORM_WINDOWS
-    UInt64 getCurrentTicks() {
+#else   // DOCTEST_PLATFORM_WINDOWS
+    UInt64 getCurrentTicks()
+    {
         timeval t;
         gettimeofday(&t, nullptr);
         return static_cast<UInt64>(t.tv_sec) * 1000000 + static_cast<UInt64>(t.tv_usec);
     }
-#endif // DOCTEST_PLATFORM_WINDOWS
+#endif  // DOCTEST_PLATFORM_WINDOWS
 
     struct Timer
     {
-        void         start() { m_ticks = getCurrentTicks(); }
-        unsigned int getElapsedMicroseconds() const {
-            return static_cast<unsigned int>(getCurrentTicks() - m_ticks);
-        }
+        void start() { m_ticks = getCurrentTicks(); }
+        unsigned int getElapsedMicroseconds() const { return static_cast<unsigned int>(getCurrentTicks() - m_ticks); }
         //unsigned int getElapsedMilliseconds() const {
         //    return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
         //}
@@ -3444,27 +3573,27 @@ namespace {
     };
 
     Timer g_timer;
-} // namespace
-namespace detail {
+}  // namespace
+namespace detail
+{
 
-    Subcase::Subcase(const char* name, const char* file, int line)
-            : m_signature(name, file, line) {
+    Subcase::Subcase(const char* name, const char* file, int line) : m_signature(name, file, line)
+    {
         ContextState* s = g_cs;
 
         // if we have already completed it
-        if(s->subcasesPassed.count(m_signature) != 0)
-            return;
+        if (s->subcasesPassed.count(m_signature) != 0) return;
 
         // check subcase filters
-        if(s->subcasesCurrentLevel < s->subcase_filter_levels) {
-            if(!matchesAny(m_signature.m_name, s->filters[6], true, s->case_sensitive))
-                return;
-            if(matchesAny(m_signature.m_name, s->filters[7], false, s->case_sensitive))
-                return;
+        if (s->subcasesCurrentLevel < s->subcase_filter_levels)
+        {
+            if (!matchesAny(m_signature.m_name, s->filters[6], true, s->case_sensitive)) return;
+            if (matchesAny(m_signature.m_name, s->filters[7], false, s->case_sensitive)) return;
         }
 
         // if a Subcase on the same level has already been entered
-        if(s->subcasesEnteredLevels.count(s->subcasesCurrentLevel) != 0) {
+        if (s->subcasesEnteredLevels.count(s->subcasesCurrentLevel) != 0)
+        {
             s->should_reenter = true;
             return;
         }
@@ -3475,14 +3604,15 @@ namespace detail {
         DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
     }
 
-    Subcase::~Subcase() {
-        if(m_entered) {
+    Subcase::~Subcase()
+    {
+        if (m_entered)
+        {
             ContextState* s = g_cs;
 
             s->subcasesCurrentLevel--;
             // only mark the subcase as passed if no subcases have been skipped
-            if(s->should_reenter == false)
-                s->subcasesPassed.insert(m_signature);
+            if (s->should_reenter == false) s->subcasesPassed.insert(m_signature);
 
             DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, m_signature);
         }
@@ -3490,78 +3620,76 @@ namespace detail {
 
     Subcase::operator bool() const { return m_entered; }
 
-    Result::Result(bool passed, const String& decomposition)
-            : m_passed(passed)
-            , m_decomp(decomposition) {}
+    Result::Result(bool passed, const String& decomposition) : m_passed(passed), m_decomp(decomposition) {}
 
     DOCTEST_DEFINE_DEFAULTS(Result);
     DOCTEST_DEFINE_COPIES(Result);
 
-    ExpressionDecomposer::ExpressionDecomposer(assertType::Enum at)
-            : m_at(at) {}
+    ExpressionDecomposer::ExpressionDecomposer(assertType::Enum at) : m_at(at) {}
 
     DOCTEST_DEFINE_DEFAULTS(ExpressionDecomposer);
 
     DOCTEST_DEFINE_DEFAULTS(TestSuite);
     DOCTEST_DEFINE_COPIES(TestSuite);
 
-    TestSuite& TestSuite::operator*(const char* in) {
+    TestSuite& TestSuite::operator*(const char* in)
+    {
         m_test_suite = in;
         // clear state
-        m_description       = nullptr;
-        m_skip              = false;
-        m_may_fail          = false;
-        m_should_fail       = false;
+        m_description = nullptr;
+        m_skip = false;
+        m_may_fail = false;
+        m_should_fail = false;
         m_expected_failures = 0;
-        m_timeout           = 0;
+        m_timeout = 0;
         return *this;
     }
 
-    TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                       const char* type, int template_id) {
-        m_file              = file;
-        m_line              = line;
-        m_name              = nullptr;
-        m_test_suite        = test_suite.m_test_suite;
-        m_description       = test_suite.m_description;
-        m_skip              = test_suite.m_skip;
-        m_may_fail          = test_suite.m_may_fail;
-        m_should_fail       = test_suite.m_should_fail;
+    TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite, const char* type,
+                       int template_id)
+    {
+        m_file = file;
+        m_line = line;
+        m_name = nullptr;
+        m_test_suite = test_suite.m_test_suite;
+        m_description = test_suite.m_description;
+        m_skip = test_suite.m_skip;
+        m_may_fail = test_suite.m_may_fail;
+        m_should_fail = test_suite.m_should_fail;
         m_expected_failures = test_suite.m_expected_failures;
-        m_timeout           = test_suite.m_timeout;
+        m_timeout = test_suite.m_timeout;
 
-        m_test        = test;
-        m_type        = type;
+        m_test = test;
+        m_type = type;
         m_template_id = template_id;
     }
 
     DOCTEST_DEFINE_DEFAULTS(TestCase);
 
-    TestCase::TestCase(const TestCase& other)
-            : TestCaseData() {
-        *this = other;
-    }
+    TestCase::TestCase(const TestCase& other) : TestCaseData() { *this = other; }
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
-    DOCTEST_MSVC_SUPPRESS_WARNING(26437)           // Do not slice
-    TestCase& TestCase::operator=(const TestCase& other) {
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434)  // hides a non-virtual function
+    DOCTEST_MSVC_SUPPRESS_WARNING(26437)            // Do not slice
+    TestCase& TestCase::operator=(const TestCase& other)
+    {
         static_cast<TestCaseData&>(*this) = static_cast<const TestCaseData&>(other);
 
-        m_test        = other.m_test;
-        m_type        = other.m_type;
+        m_test = other.m_test;
+        m_type = other.m_type;
         m_template_id = other.m_template_id;
-        m_full_name   = other.m_full_name;
+        m_full_name = other.m_full_name;
 
-        if(m_template_id != -1)
-            m_name = m_full_name.c_str();
+        if (m_template_id != -1) m_name = m_full_name.c_str();
         return *this;
     }
     DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
-    TestCase& TestCase::operator*(const char* in) {
+    TestCase& TestCase::operator*(const char* in)
+    {
         m_name = in;
         // make a new name with an appended type for templated test case
-        if(m_template_id != -1) {
+        if (m_template_id != -1)
+        {
             m_full_name = String(m_name) + m_type;
             // redirect the name to point to the newly constructed full name
             m_name = m_full_name.c_str();
@@ -3569,92 +3697,94 @@ namespace detail {
         return *this;
     }
 
-    bool TestCase::operator<(const TestCase& other) const {
-        if(m_line != other.m_line)
-            return m_line < other.m_line;
+    bool TestCase::operator<(const TestCase& other) const
+    {
+        if (m_line != other.m_line) return m_line < other.m_line;
         const int file_cmp = std::strcmp(m_file, other.m_file);
-        if(file_cmp != 0)
-            return file_cmp < 0;
+        if (file_cmp != 0) return file_cmp < 0;
         return m_template_id < other.m_template_id;
     }
-} // namespace detail
-namespace {
+}  // namespace detail
+namespace
+{
     using namespace detail;
     // for sorting tests by file/line
-    int fileOrderComparator(const void* a, const void* b) {
+    int fileOrderComparator(const void* a, const void* b)
+    {
         auto lhs = *static_cast<TestCase* const*>(a);
         auto rhs = *static_cast<TestCase* const*>(b);
 #if DOCTEST_MSVC
         // this is needed because MSVC gives different case for drive letters
         // for __FILE__ when evaluated in a header and a source file
         const int res = stricmp(lhs->m_file, rhs->m_file);
-#else  // MSVC
+#else   // MSVC
         const int res = std::strcmp(lhs->m_file, rhs->m_file);
-#endif // MSVC
-        if(res != 0)
-            return res;
+#endif  // MSVC
+        if (res != 0) return res;
         return static_cast<int>(lhs->m_line) - static_cast<int>(rhs->m_line);
     }
 
     // for sorting tests by suite/file/line
-    int suiteOrderComparator(const void* a, const void* b) {
+    int suiteOrderComparator(const void* a, const void* b)
+    {
         auto lhs = *static_cast<TestCase* const*>(a);
         auto rhs = *static_cast<TestCase* const*>(b);
 
         const int res = std::strcmp(lhs->m_test_suite, rhs->m_test_suite);
-        if(res != 0)
-            return res;
+        if (res != 0) return res;
         return fileOrderComparator(a, b);
     }
 
     // for sorting tests by name/suite/file/line
-    int nameOrderComparator(const void* a, const void* b) {
+    int nameOrderComparator(const void* a, const void* b)
+    {
         auto lhs = *static_cast<TestCase* const*>(a);
         auto rhs = *static_cast<TestCase* const*>(b);
 
         const int res_name = std::strcmp(lhs->m_name, rhs->m_name);
-        if(res_name != 0)
-            return res_name;
+        if (res_name != 0) return res_name;
         return suiteOrderComparator(a, b);
     }
 
     // all the registered tests
-    std::set<TestCase>& getRegisteredTests() {
+    std::set<TestCase>& getRegisteredTests()
+    {
         static std::set<TestCase> data;
         return data;
     }
 
 #ifdef DOCTEST_CONFIG_COLORS_WINDOWS
     HANDLE g_stdoutHandle;
-    WORD   g_origFgAttrs;
-    WORD   g_origBgAttrs;
-    bool   g_attrsInitted = false;
+    WORD g_origFgAttrs;
+    WORD g_origBgAttrs;
+    bool g_attrsInitted = false;
 
-    int colors_init() {
-        if(!g_attrsInitted) {
+    int colors_init()
+    {
+        if (!g_attrsInitted)
+        {
             g_stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
             g_attrsInitted = true;
             CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
             GetConsoleScreenBufferInfo(g_stdoutHandle, &csbiInfo);
-            g_origFgAttrs = csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED |
-                                                     BACKGROUND_BLUE | BACKGROUND_INTENSITY);
-            g_origBgAttrs = csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED |
-                                                     FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+            g_origFgAttrs =
+                csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
+            g_origBgAttrs =
+                csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
         }
         return 0;
     }
 
     int dumy_init_console_colors = colors_init();
-#endif // DOCTEST_CONFIG_COLORS_WINDOWS
+#endif  // DOCTEST_CONFIG_COLORS_WINDOWS
 
     DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    void color_to_stream(std::ostream& s, Color::Enum code) {
-        ((void)s);    // for DOCTEST_CONFIG_COLORS_NONE or DOCTEST_CONFIG_COLORS_WINDOWS
-        ((void)code); // for DOCTEST_CONFIG_COLORS_NONE
+    void color_to_stream(std::ostream& s, Color::Enum code)
+    {
+        ((void)s);     // for DOCTEST_CONFIG_COLORS_NONE or DOCTEST_CONFIG_COLORS_WINDOWS
+        ((void)code);  // for DOCTEST_CONFIG_COLORS_NONE
 #ifdef DOCTEST_CONFIG_COLORS_ANSI
-        if(g_no_colors ||
-           (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false))
-            return;
+        if (g_no_colors || (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false)) return;
 
         auto col = "";
         // clang-format off
@@ -3676,12 +3806,10 @@ namespace {
             }
         // clang-format on
         s << "\033" << col;
-#endif // DOCTEST_CONFIG_COLORS_ANSI
+#endif  // DOCTEST_CONFIG_COLORS_ANSI
 
 #ifdef DOCTEST_CONFIG_COLORS_WINDOWS
-        if(g_no_colors ||
-           (isatty(fileno(stdout)) == false && getContextOptions()->force_colors == false))
-            return;
+        if (g_no_colors || (isatty(fileno(stdout)) == false && getContextOptions()->force_colors == false)) return;
 
 #define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(g_stdoutHandle, x | g_origBgAttrs)
 
@@ -3703,22 +3831,23 @@ namespace {
             default:                 DOCTEST_SET_ATTR(g_origFgAttrs);
         }
             // clang-format on
-#endif // DOCTEST_CONFIG_COLORS_WINDOWS
+#endif  // DOCTEST_CONFIG_COLORS_WINDOWS
     }
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
-    std::vector<const IExceptionTranslator*>& getExceptionTranslators() {
+    std::vector<const IExceptionTranslator*>& getExceptionTranslators()
+    {
         static std::vector<const IExceptionTranslator*> data;
         return data;
     }
 
-    String translateActiveException() {
+    String translateActiveException()
+    {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
         String res;
-        auto&  translators = getExceptionTranslators();
-        for(auto& curr : translators)
-            if(curr->translate(res))
-                return res;
+        auto& translators = getExceptionTranslators();
+        for (auto& curr : translators)
+            if (curr->translate(res)) return res;
         // clang-format off
         try {
             throw;
@@ -3732,21 +3861,24 @@ namespace {
             return "unknown exception";
         }
 // clang-format on
-#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+#else   // DOCTEST_CONFIG_NO_EXCEPTIONS
         return "";
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+#endif  // DOCTEST_CONFIG_NO_EXCEPTIONS
     }
-} // namespace
+}  // namespace
 
-namespace detail {
+namespace detail
+{
     // used by the macros for registering tests
-    int regTest(const TestCase& tc) {
+    int regTest(const TestCase& tc)
+    {
         getRegisteredTests().insert(tc);
         return 0;
     }
 
     // sets the current test suite
-    int setTestSuite(const TestSuite& ts) {
+    int setTestSuite(const TestSuite& ts)
+    {
         doctest_detail_test_suite_ns::getCurrentTestSuite() = ts;
         return 0;
     }
@@ -3756,10 +3888,11 @@ namespace detail {
     // http://developer.apple.com/library/mac/#qa/qa2004/qa1361.html
     // Returns true if the current process is being debugged (either
     // running under the debugger or has a debugger attached post facto).
-    bool isDebuggerActive() {
-        int        mib[4];
+    bool isDebuggerActive()
+    {
+        int mib[4];
         kinfo_proc info;
-        size_t     size;
+        size_t size;
         // Initialize the flags so that, if sysctl fails for some bizarre
         // reason, we get a predictable result.
         info.kp_proc.p_flag = 0;
@@ -3771,9 +3904,11 @@ namespace detail {
         mib[3] = getpid();
         // Call sysctl.
         size = sizeof(info);
-        if(sysctl(mib, DOCTEST_COUNTOF(mib), &info, &size, 0, 0) != 0) {
-            fprintf(stderr, "\n** Call to sysctl failed - unable to determine if debugger is "
-                            "active **\n\n");
+        if (sysctl(mib, DOCTEST_COUNTOF(mib), &info, &size, 0, 0) != 0)
+        {
+            fprintf(stderr,
+                    "\n** Call to sysctl failed - unable to determine if debugger is "
+                    "active **\n\n");
             return false;
         }
         // We're being debugged if the P_TRACED flag is set.
@@ -3783,11 +3918,12 @@ namespace detail {
     bool isDebuggerActive() { return ::IsDebuggerPresent() != 0; }
 #else
     bool isDebuggerActive() { return false; }
-#endif // Platform
+#endif  // Platform
 
-    void registerExceptionTranslatorImpl(const IExceptionTranslator* et) {
-        if(std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), et) ==
-           getExceptionTranslators().end())
+    void registerExceptionTranslatorImpl(const IExceptionTranslator* et)
+    {
+        if (std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), et) ==
+            getExceptionTranslators().end())
             getExceptionTranslators().push_back(et);
     }
 
@@ -3796,7 +3932,7 @@ namespace detail {
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
     void toStream(std::ostream* s, char* in) { *s << in; }
     void toStream(std::ostream* s, const char* in) { *s << in; }
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+#endif  // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
     void toStream(std::ostream* s, bool in) { *s << std::boolalpha << in << std::noboolalpha; }
     void toStream(std::ostream* s, float in) { *s << in; }
     void toStream(std::ostream* s, double in) { *s << in; }
@@ -3814,38 +3950,38 @@ namespace detail {
     void toStream(std::ostream* s, int long long in) { *s << in; }
     void toStream(std::ostream* s, int long long unsigned in) { *s << in; }
 
-    DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
+    DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts;  // for logging with INFO()
 
-    ContextBuilder::ICapture::ICapture()  = default;
+    ContextBuilder::ICapture::ICapture() = default;
     ContextBuilder::ICapture::~ICapture() = default;
 
-    ContextBuilder::Chunk::Chunk()  = default;
+    ContextBuilder::Chunk::Chunk() = default;
     ContextBuilder::Chunk::~Chunk() = default;
 
-    ContextBuilder::Node::Node()  = default;
+    ContextBuilder::Node::Node() = default;
     ContextBuilder::Node::~Node() = default;
 
     // steal the contents of the other - acting as a move constructor...
     ContextBuilder::ContextBuilder(ContextBuilder& other)
-            : numCaptures(other.numCaptures)
-            , head(other.head)
-            , tail(other.tail) {
+        : numCaptures(other.numCaptures), head(other.head), tail(other.tail)
+    {
         other.numCaptures = 0;
-        other.head        = nullptr;
-        other.tail        = nullptr;
-        memcpy(stackChunks, other.stackChunks,
-               unsigned(int(sizeof(Chunk)) * DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK));
+        other.head = nullptr;
+        other.tail = nullptr;
+        memcpy(stackChunks, other.stackChunks, unsigned(int(sizeof(Chunk)) * DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK));
     }
 
     DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wcast-align")
-    void ContextBuilder::stringify(std::ostream* s) const {
+    void ContextBuilder::stringify(std::ostream* s) const
+    {
         int curr = 0;
         // iterate over small buffer
-        while(curr < numCaptures && curr < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK)
+        while (curr < numCaptures && curr < DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK)
             reinterpret_cast<const ICapture*>(stackChunks[curr++].buf)->toStream(s);
         // iterate over list
         auto curr_elem = head;
-        while(curr < numCaptures) {
+        while (curr < numCaptures)
+        {
             reinterpret_cast<const ICapture*>(curr_elem->chunk.buf)->toStream(s);
             curr_elem = curr_elem->next;
             ++curr;
@@ -3855,26 +3991,27 @@ namespace detail {
 
     ContextBuilder::ContextBuilder() = default;
 
-    ContextBuilder::~ContextBuilder() {
+    ContextBuilder::~ContextBuilder()
+    {
         // free the linked list - the ones on the stack are left as-is
         // no destructors are called at all - there is no need
-        while(head) {
+        while (head)
+        {
             auto next = head->next;
             delete head;
             head = next;
         }
     }
 
-    ContextScope::ContextScope(ContextBuilder& temp)
-            : contextBuilder(temp) {
-        g_infoContexts.push_back(this);
-    }
+    ContextScope::ContextScope(ContextBuilder& temp) : contextBuilder(temp) { g_infoContexts.push_back(this); }
 
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996)  // std::uncaught_exception is deprecated in C++17
     DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
     DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-    ContextScope::~ContextScope() {
-        if(std::uncaught_exception()) {
+    ContextScope::~ContextScope()
+    {
+        if (std::uncaught_exception())
+        {
             std::ostringstream s;
             this->stringify(&s);
             g_cs->stringifiedContexts.push_back(s.str().c_str());
@@ -3886,15 +4023,16 @@ namespace detail {
     DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     void ContextScope::stringify(std::ostream* s) const { contextBuilder.stringify(s); }
-} // namespace detail
-namespace {
+}  // namespace detail
+namespace
+{
     using namespace detail;
 #if !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
     struct FatalConditionHandler
     {
         void reset() {}
     };
-#else // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+#else  // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
     void reportFatal(const std::string&);
 
@@ -3902,24 +4040,27 @@ namespace {
 
     struct SignalDefs
     {
-        DWORD       id;
+        DWORD id;
         const char* name;
     };
     // There is no 1-1 mapping between signals and windows exceptions.
     // Windows can easily distinguish between SO and SigSegV,
     // but SigInt, SigTerm, etc are handled differently.
     SignalDefs signalDefs[] = {
-            {EXCEPTION_ILLEGAL_INSTRUCTION, "SIGILL - Illegal instruction signal"},
-            {EXCEPTION_STACK_OVERFLOW, "SIGSEGV - Stack overflow"},
-            {EXCEPTION_ACCESS_VIOLATION, "SIGSEGV - Segmentation violation signal"},
-            {EXCEPTION_INT_DIVIDE_BY_ZERO, "Divide by zero error"},
+        {EXCEPTION_ILLEGAL_INSTRUCTION, "SIGILL - Illegal instruction signal"},
+        {EXCEPTION_STACK_OVERFLOW, "SIGSEGV - Stack overflow"},
+        {EXCEPTION_ACCESS_VIOLATION, "SIGSEGV - Segmentation violation signal"},
+        {EXCEPTION_INT_DIVIDE_BY_ZERO, "Divide by zero error"},
     };
 
     struct FatalConditionHandler
     {
-        static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo) {
-            for(size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
-                if(ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
+        static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo)
+        {
+            for (size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i)
+            {
+                if (ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id)
+                {
                     reportFatal(signalDefs[i].name);
                 }
             }
@@ -3928,11 +4069,12 @@ namespace {
             return EXCEPTION_CONTINUE_SEARCH;
         }
 
-        FatalConditionHandler() {
+        FatalConditionHandler()
+        {
             isSet = true;
             // 32k seems enough for doctest to handle stack overflow,
             // but the value was found experimentally, so there is no strong guarantee
-            guaranteeSize          = 32 * 1024;
+            guaranteeSize = 32 * 1024;
             exceptionHandlerHandle = nullptr;
             // Register as first handler in current chain
             exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
@@ -3940,54 +4082,57 @@ namespace {
             SetThreadStackGuarantee(&guaranteeSize);
         }
 
-        static void reset() {
-            if(isSet) {
+        static void reset()
+        {
+            if (isSet)
+            {
                 // Unregister handler and restore the old guarantee
                 RemoveVectoredExceptionHandler(exceptionHandlerHandle);
                 SetThreadStackGuarantee(&guaranteeSize);
                 exceptionHandlerHandle = nullptr;
-                isSet                  = false;
+                isSet = false;
             }
         }
 
         ~FatalConditionHandler() { reset(); }
 
     private:
-        static bool  isSet;
+        static bool isSet;
         static ULONG guaranteeSize;
         static PVOID exceptionHandlerHandle;
     };
 
-    bool  FatalConditionHandler::isSet                  = false;
-    ULONG FatalConditionHandler::guaranteeSize          = 0;
+    bool FatalConditionHandler::isSet = false;
+    ULONG FatalConditionHandler::guaranteeSize = 0;
     PVOID FatalConditionHandler::exceptionHandlerHandle = nullptr;
 
-#else // DOCTEST_PLATFORM_WINDOWS
+#else  // DOCTEST_PLATFORM_WINDOWS
 
     struct SignalDefs
     {
-        int         id;
+        int id;
         const char* name;
     };
-    SignalDefs signalDefs[] = {{SIGINT, "SIGINT - Terminal interrupt signal"},
-                               {SIGILL, "SIGILL - Illegal instruction signal"},
-                               {SIGFPE, "SIGFPE - Floating point error signal"},
-                               {SIGSEGV, "SIGSEGV - Segmentation violation signal"},
-                               {SIGTERM, "SIGTERM - Termination request signal"},
-                               {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}};
+    SignalDefs signalDefs[] = {
+        {SIGINT, "SIGINT - Terminal interrupt signal"},    {SIGILL, "SIGILL - Illegal instruction signal"},
+        {SIGFPE, "SIGFPE - Floating point error signal"},  {SIGSEGV, "SIGSEGV - Segmentation violation signal"},
+        {SIGTERM, "SIGTERM - Termination request signal"}, {SIGABRT, "SIGABRT - Abort (abnormal termination) signal"}};
 
     struct FatalConditionHandler
     {
-        static bool             isSet;
+        static bool isSet;
         static struct sigaction oldSigActions[DOCTEST_COUNTOF(signalDefs)];
-        static stack_t          oldSigStack;
-        static char             altStackMem[4 * SIGSTKSZ];
+        static stack_t oldSigStack;
+        static char altStackMem[4 * SIGSTKSZ];
 
-        static void handleSignal(int sig) {
+        static void handleSignal(int sig)
+        {
             const char* name = "<unknown signal>";
-            for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+            for (std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i)
+            {
                 SignalDefs& def = signalDefs[i];
-                if(sig == def.id) {
+                if (sig == def.id)
+                {
                     name = def.name;
                     break;
                 }
@@ -3997,26 +4142,31 @@ namespace {
             raise(sig);
         }
 
-        FatalConditionHandler() {
+        FatalConditionHandler()
+        {
             isSet = true;
             stack_t sigStack;
-            sigStack.ss_sp    = altStackMem;
-            sigStack.ss_size  = sizeof(altStackMem);
+            sigStack.ss_sp = altStackMem;
+            sigStack.ss_size = sizeof(altStackMem);
             sigStack.ss_flags = 0;
             sigaltstack(&sigStack, &oldSigStack);
             struct sigaction sa = {};
-            sa.sa_handler       = handleSignal; // NOLINT
-            sa.sa_flags         = SA_ONSTACK;
-            for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+            sa.sa_handler = handleSignal;  // NOLINT
+            sa.sa_flags = SA_ONSTACK;
+            for (std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i)
+            {
                 sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
             }
         }
 
         ~FatalConditionHandler() { reset(); }
-        static void reset() {
-            if(isSet) {
+        static void reset()
+        {
+            if (isSet)
+            {
                 // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
-                for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+                for (std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i)
+                {
                     sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
                 }
                 // Return the old stack
@@ -4026,17 +4176,18 @@ namespace {
         }
     };
 
-    bool             FatalConditionHandler::isSet                                      = false;
+    bool FatalConditionHandler::isSet = false;
     struct sigaction FatalConditionHandler::oldSigActions[DOCTEST_COUNTOF(signalDefs)] = {};
-    stack_t          FatalConditionHandler::oldSigStack                                = {};
-    char             FatalConditionHandler::altStackMem[]                              = {};
+    stack_t FatalConditionHandler::oldSigStack = {};
+    char FatalConditionHandler::altStackMem[] = {};
 
-#endif // DOCTEST_PLATFORM_WINDOWS
-#endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+#endif  // DOCTEST_PLATFORM_WINDOWS
+#endif  // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
-} // namespace
+}  // namespace
 
-namespace {
+namespace
+{
     using namespace detail;
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
@@ -4044,23 +4195,26 @@ namespace {
 #else
     // TODO: integration with XCode and other IDEs
 #define DOCTEST_OUTPUT_DEBUG_STRING(text)
-#endif // Platform
+#endif  // Platform
 
-    void addAssert(assertType::Enum at) {
-        if((at & assertType::is_warn) == 0) //!OCLINT bitwise operator in conditional
+    void addAssert(assertType::Enum at)
+    {
+        if ((at & assertType::is_warn) == 0)  //!OCLINT bitwise operator in conditional
             g_cs->numAssertsForCurrentTestCase_atomic++;
     }
 
-    void addFailedAssert(assertType::Enum at) {
-        if((at & assertType::is_warn) == 0) //!OCLINT bitwise operator in conditional
+    void addFailedAssert(assertType::Enum at)
+    {
+        if ((at & assertType::is_warn) == 0)  //!OCLINT bitwise operator in conditional
             g_cs->numAssertsFailedForCurrentTestCase_atomic++;
     }
 
 #if defined(DOCTEST_CONFIG_POSIX_SIGNALS) || defined(DOCTEST_CONFIG_WINDOWS_SEH)
-    void reportFatal(const std::string& message) {
+    void reportFatal(const std::string& message)
+    {
         g_cs->seconds_so_far += g_timer.getElapsedSeconds();
         g_cs->failure_flags |= TestCaseFailureReason::Crash;
-        g_cs->error_string   = message.c_str();
+        g_cs->error_string = message.c_str();
         g_cs->should_reenter = false;
 
         // TODO: end all currently opened subcases...?
@@ -4071,81 +4225,94 @@ namespace {
 
         DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
     }
-#endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
-} // namespace
-namespace detail {
+#endif  // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
+}  // namespace
+namespace detail
+{
 
     ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                                 const char* exception_type) {
-        m_test_case      = g_cs->currentTest;
-        m_at             = at;
-        m_file           = file;
-        m_line           = line;
-        m_expr           = expr;
-        m_failed         = true;
-        m_threw          = false;
-        m_threw_as       = false;
+                                 const char* exception_type)
+    {
+        m_test_case = g_cs->currentTest;
+        m_at = at;
+        m_file = file;
+        m_line = line;
+        m_expr = expr;
+        m_failed = true;
+        m_threw = false;
+        m_threw_as = false;
         m_exception_type = exception_type;
 #if DOCTEST_MSVC
-        if(m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
+        if (m_expr[0] == ' ')  // this happens when variadic macros are disabled under MSVC
             ++m_expr;
-#endif // MSVC
+#endif  // MSVC
     }
 
     DOCTEST_DEFINE_DEFAULTS(ResultBuilder);
 
-    void ResultBuilder::setResult(const Result& res) {
+    void ResultBuilder::setResult(const Result& res)
+    {
         m_decomp = res.m_decomp;
         m_failed = !res.m_passed;
     }
 
-    void ResultBuilder::translateException() {
-        m_threw     = true;
+    void ResultBuilder::translateException()
+    {
+        m_threw = true;
         m_exception = translateActiveException();
     }
 
-    bool ResultBuilder::log() {
-        if(m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
+    bool ResultBuilder::log()
+    {
+        if (m_at & assertType::is_throws)
+        {  //!OCLINT bitwise operator in conditional
             m_failed = !m_threw;
-        } else if(m_at & assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
+        }
+        else if (m_at & assertType::is_throws_as)
+        {  //!OCLINT bitwise operator in conditional
             m_failed = !m_threw_as;
-        } else if(m_at & assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
+        }
+        else if (m_at & assertType::is_throws_with)
+        {  //!OCLINT bitwise operator in conditional
             m_failed = m_exception != m_exception_type;
-        } else if(m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
+        }
+        else if (m_at & assertType::is_nothrow)
+        {  //!OCLINT bitwise operator in conditional
             m_failed = m_threw;
         }
 
-        if(m_exception.size())
-            m_exception = String("\"") + m_exception + "\"";
+        if (m_exception.size()) m_exception = String("\"") + m_exception + "\"";
 
-        if(is_running_in_test) {
+        if (is_running_in_test)
+        {
             addAssert(m_at);
             DOCTEST_ITERATE_THROUGH_REPORTERS(log_assert, *this);
 
-            if(m_failed)
-                addFailedAssert(m_at);
-        } else if(m_failed) {
+            if (m_failed) addFailedAssert(m_at);
+        }
+        else if (m_failed)
+        {
             failed_out_of_a_testing_context(*this);
         }
 
-        return m_failed && isDebuggerActive() &&
-               !getContextOptions()->no_breaks; // break into debugger
+        return m_failed && isDebuggerActive() && !getContextOptions()->no_breaks;  // break into debugger
     }
 
-    void ResultBuilder::react() const {
-        if(m_failed && checkIfShouldThrow(m_at))
-            throwException();
+    void ResultBuilder::react() const
+    {
+        if (m_failed && checkIfShouldThrow(m_at)) throwException();
     }
 
-    void failed_out_of_a_testing_context(const AssertData& ad) {
-        if(g_cs->ah)
+    void failed_out_of_a_testing_context(const AssertData& ad)
+    {
+        if (g_cs->ah)
             g_cs->ah(ad);
         else
             std::abort();
     }
 
-    void decomp_assert(assertType::Enum at, const char* file, int line, const char* expr,
-                       Result result) {
+    void decomp_assert(assertType::Enum at, const char* file, int line, const char* expr, Result result)
+    {
         bool failed = !result.m_passed;
 
         // ###################################################################################
@@ -4156,98 +4323,105 @@ namespace detail {
         DOCTEST_ASSERT_IN_TESTS(result.m_decomp);
     }
 
-    MessageBuilder::MessageBuilder(const char* file, int line, assertType::Enum severity) {
-        m_stream   = getTlsOss();
-        m_file     = file;
-        m_line     = line;
+    MessageBuilder::MessageBuilder(const char* file, int line, assertType::Enum severity)
+    {
+        m_stream = getTlsOss();
+        m_file = file;
+        m_line = line;
         m_severity = severity;
     }
 
-    IExceptionTranslator::IExceptionTranslator()  = default;
+    IExceptionTranslator::IExceptionTranslator() = default;
     IExceptionTranslator::~IExceptionTranslator() = default;
 
-    bool MessageBuilder::log() {
+    bool MessageBuilder::log()
+    {
         m_string = getTlsOssResult();
         DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);
 
         const bool isWarn = m_severity & assertType::is_warn;
 
         // warn is just a message in this context so we dont treat it as an assert
-        if(!isWarn) {
+        if (!isWarn)
+        {
             addAssert(m_severity);
             addFailedAssert(m_severity);
         }
 
-        return isDebuggerActive() && !getContextOptions()->no_breaks && !isWarn; // break
+        return isDebuggerActive() && !getContextOptions()->no_breaks && !isWarn;  // break
     }
 
-    void MessageBuilder::react() {
-        if(m_severity & assertType::is_require) //!OCLINT bitwise operator in conditional
+    void MessageBuilder::react()
+    {
+        if (m_severity & assertType::is_require)  //!OCLINT bitwise operator in conditional
             throwException();
     }
 
     MessageBuilder::~MessageBuilder() = default;
-} // namespace detail
-namespace {
+}  // namespace detail
+namespace
+{
     std::mutex g_mutex;
 
     using namespace detail;
     struct ConsoleReporter : public IReporter
     {
-        std::ostream&                 s;
-        bool                          hasLoggedCurrentTestStart;
+        std::ostream& s;
+        bool hasLoggedCurrentTestStart;
         std::vector<SubcaseSignature> subcasesStack;
 
         // caching pointers to objects of these types - safe to do
         const ContextOptions* opt;
-        const TestCaseData*   tc;
+        const TestCaseData* tc;
 
-        ConsoleReporter(std::ostream& in)
-                : s(in) {}
+        ConsoleReporter(std::ostream& in) : s(in) {}
 
         // =========================================================================================
         // WHAT FOLLOWS ARE HELPERS USED BY THE OVERRIDES OF THE VIRTUAL METHODS OF THE INTERFACE
         // =========================================================================================
 
-        void separator_to_stream() {
+        void separator_to_stream()
+        {
             s << Color::Yellow
               << "============================================================================="
                  "=="
                  "\n";
         }
 
-        void file_line_to_stream(const char* file, int line, const char* tail = "") {
-            s << Color::LightGrey << removePathFromFilename(file)
-              << (opt->gnu_file_line ? ":" : "(")
-              << (opt->no_line_numbers ? 0 : line) // 0 or the real num depending on the option
+        void file_line_to_stream(const char* file, int line, const char* tail = "")
+        {
+            s << Color::LightGrey << removePathFromFilename(file) << (opt->gnu_file_line ? ":" : "(")
+              << (opt->no_line_numbers ? 0 : line)  // 0 or the real num depending on the option
               << (opt->gnu_file_line ? ":" : "):") << tail;
         }
 
-        const char* getSuccessOrFailString(bool success, assertType::Enum at,
-                                           const char* success_str) {
-            if(success)
-                return success_str;
+        const char* getSuccessOrFailString(bool success, assertType::Enum at, const char* success_str)
+        {
+            if (success) return success_str;
             return failureString(at);
         }
 
-        Color::Enum getSuccessOrFailColor(bool success, assertType::Enum at) {
-            return success ? Color::BrightGreen :
-                             (at & assertType::is_warn) ? Color::Yellow : Color::Red;
+        Color::Enum getSuccessOrFailColor(bool success, assertType::Enum at)
+        {
+            return success ? Color::BrightGreen : (at & assertType::is_warn) ? Color::Yellow : Color::Red;
         }
 
         void successOrFailColoredStringToStream(bool success, assertType::Enum at,
-                                                const char* success_str = "SUCCESS: ") {
-            s << getSuccessOrFailColor(success, at)
-              << getSuccessOrFailString(success, at, success_str);
+                                                const char* success_str = "SUCCESS: ")
+        {
+            s << getSuccessOrFailColor(success, at) << getSuccessOrFailString(success, at, success_str);
         }
 
-        void log_contexts() {
+        void log_contexts()
+        {
             int num_contexts = get_num_active_contexts();
-            if(num_contexts) {
+            if (num_contexts)
+            {
                 auto contexts = get_active_contexts();
 
                 s << Color::None << "  logged: ";
-                for(int i = 0; i < num_contexts; ++i) {
+                for (int i = 0; i < num_contexts; ++i)
+                {
                     s << (i == 0 ? "" : "          ");
                     contexts[i]->stringify(&s);
                     s << "\n";
@@ -4257,23 +4431,20 @@ namespace {
             s << "\n";
         }
 
-        void logTestStart() {
-            if(hasLoggedCurrentTestStart)
-                return;
+        void logTestStart()
+        {
+            if (hasLoggedCurrentTestStart) return;
 
             separator_to_stream();
             file_line_to_stream(tc->m_file, tc->m_line, "\n");
-            if(tc->m_description)
-                s << Color::Yellow << "DESCRIPTION: " << Color::None << tc->m_description << "\n";
-            if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
+            if (tc->m_description) s << Color::Yellow << "DESCRIPTION: " << Color::None << tc->m_description << "\n";
+            if (tc->m_test_suite && tc->m_test_suite[0] != '\0')
                 s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
-            if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
-                s << Color::None << "TEST CASE:  ";
+            if (strncmp(tc->m_name, "  Scenario:", 11) != 0) s << Color::None << "TEST CASE:  ";
             s << Color::None << tc->m_name << "\n";
 
-            for(auto& curr : subcasesStack)
-                if(curr.m_name[0] != '\0')
-                    s << "  " << curr.m_name << "\n";
+            for (auto& curr : subcasesStack)
+                if (curr.m_name[0] != '\0') s << "  " << curr.m_name << "\n";
 
             s << "\n";
 
@@ -4286,111 +4457,124 @@ namespace {
 
         void test_run_start(const ContextOptions& o) override { opt = &o; }
 
-        void test_run_end(const TestRunStats& p) override {
+        void test_run_end(const TestRunStats& p) override
+        {
             separator_to_stream();
 
             const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
             s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(6)
               << p.numTestCasesPassingFilters << " | "
-              << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :
-                                                                          Color::Green)
-              << std::setw(6) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
-              << Color::None << " | " << (p.numTestCasesFailed > 0 ? Color::Red : Color::None)
-              << std::setw(6) << p.numTestCasesFailed << " failed" << Color::None << " | ";
-            if(opt->no_skipped_summary == false) {
+              << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None : Color::Green) << std::setw(6)
+              << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed" << Color::None << " | "
+              << (p.numTestCasesFailed > 0 ? Color::Red : Color::None) << std::setw(6) << p.numTestCasesFailed
+              << " failed" << Color::None << " | ";
+            if (opt->no_skipped_summary == false)
+            {
                 const int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
-                s << (numSkipped == 0 ? Color::None : Color::Yellow) << std::setw(6) << numSkipped
-                  << " skipped" << Color::None;
+                s << (numSkipped == 0 ? Color::None : Color::Yellow) << std::setw(6) << numSkipped << " skipped"
+                  << Color::None;
             }
             s << "\n";
-            s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(6)
-              << p.numAsserts << " | "
-              << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
-              << std::setw(6) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
-              << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(6)
-              << p.numAssertsFailed << " failed" << Color::None << " |\n";
+            s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(6) << p.numAsserts << " | "
+              << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green) << std::setw(6)
+              << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None << " | "
+              << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(6) << p.numAssertsFailed << " failed"
+              << Color::None << " |\n";
             s << Color::Cyan << "[doctest] " << Color::None
               << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)
               << ((p.numTestCasesFailed > 0) ? "FAILURE!\n" : "SUCCESS!\n") << Color::None;
         }
 
-        void test_case_start(const TestCaseData& in) override {
+        void test_case_start(const TestCaseData& in) override
+        {
             hasLoggedCurrentTestStart = false;
-            tc                        = &in;
+            tc = &in;
         }
 
-        void test_case_end(const CurrentTestCaseStats& st) override {
+        void test_case_end(const CurrentTestCaseStats& st) override
+        {
             // log the preamble of the test case only if there is something
             // else to print - something other than that an assert has failed
-            if(opt->duration ||
-               (st.failure_flags && st.failure_flags != TestCaseFailureReason::AssertFailure))
+            if (opt->duration || (st.failure_flags && st.failure_flags != TestCaseFailureReason::AssertFailure))
                 logTestStart();
 
             // report test case exceptions and crashes
             bool crashed = st.failure_flags & TestCaseFailureReason::Crash;
-            if(crashed || (st.failure_flags & TestCaseFailureReason::Exception)) {
+            if (crashed || (st.failure_flags & TestCaseFailureReason::Exception))
+            {
                 file_line_to_stream(tc->m_file, tc->m_line, " ");
-                successOrFailColoredStringToStream(false, crashed ? assertType::is_require :
-                                                                    assertType::is_check);
-                s << Color::Red << (crashed ? "test case CRASHED: " : "test case THREW exception: ")
-                  << Color::Cyan << st.error_string << "\n";
+                successOrFailColoredStringToStream(false, crashed ? assertType::is_require : assertType::is_check);
+                s << Color::Red << (crashed ? "test case CRASHED: " : "test case THREW exception: ") << Color::Cyan
+                  << st.error_string << "\n";
 
                 int num_stringified_contexts = get_num_stringified_contexts();
-                if(num_stringified_contexts) {
+                if (num_stringified_contexts)
+                {
                     auto stringified_contexts = get_stringified_contexts();
                     s << Color::None << "  logged: ";
-                    for(int i = num_stringified_contexts - 1; i >= 0; --i) {
-                        s << (i == num_stringified_contexts - 1 ? "" : "          ")
-                          << stringified_contexts[i] << "\n";
+                    for (int i = num_stringified_contexts - 1; i >= 0; --i)
+                    {
+                        s << (i == num_stringified_contexts - 1 ? "" : "          ") << stringified_contexts[i] << "\n";
                     }
                 }
                 s << "\n";
             }
 
             // means the test case will be re-entered because there are untraversed (but discovered) subcases
-            if(st.should_reenter)
-                return;
+            if (st.should_reenter) return;
 
-            if(opt->duration)
-                s << Color::None << std::setprecision(6) << std::fixed << st.seconds_so_far
-                  << " s: " << tc->m_name << "\n";
+            if (opt->duration)
+                s << Color::None << std::setprecision(6) << std::fixed << st.seconds_so_far << " s: " << tc->m_name
+                  << "\n";
 
-            if(st.failure_flags & TestCaseFailureReason::Timeout)
-                s << Color::Red << "Test case exceeded time limit of " << std::setprecision(6)
-                  << std::fixed << tc->m_timeout << "!\n";
+            if (st.failure_flags & TestCaseFailureReason::Timeout)
+                s << Color::Red << "Test case exceeded time limit of " << std::setprecision(6) << std::fixed
+                  << tc->m_timeout << "!\n";
 
-            if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt) {
+            if (st.failure_flags & TestCaseFailureReason::ShouldHaveFailedButDidnt)
+            {
                 s << Color::Red << "Should have failed but didn't! Marking it as failed!\n";
-            } else if(st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid) {
+            }
+            else if (st.failure_flags & TestCaseFailureReason::ShouldHaveFailedAndDid)
+            {
                 s << Color::Yellow << "Failed as expected so marking it as not failed\n";
-            } else if(st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid) {
+            }
+            else if (st.failure_flags & TestCaseFailureReason::CouldHaveFailedAndDid)
+            {
                 s << Color::Yellow << "Allowed to fail so marking it as not failed\n";
-            } else if(st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes) {
+            }
+            else if (st.failure_flags & TestCaseFailureReason::DidntFailExactlyNumTimes)
+            {
                 s << Color::Red << "Didn't fail exactly " << tc->m_expected_failures
                   << " times so marking it as failed!\n";
-            } else if(st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes) {
+            }
+            else if (st.failure_flags & TestCaseFailureReason::FailedExactlyNumTimes)
+            {
                 s << Color::Yellow << "Failed exactly " << tc->m_expected_failures
                   << " times as expected so marking it as not failed!\n";
             }
-            if(st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts) {
+            if (st.failure_flags & TestCaseFailureReason::TooManyFailedAsserts)
+            {
                 s << Color::Red << "Aborting - too many failed asserts!\n";
             }
             s << Color::None;
         }
 
-        void subcase_start(const SubcaseSignature& subc) override {
+        void subcase_start(const SubcaseSignature& subc) override
+        {
             subcasesStack.push_back(subc);
             hasLoggedCurrentTestStart = false;
         }
 
-        void subcase_end(const SubcaseSignature& /*subc*/) override {
+        void subcase_end(const SubcaseSignature& /*subc*/) override
+        {
             subcasesStack.pop_back();
             hasLoggedCurrentTestStart = false;
         }
 
-        void log_assert(const AssertData& rb) override {
-            if(!rb.m_failed && !opt->success)
-                return;
+        void log_assert(const AssertData& rb) override
+        {
+            if (!rb.m_failed && !opt->success) return;
 
             std::lock_guard<std::mutex> lock(g_mutex);
 
@@ -4398,36 +4582,38 @@ namespace {
 
             file_line_to_stream(rb.m_file, rb.m_line, " ");
             successOrFailColoredStringToStream(!rb.m_failed, rb.m_at);
-            if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==
-               0) //!OCLINT bitwise operator in conditional
-                s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) "
-                  << Color::None;
+            if ((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==
+                0)  //!OCLINT bitwise operator in conditional
+                s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) " << Color::None;
 
-            if(rb.m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
+            if (rb.m_at & assertType::is_throws)
+            {  //!OCLINT bitwise operator in conditional
                 s << (rb.m_threw ? "threw as expected!" : "did NOT throw at all!") << "\n";
-            } else if(rb.m_at &
-                      assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
-                s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", "
-                  << rb.m_exception_type << " ) " << Color::None
-                  << (rb.m_threw ? (rb.m_threw_as ? "threw as expected!" :
-                                                    "threw a DIFFERENT exception: ") :
-                                   "did NOT throw at all!")
+            }
+            else if (rb.m_at & assertType::is_throws_as)
+            {  //!OCLINT bitwise operator in conditional
+                s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", " << rb.m_exception_type << " ) "
+                  << Color::None
+                  << (rb.m_threw ? (rb.m_threw_as ? "threw as expected!" : "threw a DIFFERENT exception: ")
+                                 : "did NOT throw at all!")
                   << Color::Cyan << rb.m_exception << "\n";
-            } else if(rb.m_at &
-                      assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
-                s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-                  << rb.m_exception_type << "\" ) " << Color::None
-                  << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" :
-                                                   "threw a DIFFERENT exception: ") :
-                                   "did NOT throw at all!")
+            }
+            else if (rb.m_at & assertType::is_throws_with)
+            {  //!OCLINT bitwise operator in conditional
+                s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \"" << rb.m_exception_type
+                  << "\" ) " << Color::None
+                  << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" : "threw a DIFFERENT exception: ")
+                                 : "did NOT throw at all!")
                   << Color::Cyan << rb.m_exception << "\n";
-            } else if(rb.m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
-                s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan
-                  << rb.m_exception << "\n";
-            } else {
-                s << (rb.m_threw ? "THREW exception: " :
-                                   (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
-                if(rb.m_threw)
+            }
+            else if (rb.m_at & assertType::is_nothrow)
+            {  //!OCLINT bitwise operator in conditional
+                s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan << rb.m_exception << "\n";
+            }
+            else
+            {
+                s << (rb.m_threw ? "THREW exception: " : (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
+                if (rb.m_threw)
                     s << rb.m_exception << "\n";
                 else
                     s << "  values: " << assertString(rb.m_at) << "( " << rb.m_decomp << " )\n";
@@ -4436,15 +4622,15 @@ namespace {
             log_contexts();
         }
 
-        void log_message(const MessageData& mb) override {
+        void log_message(const MessageData& mb) override
+        {
             std::lock_guard<std::mutex> lock(g_mutex);
 
             logTestStart();
 
             file_line_to_stream(mb.m_file, mb.m_line, " ");
             s << getSuccessOrFailColor(false, mb.m_severity)
-              << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity,
-                                        "MESSAGE: ");
+              << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity, "MESSAGE: ");
             s << Color::None << mb.m_string << "\n";
             log_contexts();
         }
@@ -4455,35 +4641,36 @@ namespace {
     struct Whitespace
     {
         int nrSpaces;
-        explicit Whitespace(int nr)
-                : nrSpaces(nr) {}
+        explicit Whitespace(int nr) : nrSpaces(nr) {}
     };
 
-    std::ostream& operator<<(std::ostream& out, const Whitespace& ws) {
-        if(ws.nrSpaces != 0)
-            out << std::setw(ws.nrSpaces) << ' ';
+    std::ostream& operator<<(std::ostream& out, const Whitespace& ws)
+    {
+        if (ws.nrSpaces != 0) out << std::setw(ws.nrSpaces) << ' ';
         return out;
     }
 
     // extension of the console reporter - with a bunch of helpers for the stdout stream redirection
     struct ConsoleReporterWithHelpers : public ConsoleReporter
     {
-        ConsoleReporterWithHelpers(std::ostream& in)
-                : ConsoleReporter(in) {}
+        ConsoleReporterWithHelpers(std::ostream& in) : ConsoleReporter(in) {}
 
-        void printVersion() {
-            if(getContextOptions()->no_version == false)
-                s << Color::Cyan << "[doctest] " << Color::None << "doctest version is \""
-                  << DOCTEST_VERSION_STR << "\"\n";
+        void printVersion()
+        {
+            if (getContextOptions()->no_version == false)
+                s << Color::Cyan << "[doctest] " << Color::None << "doctest version is \"" << DOCTEST_VERSION_STR
+                  << "\"\n";
         }
 
-        void printIntro() {
+        void printIntro()
+        {
             printVersion();
             s << Color::Cyan << "[doctest] " << Color::None
               << "run with \"--" DOCTEST_OPTIONS_PREFIX_DISPLAY "help\" for options\n";
         }
 
-        void printHelp() {
+        void printHelp()
+        {
             int sizePrefixDisplay = static_cast<int>(strlen(DOCTEST_OPTIONS_PREFIX_DISPLAY));
             printVersion();
             // clang-format off
@@ -4592,36 +4779,40 @@ namespace {
             s << "for more information visit the project documentation\n\n";
         }
 
-        void printRegisteredReporters() {
+        void printRegisteredReporters()
+        {
             printVersion();
             s << Color::Cyan << "[doctest] " << Color::None << "listing all registered reporters\n";
-            for(auto& curr : getReporters())
-                s << "priority: " << std::setw(5) << curr.first.first
-                  << " name: " << curr.first.second << "\n";
+            for (auto& curr : getReporters())
+                s << "priority: " << std::setw(5) << curr.first.first << " name: " << curr.first.second << "\n";
         }
 
-        void output_query_results() {
+        void output_query_results()
+        {
             separator_to_stream();
-            if(getContextOptions()->count || getContextOptions()->list_test_cases) {
+            if (getContextOptions()->count || getContextOptions()->list_test_cases)
+            {
                 s << Color::Cyan << "[doctest] " << Color::None
-                  << "unskipped test cases passing the current filters: "
-                  << g_cs->numTestCasesPassingFilters << "\n";
-            } else if(getContextOptions()->list_test_suites) {
+                  << "unskipped test cases passing the current filters: " << g_cs->numTestCasesPassingFilters << "\n";
+            }
+            else if (getContextOptions()->list_test_suites)
+            {
                 s << Color::Cyan << "[doctest] " << Color::None
-                  << "unskipped test cases passing the current filters: "
-                  << g_cs->numTestCasesPassingFilters << "\n";
+                  << "unskipped test cases passing the current filters: " << g_cs->numTestCasesPassingFilters << "\n";
                 s << Color::Cyan << "[doctest] " << Color::None
                   << "test suites with unskipped test cases passing the current filters: "
                   << g_cs->numTestSuitesPassingFilters << "\n";
             }
         }
 
-        void output_query_preamble_test_cases() {
+        void output_query_preamble_test_cases()
+        {
             s << Color::Cyan << "[doctest] " << Color::None << "listing all test case names\n";
             separator_to_stream();
         }
 
-        void output_query_preamble_test_suites() {
+        void output_query_preamble_test_suites()
+        {
             s << Color::Cyan << "[doctest] " << Color::None << "listing all test suites\n";
             separator_to_stream();
         }
@@ -4634,19 +4825,20 @@ namespace {
     {
         DOCTEST_THREAD_LOCAL static std::ostringstream oss;
 
-        DebugOutputWindowReporter()
-                : ConsoleReporter(oss) {}
+        DebugOutputWindowReporter() : ConsoleReporter(oss) {}
 
-#define DOCTEST_DEBUG_OUTPUT_WINDOW_REPORTER_OVERRIDE(func, type)                                  \
-    void func(type in) override {                                                                  \
-        if(isDebuggerActive()) {                                                                   \
-            bool with_col = g_no_colors;                                                           \
-            g_no_colors   = false;                                                                 \
-            ConsoleReporter::func(in);                                                             \
-            DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                        \
-            oss.str("");                                                                           \
-            g_no_colors = with_col;                                                                \
-        }                                                                                          \
+#define DOCTEST_DEBUG_OUTPUT_WINDOW_REPORTER_OVERRIDE(func, type) \
+    void func(type in) override                                   \
+    {                                                             \
+        if (isDebuggerActive())                                   \
+        {                                                         \
+            bool with_col = g_no_colors;                          \
+            g_no_colors = false;                                  \
+            ConsoleReporter::func(in);                            \
+            DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());       \
+            oss.str("");                                          \
+            g_no_colors = with_col;                               \
+        }                                                         \
     }
 
         DOCTEST_DEBUG_OUTPUT_WINDOW_REPORTER_OVERRIDE(test_run_start, const ContextOptions&)
@@ -4661,56 +4853,67 @@ namespace {
     };
 
     DOCTEST_THREAD_LOCAL std::ostringstream DebugOutputWindowReporter::oss;
-#endif // DOCTEST_PLATFORM_WINDOWS
+#endif  // DOCTEST_PLATFORM_WINDOWS
 
     // the implementation of parseFlag()
-    bool parseFlagImpl(int argc, const char* const* argv, const char* pattern) {
-        for(int i = argc - 1; i >= 0; --i) {
+    bool parseFlagImpl(int argc, const char* const* argv, const char* pattern)
+    {
+        for (int i = argc - 1; i >= 0; --i)
+        {
             auto temp = std::strstr(argv[i], pattern);
-            if(temp && strlen(temp) == strlen(pattern)) {
+            if (temp && strlen(temp) == strlen(pattern))
+            {
                 // eliminate strings in which the chars before the option are not '-'
-                bool noBadCharsFound = true; //!OCLINT prefer early exits and continue
-                while(temp != argv[i]) {
-                    if(*--temp != '-') {
+                bool noBadCharsFound = true;  //!OCLINT prefer early exits and continue
+                while (temp != argv[i])
+                {
+                    if (*--temp != '-')
+                    {
                         noBadCharsFound = false;
                         break;
                     }
                 }
-                if(noBadCharsFound && argv[i][0] == '-')
-                    return true;
+                if (noBadCharsFound && argv[i][0] == '-') return true;
             }
         }
         return false;
     }
 
     // locates a flag on the command line
-    bool parseFlag(int argc, const char* const* argv, const char* pattern) {
+    bool parseFlag(int argc, const char* const* argv, const char* pattern)
+    {
 #ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
         // offset (normally 3 for "dt-") to skip prefix
-        if(parseFlagImpl(argc, argv, pattern + strlen(DOCTEST_CONFIG_OPTIONS_PREFIX)))
-            return true;
-#endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+        if (parseFlagImpl(argc, argv, pattern + strlen(DOCTEST_CONFIG_OPTIONS_PREFIX))) return true;
+#endif  // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
         return parseFlagImpl(argc, argv, pattern);
     }
 
     // the implementation of parseOption()
-    bool parseOptionImpl(int argc, const char* const* argv, const char* pattern, String& res) {
-        for(int i = argc - 1; i >= 0; --i) {
+    bool parseOptionImpl(int argc, const char* const* argv, const char* pattern, String& res)
+    {
+        for (int i = argc - 1; i >= 0; --i)
+        {
             auto temp = std::strstr(argv[i], pattern);
-            if(temp) { //!OCLINT prefer early exits and continue
+            if (temp)
+            {  //!OCLINT prefer early exits and continue
                 // eliminate matches in which the chars before the option are not '-'
                 bool noBadCharsFound = true;
-                auto curr            = argv[i];
-                while(curr != temp) {
-                    if(*curr++ != '-') {
+                auto curr = argv[i];
+                while (curr != temp)
+                {
+                    if (*curr++ != '-')
+                    {
                         noBadCharsFound = false;
                         break;
                     }
                 }
-                if(noBadCharsFound && argv[i][0] == '-') {
+                if (noBadCharsFound && argv[i][0] == '-')
+                {
                     temp += strlen(pattern);
                     const unsigned len = strlen(temp);
-                    if(len) {
+                    if (len)
+                    {
                         res = temp;
                         return true;
                     }
@@ -4722,28 +4925,29 @@ namespace {
 
     // parses an option and returns the string after the '=' character
     bool parseOption(int argc, const char* const* argv, const char* pattern, String& res,
-                     const String& defaultVal = String()) {
+                     const String& defaultVal = String())
+    {
         res = defaultVal;
 #ifndef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
         // offset (normally 3 for "dt-") to skip prefix
-        if(parseOptionImpl(argc, argv, pattern + strlen(DOCTEST_CONFIG_OPTIONS_PREFIX), res))
-            return true;
-#endif // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
+        if (parseOptionImpl(argc, argv, pattern + strlen(DOCTEST_CONFIG_OPTIONS_PREFIX), res)) return true;
+#endif  // DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
         return parseOptionImpl(argc, argv, pattern, res);
     }
 
     // parses a comma separated list of words after a pattern in one of the arguments in argv
-    bool parseCommaSepArgs(int argc, const char* const* argv, const char* pattern,
-                           std::vector<String>& res) {
+    bool parseCommaSepArgs(int argc, const char* const* argv, const char* pattern, std::vector<String>& res)
+    {
         String filtersString;
-        if(parseOption(argc, argv, pattern, filtersString)) {
+        if (parseOption(argc, argv, pattern, filtersString))
+        {
             // tokenize with "," as a separator
             // cppcheck-suppress strtokCalled
             DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-            auto pch = std::strtok(filtersString.c_str(), ","); // modifies the string
-            while(pch != nullptr) {
-                if(strlen(pch))
-                    res.push_back(pch);
+            auto pch = std::strtok(filtersString.c_str(), ",");  // modifies the string
+            while (pch != nullptr)
+            {
+                if (strlen(pch)) res.push_back(pch);
                 // uses the strtok() internal state to go to the next token
                 // cppcheck-suppress strtokCalled
                 pch = std::strtok(nullptr, ",");
@@ -4761,56 +4965,60 @@ namespace {
     };
 
     // parses an int/bool option from the command line
-    bool parseIntOption(int argc, const char* const* argv, const char* pattern, optionType type,
-                        int& res) {
+    bool parseIntOption(int argc, const char* const* argv, const char* pattern, optionType type, int& res)
+    {
         String parsedValue;
-        if(!parseOption(argc, argv, pattern, parsedValue))
-            return false;
+        if (!parseOption(argc, argv, pattern, parsedValue)) return false;
 
-        if(type == 0) {
+        if (type == 0)
+        {
             // boolean
-            const char positive[][5] = {"1", "true", "on", "yes"};  // 5 - strlen("true") + 1
-            const char negative[][6] = {"0", "false", "off", "no"}; // 6 - strlen("false") + 1
+            const char positive[][5] = {"1", "true", "on", "yes"};   // 5 - strlen("true") + 1
+            const char negative[][6] = {"0", "false", "off", "no"};  // 6 - strlen("false") + 1
 
             // if the value matches any of the positive/negative possibilities
-            for(unsigned i = 0; i < 4; i++) {
-                if(parsedValue.compare(positive[i], true) == 0) {
-                    res = 1; //!OCLINT parameter reassignment
+            for (unsigned i = 0; i < 4; i++)
+            {
+                if (parsedValue.compare(positive[i], true) == 0)
+                {
+                    res = 1;  //!OCLINT parameter reassignment
                     return true;
                 }
-                if(parsedValue.compare(negative[i], true) == 0) {
-                    res = 0; //!OCLINT parameter reassignment
+                if (parsedValue.compare(negative[i], true) == 0)
+                {
+                    res = 0;  //!OCLINT parameter reassignment
                     return true;
                 }
             }
-        } else {
+        }
+        else
+        {
             // integer
             // TODO: change this to use std::stoi or something else! currently it uses undefined behavior - assumes '0' on unsuccessful parse...
-            int theInt = std::atoi(parsedValue.c_str()); // NOLINT
-            if(theInt != 0) {
-                res = theInt; //!OCLINT parameter reassignment
+            int theInt = std::atoi(parsedValue.c_str());  // NOLINT
+            if (theInt != 0)
+            {
+                res = theInt;  //!OCLINT parameter reassignment
                 return true;
             }
         }
         return false;
     }
-} // namespace
+}  // namespace
 
-Context::Context(int argc, const char* const* argv)
-        : p(new detail::ContextState) {
-    parseArgs(argc, argv, true);
-}
+Context::Context(int argc, const char* const* argv) : p(new detail::ContextState) { parseArgs(argc, argv, true); }
 
-Context::~Context() {
-    if(g_cs == p)
-        g_cs = nullptr;
+Context::~Context()
+{
+    if (g_cs == p) g_cs = nullptr;
     delete p;
 }
 
 void Context::applyCommandLine(int argc, const char* const* argv) { parseArgs(argc, argv); }
 
 // parses args
-void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
+void Context::parseArgs(int argc, const char* const* argv, bool withDefaults)
+{
     using namespace detail;
 
     // clang-format off
@@ -4834,30 +5042,29 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     parseCommaSepArgs(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "r=",                  p->filters[8]);
     // clang-format on
 
-    int    intRes = 0;
+    int intRes = 0;
     String strRes;
 
 #define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                   \
-    if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||  \
-       parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))   \
+    if (parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) || \
+        parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))  \
         p->var = !!intRes;                                                                         \
-    else if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                           \
-            parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                            \
+    else if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                          \
+             parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                           \
         p->var = true;                                                                             \
-    else if(withDefaults)                                                                          \
+    else if (withDefaults)                                                                         \
     p->var = default
 
-#define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                        \
-    if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_int, intRes) ||   \
-       parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_int, intRes))    \
-        p->var = intRes;                                                                           \
-    else if(withDefaults)                                                                          \
+#define DOCTEST_PARSE_INT_OPTION(name, sname, var, default)                                       \
+    if (parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_int, intRes) || \
+        parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_int, intRes))  \
+        p->var = intRes;                                                                          \
+    else if (withDefaults)                                                                        \
     p->var = default
 
-#define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                        \
-    if(parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", strRes, default) ||         \
-       parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", strRes, default) ||        \
-       withDefaults)                                                                               \
+#define DOCTEST_PARSE_STR_OPTION(name, sname, var, default)                                                \
+    if (parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", strRes, default) ||                \
+        parseOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", strRes, default) || withDefaults) \
     p->var = strRes
 
     // clang-format off
@@ -4888,44 +5095,51 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skipped-summary", "nss", no_skipped_summary, false);
     // clang-format on
 
-    if(withDefaults) {
-        p->help             = false;
-        p->version          = false;
-        p->count            = false;
-        p->list_test_cases  = false;
+    if (withDefaults)
+    {
+        p->help = false;
+        p->version = false;
+        p->count = false;
+        p->list_test_cases = false;
         p->list_test_suites = false;
-        p->list_reporters   = false;
+        p->list_reporters = false;
     }
-    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "help") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "h") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "?")) {
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "help") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "h") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "?"))
+    {
         p->help = true;
         p->exit = true;
     }
-    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "version") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "v")) {
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "version") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "v"))
+    {
         p->version = true;
-        p->exit    = true;
+        p->exit = true;
     }
-    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "count") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "c")) {
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "count") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "c"))
+    {
         p->count = true;
-        p->exit  = true;
+        p->exit = true;
     }
-    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-cases") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ltc")) {
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-cases") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "ltc"))
+    {
         p->list_test_cases = true;
-        p->exit            = true;
+        p->exit = true;
     }
-    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-suites") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lts")) {
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-test-suites") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lts"))
+    {
         p->list_test_suites = true;
-        p->exit             = true;
+        p->exit = true;
     }
-    if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-reporters") ||
-       parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lr")) {
+    if (parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "list-reporters") ||
+        parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX "lr"))
+    {
         p->list_reporters = true;
-        p->exit           = true;
+        p->exit = true;
     }
 }
 
@@ -4933,19 +5147,18 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
 void Context::addFilter(const char* filter, const char* value) { setOption(filter, value); }
 
 // allows the user to clear all filters from the command line
-void Context::clearFilters() {
-    for(auto& curr : p->filters)
-        curr.clear();
+void Context::clearFilters()
+{
+    for (auto& curr : p->filters) curr.clear();
 }
 
 // allows the user to override procedurally the int/bool options from the command line
-void Context::setOption(const char* option, int value) {
-    setOption(option, toString(value).c_str());
-}
+void Context::setOption(const char* option, int value) { setOption(option, toString(value).c_str()); }
 
 // allows the user to override procedurally the string options from the command line
-void Context::setOption(const char* option, const char* value) {
-    auto argv   = String("-") + option + "=" + value;
+void Context::setOption(const char* option, const char* value)
+{
+    auto argv = String("-") + option + "=" + value;
     auto lvalue = argv.c_str();
     parseArgs(1, &lvalue);
 }
@@ -4958,13 +5171,14 @@ void Context::setAsDefaultForAssertsOutOfTestCases() { g_cs = p; }
 void Context::setAssertHandler(detail::assert_handler ah) { p->ah = ah; }
 
 // the main function that does all the filtering and test running
-int Context::run() {
+int Context::run()
+{
     using namespace detail;
 
-    auto old_cs        = g_cs;
-    g_cs               = p;
+    auto old_cs = g_cs;
+    g_cs = p;
     is_running_in_test = true;
-    g_no_colors        = p->no_colors;
+    g_no_colors = p->no_colors;
     p->resetRunData();
 
     ConsoleReporterWithHelpers con_rep(std::cout);
@@ -4972,32 +5186,30 @@ int Context::run() {
 
     // setup default reporter if none is given through the command line
     p->reporters_currently_used.clear();
-    if(p->filters[8].empty())
+    if (p->filters[8].empty())
         p->reporters_currently_used.push_back(getReporters()[reporterMap::key_type(0, "console")]);
 
     // check to see if any of the registered reporters has been selected
-    for(auto& curr : getReporters()) {
-        if(matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
+    for (auto& curr : getReporters())
+    {
+        if (matchesAny(curr.first.second.c_str(), p->filters[8], false, p->case_sensitive))
             p->reporters_currently_used.push_back(curr.second);
     }
 
     // always use the debug output window reporter
 #ifdef DOCTEST_PLATFORM_WINDOWS
     DebugOutputWindowReporter debug_output_rep;
-    if(isDebuggerActive())
-        p->reporters_currently_used.push_back(&debug_output_rep);
-#endif // DOCTEST_PLATFORM_WINDOWS
+    if (isDebuggerActive()) p->reporters_currently_used.push_back(&debug_output_rep);
+#endif  // DOCTEST_PLATFORM_WINDOWS
 
     // handle version, help and no_run
-    if(p->no_run || p->version || p->help || p->list_reporters) {
-        if(p->version)
-            con_rep.printVersion();
-        if(p->help)
-            con_rep.printHelp();
-        if(p->list_reporters)
-            con_rep.printRegisteredReporters();
+    if (p->no_run || p->version || p->help || p->list_reporters)
+    {
+        if (p->version) con_rep.printVersion();
+        if (p->help) con_rep.printHelp();
+        if (p->list_reporters) con_rep.printRegisteredReporters();
 
-        g_cs               = old_cs;
+        g_cs = old_cs;
         is_running_in_test = false;
 
         return EXIT_SUCCESS;
@@ -5006,94 +5218,94 @@ int Context::run() {
     con_rep.printIntro();
 
     std::vector<const TestCase*> testArray;
-    for(auto& curr : getRegisteredTests())
-        testArray.push_back(&curr);
+    for (auto& curr : getRegisteredTests()) testArray.push_back(&curr);
     p->numTestCases = testArray.size();
 
     // sort the collected records
-    if(!testArray.empty()) {
-        if(p->order_by.compare("file", true) == 0) {
+    if (!testArray.empty())
+    {
+        if (p->order_by.compare("file", true) == 0)
+        {
             std::qsort(&testArray[0], testArray.size(), sizeof(TestCase*), fileOrderComparator);
-        } else if(p->order_by.compare("suite", true) == 0) {
+        }
+        else if (p->order_by.compare("suite", true) == 0)
+        {
             std::qsort(&testArray[0], testArray.size(), sizeof(TestCase*), suiteOrderComparator);
-        } else if(p->order_by.compare("name", true) == 0) {
+        }
+        else if (p->order_by.compare("name", true) == 0)
+        {
             std::qsort(&testArray[0], testArray.size(), sizeof(TestCase*), nameOrderComparator);
-        } else if(p->order_by.compare("rand", true) == 0) {
+        }
+        else if (p->order_by.compare("rand", true) == 0)
+        {
             std::srand(p->rand_seed);
 
             // random_shuffle implementation
             const auto first = &testArray[0];
-            for(size_t i = testArray.size() - 1; i > 0; --i) {
-                int idxToSwap = std::rand() % (i + 1); // NOLINT
+            for (size_t i = testArray.size() - 1; i > 0; --i)
+            {
+                int idxToSwap = std::rand() % (i + 1);  // NOLINT
 
                 const auto temp = first[i];
 
-                first[i]         = first[idxToSwap];
+                first[i] = first[idxToSwap];
                 first[idxToSwap] = temp;
             }
         }
     }
 
-    if(p->list_test_cases)
-        con_rep.output_query_preamble_test_cases();
+    if (p->list_test_cases) con_rep.output_query_preamble_test_cases();
 
     std::set<String> testSuitesPassingFilt;
-    if(p->list_test_suites)
-        con_rep.output_query_preamble_test_suites();
+    if (p->list_test_suites) con_rep.output_query_preamble_test_suites();
 
     bool query_mode = p->count || p->list_test_cases || p->list_test_suites;
 
-    if(!query_mode)
-        DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, *g_cs);
+    if (!query_mode) DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, *g_cs);
 
     // invoke the registered functions if they match the filter criteria (or just count them)
-    for(auto& curr : testArray) {
+    for (auto& curr : testArray)
+    {
         const auto tc = *curr;
 
         bool skip_me = false;
-        if(tc.m_skip && !p->no_skip)
-            skip_me = true;
+        if (tc.m_skip && !p->no_skip) skip_me = true;
 
-        if(!matchesAny(tc.m_file, p->filters[0], true, p->case_sensitive))
-            skip_me = true;
-        if(matchesAny(tc.m_file, p->filters[1], false, p->case_sensitive))
-            skip_me = true;
-        if(!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive))
-            skip_me = true;
-        if(matchesAny(tc.m_test_suite, p->filters[3], false, p->case_sensitive))
-            skip_me = true;
-        if(!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive))
-            skip_me = true;
-        if(matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive))
-            skip_me = true;
+        if (!matchesAny(tc.m_file, p->filters[0], true, p->case_sensitive)) skip_me = true;
+        if (matchesAny(tc.m_file, p->filters[1], false, p->case_sensitive)) skip_me = true;
+        if (!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive)) skip_me = true;
+        if (matchesAny(tc.m_test_suite, p->filters[3], false, p->case_sensitive)) skip_me = true;
+        if (!matchesAny(tc.m_name, p->filters[4], true, p->case_sensitive)) skip_me = true;
+        if (matchesAny(tc.m_name, p->filters[5], false, p->case_sensitive)) skip_me = true;
 
-        if(!skip_me)
-            p->numTestCasesPassingFilters++;
+        if (!skip_me) p->numTestCasesPassingFilters++;
 
         // skip the test if it is not in the execution range
-        if((p->last < p->numTestCasesPassingFilters && p->first <= p->last) ||
-           (p->first > p->numTestCasesPassingFilters))
+        if ((p->last < p->numTestCasesPassingFilters && p->first <= p->last) ||
+            (p->first > p->numTestCasesPassingFilters))
             skip_me = true;
 
-        if(skip_me) {
-            if(!query_mode)
-                DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_skipped, tc);
+        if (skip_me)
+        {
+            if (!query_mode) DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_skipped, tc);
             continue;
         }
 
         // do not execute the test if we are to only count the number of filter passing tests
-        if(p->count)
-            continue;
+        if (p->count) continue;
 
         // print the name of the test and don't execute it
-        if(p->list_test_cases) {
+        if (p->list_test_cases)
+        {
             con_rep.output_c_string_with_newline(tc.m_name);
             continue;
         }
 
         // print the name of the test suite if not done already and don't execute it
-        if(p->list_test_suites) {
-            if((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0') {
+        if (p->list_test_suites)
+        {
+            if ((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0')
+            {
                 con_rep.output_c_string_with_newline(tc.m_test_suite);
                 testSuitesPassingFilt.insert(tc.m_test_suite);
                 p->numTestSuitesPassingFilters++;
@@ -5105,18 +5317,19 @@ int Context::run() {
         {
             p->currentTest = &tc;
 
-            p->failure_flags  = TestCaseFailureReason::None;
+            p->failure_flags = TestCaseFailureReason::None;
             p->seconds_so_far = 0;
-            p->error_string   = "";
+            p->error_string = "";
 
             // reset non-atomic counters
             p->numAssertsFailedForCurrentTestCase = 0;
-            p->numAssertsForCurrentTestCase       = 0;
+            p->numAssertsForCurrentTestCase = 0;
 
             p->subcasesPassed.clear();
-            do {
+            do
+            {
                 // reset some of the fields for subcases (except for the set of fully passed ones)
-                p->should_reenter       = false;
+                p->should_reenter = false;
                 p->subcasesCurrentLevel = 0;
                 p->subcasesEnteredLevels.clear();
 
@@ -5125,27 +5338,32 @@ int Context::run() {
 
                 // reset atomic counters
                 p->numAssertsFailedForCurrentTestCase_atomic = 0;
-                p->numAssertsForCurrentTestCase_atomic       = 0;
+                p->numAssertsForCurrentTestCase_atomic = 0;
 
                 DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
 
                 g_timer.start();
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                try {
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-                    FatalConditionHandler fatalConditionHandler; // Handle signals
+                try
+                {
+#endif  // DOCTEST_CONFIG_NO_EXCEPTIONS
+                    FatalConditionHandler fatalConditionHandler;  // Handle signals
                     // execute the test
                     tc.m_test();
                     fatalConditionHandler.reset();
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-                } catch(const TestFailureException&) {
+                }
+                catch (const TestFailureException&)
+                {
                     p->failure_flags |= TestCaseFailureReason::AssertFailure;
-                } catch(...) {
+                }
+                catch (...)
+                {
                     p->error_string = translateActiveException();
                     p->failure_flags |= TestCaseFailureReason::Exception;
                 }
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+#endif  // DOCTEST_CONFIG_NO_EXCEPTIONS
 
                 p->seconds_so_far += g_timer.getElapsedSeconds();
 
@@ -5153,44 +5371,55 @@ int Context::run() {
                 p->numAsserts += p->numAssertsForCurrentTestCase_atomic;
                 p->numAssertsForCurrentTestCase += p->numAssertsForCurrentTestCase_atomic;
                 p->numAssertsFailed += p->numAssertsFailedForCurrentTestCase_atomic;
-                p->numAssertsFailedForCurrentTestCase +=
-                        p->numAssertsFailedForCurrentTestCase_atomic;
+                p->numAssertsFailedForCurrentTestCase += p->numAssertsFailedForCurrentTestCase_atomic;
 
                 // exit this loop if enough assertions have failed - even if there are more subcases
-                if(p->abort_after > 0 && p->numAssertsFailed >= p->abort_after) {
+                if (p->abort_after > 0 && p->numAssertsFailed >= p->abort_after)
+                {
                     p->should_reenter = false;
                     p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
                 }
 
                 // call it from here only if we will continue looping for other subcases and
                 // call it again outside of the loop for one final time - with updated flags
-                if(p->should_reenter == true) {
+                if (p->should_reenter == true)
+                {
                     DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
                     // remove these flags - it is expected that the reporters have handled these issues
                     p->failure_flags &= ~TestCaseFailureReason::Exception;
                     p->failure_flags &= ~TestCaseFailureReason::AssertFailure;
                 }
-            } while(p->should_reenter == true);
+            } while (p->should_reenter == true);
 
-            if(p->numAssertsFailedForCurrentTestCase)
-                p->failure_flags |= TestCaseFailureReason::AssertFailure;
+            if (p->numAssertsFailedForCurrentTestCase) p->failure_flags |= TestCaseFailureReason::AssertFailure;
 
-            if(Approx(p->currentTest->m_timeout).epsilon(DBL_EPSILON) != 0 &&
-               Approx(p->seconds_so_far).epsilon(DBL_EPSILON) > p->currentTest->m_timeout)
+            if (Approx(p->currentTest->m_timeout).epsilon(DBL_EPSILON) != 0 &&
+                Approx(p->seconds_so_far).epsilon(DBL_EPSILON) > p->currentTest->m_timeout)
                 p->failure_flags |= TestCaseFailureReason::Timeout;
 
-            if(tc.m_should_fail) {
-                if(p->failure_flags) {
+            if (tc.m_should_fail)
+            {
+                if (p->failure_flags)
+                {
                     p->failure_flags |= TestCaseFailureReason::ShouldHaveFailedAndDid;
-                } else {
+                }
+                else
+                {
                     p->failure_flags |= TestCaseFailureReason::ShouldHaveFailedButDidnt;
                 }
-            } else if(p->failure_flags && tc.m_may_fail) {
+            }
+            else if (p->failure_flags && tc.m_may_fail)
+            {
                 p->failure_flags |= TestCaseFailureReason::CouldHaveFailedAndDid;
-            } else if(tc.m_expected_failures > 0) {
-                if(p->numAssertsFailedForCurrentTestCase == tc.m_expected_failures) {
+            }
+            else if (tc.m_expected_failures > 0)
+            {
+                if (p->numAssertsFailedForCurrentTestCase == tc.m_expected_failures)
+                {
                     p->failure_flags |= TestCaseFailureReason::FailedExactlyNumTimes;
-                } else {
+                }
+                else
+                {
                     p->failure_flags |= TestCaseFailureReason::DidntFailExactlyNumTimes;
                 }
             }
@@ -5200,29 +5429,26 @@ int Context::run() {
                               (TestCaseFailureReason::FailedExactlyNumTimes & p->failure_flags);
 
             // if any subcase has failed - the whole test case has failed
-            if(p->failure_flags && !ok_to_fail)
-                p->numTestCasesFailed++;
+            if (p->failure_flags && !ok_to_fail) p->numTestCasesFailed++;
 
             DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_end, *g_cs);
 
             p->currentTest = nullptr;
 
             // stop executing tests if enough assertions have failed
-            if(p->abort_after > 0 && p->numAssertsFailed >= p->abort_after)
-                break;
+            if (p->abort_after > 0 && p->numAssertsFailed >= p->abort_after) break;
         }
     }
 
-    if(!query_mode)
+    if (!query_mode)
         DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_end, *g_cs);
     else
         con_rep.output_query_results();
 
-    g_cs               = old_cs;
+    g_cs = old_cs;
     is_running_in_test = false;
 
-    if(p->numTestCasesFailed && !p->no_exitcode)
-        return EXIT_FAILURE;
+    if (p->numTestCasesFailed && !p->no_exitcode) return EXIT_FAILURE;
     return EXIT_SUCCESS;
 }
 
@@ -5233,16 +5459,19 @@ DOCTEST_DEFINE_DEFAULTS(TestRunStats);
 IReporter::~IReporter() = default;
 
 int IReporter::get_num_active_contexts() { return detail::g_infoContexts.size(); }
-const IContextScope* const* IReporter::get_active_contexts() {
+const IContextScope* const* IReporter::get_active_contexts()
+{
     return get_num_active_contexts() ? &detail::g_infoContexts[0] : nullptr;
 }
 
 int IReporter::get_num_stringified_contexts() { return detail::g_cs->stringifiedContexts.size(); }
-const String* IReporter::get_stringified_contexts() {
+const String* IReporter::get_stringified_contexts()
+{
     return get_num_stringified_contexts() ? &detail::g_cs->stringifiedContexts[0] : nullptr;
 }
 
-int registerReporter(const char* name, int priority, IReporter& r) {
+int registerReporter(const char* name, int priority, IReporter& r)
+{
     getReporters().insert(reporterMap::value_type(reporterMap::key_type(priority, name), &r));
     return 0;
 }
@@ -5252,17 +5481,17 @@ int registerReporter(const char* name, int priority, IReporter& r) {
 // - https://github.com/onqtam/doctest/issues/126
 void DOCTEST_FIX_FOR_MACOS_LIBCPP_IOSFWD_STRING_LINK_ERRORS() { std::cout << std::string(); }
 
-} // namespace doctest
+}  // namespace doctest
 
-#endif // DOCTEST_CONFIG_DISABLE
+#endif  // DOCTEST_CONFIG_DISABLE
 
 #ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 int main(int argc, char** argv) { return doctest::Context(argc, argv).run(); }
-#endif // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#endif  // DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_GCC_SUPPRESS_WARNING_POP
 
-#endif // DOCTEST_LIBRARY_IMPLEMENTATION
-#endif // DOCTEST_CONFIG_IMPLEMENT
+#endif  // DOCTEST_LIBRARY_IMPLEMENTATION
+#endif  // DOCTEST_CONFIG_IMPLEMENT

--- a/test/api/cpp/tests/CommUtil_tests.cpp
+++ b/test/api/cpp/tests/CommUtil_tests.cpp
@@ -9,258 +9,282 @@
 
 using namespace gravity;
 
-TEST_CASE("tests for sending/reading ZMQ messages") {
-  
-  //initialize zmq context
-  void* context = zmq_init(1);
-  REQUIRE_MESSAGE(context, "error initializing context");
+TEST_CASE("tests for sending/reading ZMQ messages")
+{
+    //initialize zmq context
+    void* context = zmq_init(1);
+    REQUIRE_MESSAGE(context, "error initializing context");
 
-  //create client socket and bind to endpoint
-  void* clientSocket = zmq_socket(context, ZMQ_REQ);
-  int ret = zmq_bind(clientSocket, "inproc://endpoint_for_accepting_connections");
-  REQUIRE_MESSAGE(ret == 0, "error connecting client socket");
+    //create client socket and bind to endpoint
+    void* clientSocket = zmq_socket(context, ZMQ_REQ);
+    int ret = zmq_bind(clientSocket, "inproc://endpoint_for_accepting_connections");
+    REQUIRE_MESSAGE(ret == 0, "error connecting client socket");
 
-  //create service socket and bind to endpoint
-  void* serviceSocket = zmq_socket(context, ZMQ_REP);
-  ret = zmq_connect(serviceSocket, "inproc://endpoint_for_accepting_connections");
-  REQUIRE_MESSAGE(ret == 0, "error connecting service socket");
+    //create service socket and bind to endpoint
+    void* serviceSocket = zmq_socket(context, ZMQ_REP);
+    ret = zmq_connect(serviceSocket, "inproc://endpoint_for_accepting_connections");
+    REQUIRE_MESSAGE(ret == 0, "error connecting service socket");
 
-  SUBCASE("tests for sending/receiving one-part String messages") {
-    std::string message = "message";
+    SUBCASE("tests for sending/receiving one-part String messages")
+    {
+        std::string message = "message";
 
-    GIVEN("an empty string sent from client -> service") {
-      std::string empty = "";
-      sendStringMessage(clientSocket, empty, ZMQ_DONTWAIT);
+        GIVEN("an empty string sent from client -> service")
+        {
+            std::string empty = "";
+            sendStringMessage(clientSocket, empty, ZMQ_DONTWAIT);
 
-      THEN("receive an empty message back") {
-        std::string result = readStringMessage(serviceSocket,ZMQ_DONTWAIT);
-        CHECK("" == result);
-      }
+            THEN("receive an empty message back")
+            {
+                std::string result = readStringMessage(serviceSocket, ZMQ_DONTWAIT);
+                CHECK("" == result);
+            }
 
-      THEN("receive an empty message back") {
-        std::string result = readStringMessage(serviceSocket); //without flag
-        CHECK("" == result);
-      }
+            THEN("receive an empty message back")
+            {
+                std::string result = readStringMessage(serviceSocket);  //without flag
+                CHECK("" == result);
+            }
+        }
 
+        GIVEN("a non-empty string sent from the service -> client")
+        {
+            sendStringMessage(serviceSocket, message, ZMQ_DONTWAIT);
+
+            THEN("receive an empty message back")
+            {
+                std::string result = readStringMessage(clientSocket, ZMQ_DONTWAIT);
+                CHECK("" == result);
+            }
+
+            THEN("receive an empty message back")
+            {
+                std::string result = readStringMessage(clientSocket);  //without flag
+                CHECK("" == result);
+            }
+        }
+
+        GIVEN("an incomplete message sent from the client -> service")
+        {
+            //Flag ZMQ_SNDMORE indicates that at least one more message follows
+            sendStringMessage(clientSocket, message, ZMQ_SNDMORE);
+            THEN("receive an empty message back")
+            {
+                //Flag ZMQ_DONTWAIT indicates for this read function to be non-blocking
+                //It should return an empty string because it hasn't received any messages yet
+                //Without this flag, this function would hang until indefinitely waiting for
+                // a message that will never arrive.
+                std::string result = readStringMessage(serviceSocket, ZMQ_DONTWAIT);
+                CHECK("" == result);
+            }
+        }
+
+        //check typical use case of request & response
+        GIVEN("a non-empty string message sent from the client -> service")
+        {
+            sendStringMessage(clientSocket, message, ZMQ_DONTWAIT);
+
+            THEN("receive message on service socket")
+            {
+                std::string result = readStringMessage(serviceSocket, ZMQ_DONTWAIT);
+                CHECK(message == result);
+                THEN("should be no more additional messages to read")
+                {
+                    result = readStringMessage(serviceSocket, ZMQ_DONTWAIT);
+                    CHECK("" == result);
+                }
+            }
+
+            THEN("receive message on service socket")
+            {
+                std::string result = readStringMessage(serviceSocket);  //without flag
+                CHECK(message == result);
+                THEN("should be no more additional messages to read")
+                {
+                    result = readStringMessage(serviceSocket);  //without flag
+                    CHECK("" == result);
+                }
+            }
+
+            GIVEN("a one-part string response from service -> client")
+            {
+                readStringMessage(serviceSocket, ZMQ_DONTWAIT);
+                std::string response = "message 3";
+                sendStringMessage(serviceSocket, response, ZMQ_DONTWAIT);
+
+                THEN("receive message on client socket")
+                {
+                    std::string result = readStringMessage(clientSocket, ZMQ_DONTWAIT);
+                    CHECK(response == result);
+                    THEN("should be no more additional messages to read")
+                    {
+                        result = readStringMessage(clientSocket, ZMQ_DONTWAIT);
+                        CHECK("" == result);
+                    }
+                }
+
+                THEN("receive message on client socket")
+                {
+                    std::string result = readStringMessage(clientSocket);  //without flag
+                    CHECK(response == result);
+                    THEN("should be no more additional messages to read")
+                    {
+                        result = readStringMessage(clientSocket);  //without flag
+                        CHECK("" == result);
+                    }
+                }
+            }
+        }
     }
 
-    GIVEN("a non-empty string sent from the service -> client") {
-      sendStringMessage(serviceSocket, message, ZMQ_DONTWAIT);
+    //Only testing with readStringMessage(void*) which is a blocking call.
+    //The caller will be blocked until it receives a message.
+    //
+    //The unit tests above highlight the difference
+    //between readStringMessage(void*,int) and readStringMessage(void*) so
+    //no need for further testing.
+    //
+    SUBCASE("tests for sending/receiving multi-part String messages")
+    {
+        GIVEN("non- empty strings sent from service -> client")
+        {
+            std::string message = "message";
+            sendStringMessage(serviceSocket, message, ZMQ_DONTWAIT);
 
-      THEN("receive an empty message back") {
-        std::string result = readStringMessage(clientSocket,ZMQ_DONTWAIT);
-        CHECK("" == result);
-      }
+            THEN("receive an empty message back")
+            {
+                std::string result = readStringMessage(clientSocket);
+                CHECK("" == result);
+            }
+        }
 
-      THEN("receive an empty message back") {
-        std::string result = readStringMessage(clientSocket); //without flag
-        CHECK("" == result);
-      }
+        //check typical use case of request & response
+        GIVEN("sending multiple string messages form client -> service")
+        {
+            std::string message1 = "message1";
+            std::string message2 = "message2";
+            std::string message3 = "message3";
 
-    }  
+            sendStringMessage(clientSocket, message1, ZMQ_SNDMORE);
+            sendStringMessage(clientSocket, message2, ZMQ_SNDMORE);
+            sendStringMessage(clientSocket, message3, ZMQ_DONTWAIT);
 
-    GIVEN("an incomplete message sent from the client -> service") {
-      //Flag ZMQ_SNDMORE indicates that at least one more message follows 
-      sendStringMessage(clientSocket, message, ZMQ_SNDMORE);
-      THEN("receive an empty message back") {
-        //Flag ZMQ_DONTWAIT indicates for this read function to be non-blocking 
-        //It should return an empty string because it hasn't received any messages yet
-        //Without this flag, this function would hang until indefinitely waiting for
-        // a message that will never arrive.
-        std::string result = readStringMessage(serviceSocket,ZMQ_DONTWAIT);
-        CHECK("" == result);
-      }
+            THEN("receive string messages on service socket")
+            {
+                std::string result = readStringMessage(serviceSocket);
+                CHECK(message1 == result);
+                result = readStringMessage(serviceSocket);
+                CHECK(message2 == result);
+                result = readStringMessage(serviceSocket);
+                CHECK(message3 == result);
+                result = readStringMessage(serviceSocket);
+                CHECK("" == result);  //no more messages
+
+                GIVEN("sending a multi-part response from service -> client")
+                {
+                    readStringMessage(serviceSocket);
+                    readStringMessage(serviceSocket);
+                    readStringMessage(serviceSocket);
+
+                    std::string response1 = "response1";
+                    std::string response2 = "response2";
+                    std::string response3 = "response3";
+
+                    sendStringMessage(serviceSocket, response1, ZMQ_SNDMORE);
+                    sendStringMessage(serviceSocket, response2, ZMQ_SNDMORE);
+                    sendStringMessage(serviceSocket, response3, ZMQ_DONTWAIT);
+
+                    THEN("receive response messages on client socket")
+                    {
+                        std::string result = readStringMessage(clientSocket);
+                        CHECK(response1 == result);
+                        result = readStringMessage(clientSocket);
+                        CHECK(response2 == result);
+                        result = readStringMessage(clientSocket);
+                        CHECK(response3 == result);
+                        result = readStringMessage(clientSocket);
+                        CHECK("" == result);  //no more messages
+                    }
+                }
+            }
+        }
     }
 
-    //check typical use case of request & response
-    GIVEN("a non-empty string message sent from the client -> service") {
-      sendStringMessage(clientSocket, message, ZMQ_DONTWAIT);
+    //functions for reading/sending int, unit32_t, uint64_t are
+    //nearly identical, so only testing with int
+    SUBCASE("tests for sending/receiving one-part int messages")
+    {
+        int message = 25;
 
-      THEN("receive message on service socket") {
-        std::string result = readStringMessage(serviceSocket,ZMQ_DONTWAIT);
-        CHECK(message == result);
-        THEN("should be no more additional messages to read") {
-          result = readStringMessage(serviceSocket,ZMQ_DONTWAIT);
-          CHECK("" == result);
+        //check typical use case of request & response
+        GIVEN("an integer message sent from the client -> service")
+        {
+            sendIntMessage(clientSocket, message, ZMQ_DONTWAIT);
+
+            THEN("receive message on service socket")
+            {
+                int result = readIntMessage(serviceSocket);
+                CHECK(message == result);
+            }
+
+            GIVEN("a one-part string response from service -> client")
+            {
+                readIntMessage(serviceSocket);
+                int response = 4;
+                sendIntMessage(serviceSocket, response, ZMQ_DONTWAIT);
+
+                THEN("receive message on client socket")
+                {
+                    int result = readIntMessage(clientSocket);
+                    CHECK(response == result);
+                }
+            }
         }
-      }
-
-      THEN("receive message on service socket") {
-        std::string result = readStringMessage(serviceSocket); //without flag
-        CHECK(message == result);
-        THEN("should be no more additional messages to read") {
-          result = readStringMessage(serviceSocket); //without flag
-          CHECK("" == result);
-        }
-      }
-
-      GIVEN("a one-part string response from service -> client") {
-        readStringMessage(serviceSocket,ZMQ_DONTWAIT);
-        std::string response = "message 3";
-        sendStringMessage(serviceSocket, response, ZMQ_DONTWAIT);
-
-        THEN("receive message on client socket") {
-          std::string result = readStringMessage(clientSocket,ZMQ_DONTWAIT);
-          CHECK(response == result);
-          THEN("should be no more additional messages to read") {
-            result = readStringMessage(clientSocket,ZMQ_DONTWAIT);
-            CHECK("" == result);
-          }
-        }
-
-        THEN("receive message on client socket") {
-          std::string result = readStringMessage(clientSocket); //without flag
-          CHECK(response == result);
-          THEN("should be no more additional messages to read") {
-            result = readStringMessage(clientSocket); //without flag
-            CHECK("" == result);
-          }
-        }
-
-      }
-    }
-  }
-
-  //Only testing with readStringMessage(void*) which is a blocking call.
-  //The caller will be blocked until it receives a message.
-  //
-  //The unit tests above highlight the difference
-  //between readStringMessage(void*,int) and readStringMessage(void*) so
-  //no need for further testing. 
-  //
-  SUBCASE("tests for sending/receiving multi-part String messages") {
- 
-    GIVEN("non- empty strings sent from service -> client") {
-      std::string message = "message";
-      sendStringMessage(serviceSocket, message, ZMQ_DONTWAIT);
-
-      THEN("receive an empty message back") {
-        std::string result = readStringMessage(clientSocket); 
-        CHECK("" == result);
-      }
     }
 
-
-    //check typical use case of request & response
-    GIVEN("sending multiple string messages form client -> service") {
-
-      std::string message1 = "message1";
-      std::string message2 = "message2";
-      std::string message3 = "message3";
-      
-      sendStringMessage(clientSocket, message1, ZMQ_SNDMORE);
-      sendStringMessage(clientSocket, message2, ZMQ_SNDMORE);
-      sendStringMessage(clientSocket, message3, ZMQ_DONTWAIT);
-
-      THEN("receive string messages on service socket") {
-        std::string result = readStringMessage(serviceSocket);
-        CHECK(message1 == result);
-        result = readStringMessage(serviceSocket);
-        CHECK(message2 == result);
-        result = readStringMessage(serviceSocket);
-        CHECK(message3 == result);
-        result = readStringMessage(serviceSocket);
-        CHECK("" == result); //no more messages
-
-        GIVEN("sending a multi-part response from service -> client") {
-          readStringMessage(serviceSocket);
-          readStringMessage(serviceSocket);
-          readStringMessage(serviceSocket);
-
-          std::string response1 = "response1";
-          std::string response2 = "response2"; 
-          std::string response3 = "response3"; 
-
-          sendStringMessage(serviceSocket, response1, ZMQ_SNDMORE);
-          sendStringMessage(serviceSocket, response2, ZMQ_SNDMORE);
-          sendStringMessage(serviceSocket, response3, ZMQ_DONTWAIT);
-
-          THEN("receive response messages on client socket") {
-            std::string result = readStringMessage(clientSocket);
-            CHECK(response1 == result);
-            result = readStringMessage(clientSocket);
-            CHECK(response2 == result);
-            result = readStringMessage(clientSocket);
-            CHECK(response3 == result);
-            result = readStringMessage(clientSocket);
-            CHECK("" == result); //no more messages
-          }
+    SUBCASE("tests for sending GravityDataProducts")
+    {
+        std::string dataProductID = "TestID";
+        //check typical use case of request & response
+        GIVEN("sending a non-empty GravityDataProduct from client->service")
+        {
+            GravityDataProduct gdp(dataProductID);
+            std::string data = "string of data";
+            gdp.setData((const void*)data.c_str(), data.size());
+            int bytes = sendGravityDataProduct(clientSocket, gdp, ZMQ_DONTWAIT);
+            THEN("receive back the correct number of bytes") { CHECK(gdp.getSize() == bytes); }
         }
-      }
-    }   
-  }
-
-  //functions for reading/sending int, unit32_t, uint64_t are
-  //nearly identical, so only testing with int 
-  SUBCASE("tests for sending/receiving one-part int messages") {
-    int message = 25;
-
-    //check typical use case of request & response
-    GIVEN("an integer message sent from the client -> service") {
-      sendIntMessage(clientSocket, message, ZMQ_DONTWAIT);
-
-      THEN("receive message on service socket") {
-        int result = readIntMessage(serviceSocket);
-        CHECK(message == result);
-      }
-
-      GIVEN("a one-part string response from service -> client") {
-        readIntMessage(serviceSocket);
-        int response = 4;
-        sendIntMessage(serviceSocket, response, ZMQ_DONTWAIT);
-
-        THEN("receive message on client socket") {
-          int result = readIntMessage(clientSocket);
-          CHECK(response == result);
-        }
-      }
     }
 
-  }
+    SUBCASE("tests for sending protobufs")
+    {
+        BasicCounterDataProductPB pb;
+        pb.set_count(34);
 
-  SUBCASE("tests for sending GravityDataProducts") {
-    std::string dataProductID = "TestID";
-    //check typical use case of request & response
-    GIVEN("sending a non-empty GravityDataProduct from client->service") {
-		  GravityDataProduct gdp(dataProductID);
-      std::string data = "string of data";
-      gdp.setData((const void*) data.c_str(), data.size()); 
-      int bytes = sendGravityDataProduct(clientSocket, gdp, ZMQ_DONTWAIT); 
-      THEN("receive back the correct number of bytes") {
-        CHECK(gdp.getSize() == bytes);
-      }
-    } 
-  }
+        GIVEN("sending a non-empty Protobuf from client->service")
+        {
+            int bytes = sendProtobufMessage(clientSocket, pb, ZMQ_DONTWAIT);
+            THEN("receive back the correct number of bytes") { CHECK(pb.ByteSize() == bytes); }
+        }
+    }
 
-  SUBCASE("tests for sending protobufs") {
-		BasicCounterDataProductPB pb;
-		pb.set_count(34);
+    // SUBCASE("tests for timeval functions") {
+    //   struct timeval {
+    //    long tv_sec;
+    //    long tv_usec;
+    //   };
+    //   GIVEN("a timeval") {
+    //     timeval t1;
+    //     t1.tv_sec = 100;
+    //     t1.tv_usec = 1000;
+    //     THEN("add seconds to timeval") {
+    //       timeval t2 = addTime(&t1, 1);
+    //       CHECK(t2.tv_sec == 101);
+    //       CHECK(t2.tv_usec == 1000);
+    //     }
+    //   }
+    // }
 
-    GIVEN("sending a non-empty Protobuf from client->service") {
-      int bytes = sendProtobufMessage(clientSocket, pb, ZMQ_DONTWAIT); 
-      THEN("receive back the correct number of bytes") {
-        CHECK(pb.ByteSize() == bytes);
-      }
-    } 
-  }
-
-  // SUBCASE("tests for timeval functions") {
-  //   struct timeval {
-  //    long tv_sec;
-  //    long tv_usec;
-  //   };
-  //   GIVEN("a timeval") {
-  //     timeval t1;
-  //     t1.tv_sec = 100;
-  //     t1.tv_usec = 1000;
-  //     THEN("add seconds to timeval") {
-  //       timeval t2 = addTime(&t1, 1); 
-  //       CHECK(t2.tv_sec == 101);
-  //       CHECK(t2.tv_usec == 1000);
-  //     }
-  //   }
-  // }
-
-  zmq_close(clientSocket);
-  zmq_close(serviceSocket);
+    zmq_close(clientSocket);
+    zmq_close(serviceSocket);
 }

--- a/test/api/cpp/tests/DomainDataKey_tests.cpp
+++ b/test/api/cpp/tests/DomainDataKey_tests.cpp
@@ -4,58 +4,65 @@
 #include <string>
 #include <iostream>
 
-TEST_CASE("Tests for DomainDataKey") {
-  
-  GIVEN("two DomainDataKeys with empty domain and dataProductIDs") {
-    DomainDataKey key1("",""); 
-    DomainDataKey key2("",""); 
-    THEN("they should be equal") {
-      CHECK(key1 == key2);
-      CHECK(key2 == key1);
-      CHECK(!(key1 != key2));
-      CHECK(!(key2 != key1));
+TEST_CASE("Tests for DomainDataKey")
+{
+    GIVEN("two DomainDataKeys with empty domain and dataProductIDs")
+    {
+        DomainDataKey key1("", "");
+        DomainDataKey key2("", "");
+        THEN("they should be equal")
+        {
+            CHECK(key1 == key2);
+            CHECK(key2 == key1);
+            CHECK(!(key1 != key2));
+            CHECK(!(key2 != key1));
+        }
+        THEN("they should not be less than or greater than")
+        {
+            CHECK(!(key1 < key2));
+            CHECK(!(key2 < key1));
+            CHECK(!(key1 > key2));
+            CHECK(!(key2 > key1));
+        }
     }
-    THEN("they should not be less than or greater than") {
-      CHECK(!(key1 < key2));
-      CHECK(!(key2 < key1));
-      CHECK(!(key1 > key2));
-      CHECK(!(key2 > key1));
-    }
-  }
 
-  GIVEN("the key2 domain > key1 domain but key2 dataProductID < key 1 dataProductID") {
-    DomainDataKey key1("Domain1","DataProduct2"); 
-    DomainDataKey key2("Domain2","DataProduct1"); 
-    THEN("they should not be equal") {
-      CHECK(key1 != key2);
-      CHECK(key2 != key1);
-      CHECK(!(key1 == key2));
-      CHECK(!(key2 == key1));
+    GIVEN("the key2 domain > key1 domain but key2 dataProductID < key 1 dataProductID")
+    {
+        DomainDataKey key1("Domain1", "DataProduct2");
+        DomainDataKey key2("Domain2", "DataProduct1");
+        THEN("they should not be equal")
+        {
+            CHECK(key1 != key2);
+            CHECK(key2 != key1);
+            CHECK(!(key1 == key2));
+            CHECK(!(key2 == key1));
+        }
+        THEN("key2 should be greater than key1")
+        {
+            CHECK((key1 < key2));
+            CHECK((key2 > key1));
+            CHECK(!(key1 > key2));
+            CHECK(!(key2 < key1));
+        }
     }
-    THEN("key2 should be greater than key1") {
-      CHECK((key1 < key2));
-      CHECK((key2 > key1));
-      CHECK(!(key1 > key2));
-      CHECK(!(key2 < key1));
-    }
-  }
 
-  GIVEN("equal domains, but key2 dataProduct < key1 data product") {
-    DomainDataKey key1("Domain","DataProduct2"); 
-    DomainDataKey key2("Domain","DataProduct1"); 
-    THEN("they should not be equal") {
-      CHECK(key1 != key2);
-      CHECK(key2 != key1);
-      CHECK(!(key1 == key2));
-      CHECK(!(key2 == key1));
+    GIVEN("equal domains, but key2 dataProduct < key1 data product")
+    {
+        DomainDataKey key1("Domain", "DataProduct2");
+        DomainDataKey key2("Domain", "DataProduct1");
+        THEN("they should not be equal")
+        {
+            CHECK(key1 != key2);
+            CHECK(key2 != key1);
+            CHECK(!(key1 == key2));
+            CHECK(!(key2 == key1));
+        }
+        THEN("key2 should be less than key1")
+        {
+            CHECK(!(key1 < key2));
+            CHECK(!(key2 > key1));
+            CHECK((key1 > key2));
+            CHECK((key2 < key1));
+        }
     }
-    THEN("key2 should be less than key1") {
-      CHECK(!(key1 < key2));
-      CHECK(!(key2 > key1));
-      CHECK((key1 > key2));
-      CHECK((key2 < key1));
-    }
-  }
-
 }
-

--- a/test/api/cpp/tests/GravityDataProduct_tests.cpp
+++ b/test/api/cpp/tests/GravityDataProduct_tests.cpp
@@ -6,67 +6,74 @@
 
 using namespace gravity;
 
-TEST_CASE("Tests without the mocking framework") {
+TEST_CASE("Tests without the mocking framework")
+{
+    //only functions that are not setters/getters
+    SUBCASE("Test equality of GravityDataProdcuts")
+    {
+        GravityDataProduct gdp("testProductID");
+        char data[12];
+        sprintf(data, "Hello World");
+        gdp.setData((void*)data, strlen(data));
 
-  //only functions that are not setters/getters
-  SUBCASE("Test equality of GravityDataProdcuts") {
-    GravityDataProduct gdp("testProductID");
-		char data[12];
-		sprintf(data, "Hello World");
-		gdp.setData((void*)data, strlen(data));
-        
-    GIVEN("two DataProducts with the same dataProductIDs and same data.") {
-      GravityDataProduct gdp2("testProductID");
-      char data2[12];
-	    sprintf(data2, "Hello World");
-	    gdp2.setData((void*)data2, strlen(data2));
-      THEN("they should be equal") {
-        CHECK(gdp == gdp2);
-        CHECK(gdp2 == gdp);
-        CHECK(!(gdp != gdp2));
-        CHECK(!(gdp2 != gdp));
-      }
+        GIVEN("two DataProducts with the same dataProductIDs and same data.")
+        {
+            GravityDataProduct gdp2("testProductID");
+            char data2[12];
+            sprintf(data2, "Hello World");
+            gdp2.setData((void*)data2, strlen(data2));
+            THEN("they should be equal")
+            {
+                CHECK(gdp == gdp2);
+                CHECK(gdp2 == gdp);
+                CHECK(!(gdp != gdp2));
+                CHECK(!(gdp2 != gdp));
+            }
+        }
+
+        GIVEN("two DataProducts with different dataProductIDs and the same data.")
+        {
+            GravityDataProduct gdp2("testProductID_2");
+            char data2[12];
+            sprintf(data2, "Hello World");
+            gdp2.setData((void*)data2, strlen(data2));
+            THEN("they should not be equal")
+            {
+                CHECK(gdp != gdp2);
+                CHECK(gdp2 != gdp);
+                CHECK(!(gdp == gdp2));
+                CHECK(!(gdp2 == gdp));
+            }
+        }
+
+        GIVEN("two DataProducts with the same dataProductIDs and different data.")
+        {
+            GravityDataProduct gdp2("testProductID");
+            char data2[12];
+            sprintf(data2, "hello world");
+            gdp2.setData((void*)data2, strlen(data2));
+            THEN("they should not be equal")
+            {
+                CHECK(gdp != gdp2);
+                CHECK(gdp2 != gdp);
+                CHECK(!(gdp == gdp2));
+                CHECK(!(gdp2 == gdp));
+            }
+        }
+
+        GIVEN("two DataProducts with different dataProductIDs and different data.")
+        {
+            GravityDataProduct gdp2("testProductID_");
+            char data2[12];
+            sprintf(data2, "hello world");
+            gdp2.setData((void*)data2, strlen(data2));
+            THEN("they should not be equal")
+            {
+                CHECK(gdp != gdp2);
+                CHECK(gdp2 != gdp);
+                CHECK(!(gdp == gdp2));
+                CHECK(!(gdp2 == gdp));
+            }
+        }
     }
-
-    GIVEN("two DataProducts with different dataProductIDs and the same data.") {
-      GravityDataProduct gdp2("testProductID_2");
-      char data2[12];
-	    sprintf(data2, "Hello World");
-	    gdp2.setData((void*)data2, strlen(data2));
-      THEN("they should not be equal") {
-        CHECK(gdp != gdp2);
-        CHECK(gdp2 != gdp);
-        CHECK(!(gdp == gdp2));
-        CHECK(!(gdp2 == gdp));
-      }
-    }
-
-    GIVEN("two DataProducts with the same dataProductIDs and different data.") {
-      GravityDataProduct gdp2("testProductID");
-      char data2[12];
-	    sprintf(data2, "hello world");
-	    gdp2.setData((void*)data2, strlen(data2));
-      THEN("they should not be equal") {
-        CHECK(gdp != gdp2);
-        CHECK(gdp2 != gdp);
-        CHECK(!(gdp == gdp2));
-        CHECK(!(gdp2 == gdp));
-      }
-    }
-
-    GIVEN("two DataProducts with different dataProductIDs and different data.") {
-      GravityDataProduct gdp2("testProductID_");
-      char data2[12];
-	    sprintf(data2, "hello world");
-	    gdp2.setData((void*)data2, strlen(data2));
-      THEN("they should not be equal") {
-        CHECK(gdp != gdp2);
-        CHECK(gdp2 != gdp);
-        CHECK(!(gdp == gdp2));
-        CHECK(!(gdp2 == gdp));
-      }
-    }
-
-  }
 }
-

--- a/test/api/cpp/tests/GravityLogger_tests.cpp
+++ b/test/api/cpp/tests/GravityLogger_tests.cpp
@@ -10,255 +10,283 @@
 using namespace gravity;
 
 // Create a logger that uses the Logger interface
-class TestLogger : public Logger {
-  public: 
+class TestLogger : public Logger
+{
+public:
     TestLogger() = default;
     std::string lastMessage;
 
-    //must implement the Log function   
-    void Log(int level, const char* messagestr)
-    {
-      lastMessage = std::string(messagestr);
-    }
+    //must implement the Log function
+    void Log(int level, const char* messagestr) { lastMessage = std::string(messagestr); }
 };
 
-TEST_CASE("Tests without the mocking framework") {
-
-  SUBCASE("Test the LogLevelToString() function") {
-    GIVEN("A LogLevel") {
-      Log::LogLevel loglevel = Log::LogLevel::FATAL;
-      THEN("Return as a string") {
-         auto c_str = Log::LogLevelToString(loglevel); 
-         std::string str(c_str);
-         CHECK(str == "FATAL");
-      }
-    }
-  }
-
-  SUBCASE("Test the LogStringToLevel() function") {
-    GIVEN("An empty string") {
-      THEN("Return as LogLevel::NONE") {
-        Log::LogLevel loglevel = Log::LogStringToLevel(""); 
-        CHECK(loglevel == Log::LogLevel::NONE);
-      }
-    }
-
-    GIVEN("An invalid string") {
-      THEN("Return as LogLevel::NONE") {
-        Log::LogLevel loglevel = Log::LogStringToLevel("error"); 
-        CHECK(loglevel == Log::LogLevel::NONE);
-      }
-    }
-
-    GIVEN("An lower-case string of a valid log level") {
-      THEN("Return LogLevel") {
-        Log::LogLevel loglevel = Log::LogStringToLevel("fatal"); 
-        CHECK(loglevel == Log::LogLevel::FATAL);
-      }
-    }
-
-  }
-
-  SUBCASE("Test ability to truncate string") {
-      GIVEN("a string with %n") {
-          TestLogger* logger = new TestLogger();
-          Log::initAndAddLogger(logger, Log::DEBUG); //ptr now owned by Log
-          std::string truncStr(" !!!!!!!!! '%n' DETECTED, MESSAGE TRUNCATED");
-          THEN("Truncate only %n") {
-              std::string shortBadStr("%-4.7Ln");
-              Log::debug(shortBadStr.c_str());
-              CHECK(logger->lastMessage == truncStr);
-          }
-          THEN("Truncate short log line") {
-              std::string shortBadStr("a bad string %+9.0n");
-              Log::debug(shortBadStr.c_str());
-              CHECK(logger->lastMessage == shortBadStr.substr(0, shortBadStr.size() - 7) + truncStr);
-          }
-          THEN("Truncate long log line") {
-              std::string longBadStr(5000, 'a');
-              longBadStr += "% 2*n";
-              Log::debug(longBadStr.c_str());
-              CHECK(logger->lastMessage == longBadStr.substr(0, 4096 - truncStr.size() - 2) + truncStr);
-          }
-          THEN("No truncate %n as arg") {
-              Log::debug("good string %s", "%n");
-              CHECK(logger->lastMessage == "good string %n");
-          }
-          Log::RemoveLogger(logger);
-      }
-  }
-  //Note: equally tests initAndAddConsoleLogger because
-  //the ConsoleLogger inherits from FileLogger with the only
-  //difference being that logs are directed to stdout
-  SUBCASE("Test the initAndAddFileLogger() function") {
-
-    GIVEN("a debug file logger with an invalid componentID") {
-      std::string componentID =  "/foo/blah/?test";
-      Log::initAndAddFileLogger("", componentID.c_str(), Log::LogLevel::DEBUG);
-      THEN("Create a Gravity.log file") {
-        std::ifstream myfile("Gravity.log"); 
-        CHECK(myfile.is_open());
-        myfile.close();
-        GIVEN("A debug log message") {
-          std::string message = "My unique message";
-          //log message
-          Log::debug(message.c_str());
-          THEN("Write log message with invalid componentID") {
-            //read message
-            std::string line;
-            if(myfile.is_open())
+TEST_CASE("Tests without the mocking framework")
+{
+    SUBCASE("Test the LogLevelToString() function")
+    {
+        GIVEN("A LogLevel")
+        {
+            Log::LogLevel loglevel = Log::LogLevel::FATAL;
+            THEN("Return as a string")
             {
-              std::getline(myfile, line);
-              auto pos = line.find_first_of("DEBUG");
-              CHECK_MESSAGE(pos != std::string::npos, "contains DEBUG statement");
-              pos = line.find_first_of(componentID);
-              CHECK_MESSAGE(pos != std::string::npos, "contains componentID");
-              pos = line.find_first_of(message);
-              CHECK_MESSAGE(pos != std::string::npos, "contains message");
-              CHECK_MESSAGE(!(std::getline(myfile,line)), "Only one line should have been written");
-              myfile.close();
+                auto c_str = Log::LogLevelToString(loglevel);
+                std::string str(c_str);
+                CHECK(str == "FATAL");
+            }
+        }
+    }
+
+    SUBCASE("Test the LogStringToLevel() function")
+    {
+        GIVEN("An empty string")
+        {
+            THEN("Return as LogLevel::NONE")
+            {
+                Log::LogLevel loglevel = Log::LogStringToLevel("");
+                CHECK(loglevel == Log::LogLevel::NONE);
+            }
+        }
+
+        GIVEN("An invalid string")
+        {
+            THEN("Return as LogLevel::NONE")
+            {
+                Log::LogLevel loglevel = Log::LogStringToLevel("error");
+                CHECK(loglevel == Log::LogLevel::NONE);
+            }
+        }
+
+        GIVEN("An lower-case string of a valid log level")
+        {
+            THEN("Return LogLevel")
+            {
+                Log::LogLevel loglevel = Log::LogStringToLevel("fatal");
+                CHECK(loglevel == Log::LogLevel::FATAL);
+            }
+        }
+    }
+
+    SUBCASE("Test ability to truncate string")
+    {
+        GIVEN("a string with %n")
+        {
+            TestLogger* logger = new TestLogger();
+            Log::initAndAddLogger(logger, Log::DEBUG);  //ptr now owned by Log
+            std::string truncStr(" !!!!!!!!! '%n' DETECTED, MESSAGE TRUNCATED");
+            THEN("Truncate only %n")
+            {
+                std::string shortBadStr("%-4.7Ln");
+                Log::debug(shortBadStr.c_str());
+                CHECK(logger->lastMessage == truncStr);
+            }
+            THEN("Truncate short log line")
+            {
+                std::string shortBadStr("a bad string %+9.0n");
+                Log::debug(shortBadStr.c_str());
+                CHECK(logger->lastMessage == shortBadStr.substr(0, shortBadStr.size() - 7) + truncStr);
+            }
+            THEN("Truncate long log line")
+            {
+                std::string longBadStr(5000, 'a');
+                longBadStr += "% 2*n";
+                Log::debug(longBadStr.c_str());
+                CHECK(logger->lastMessage == longBadStr.substr(0, 4096 - truncStr.size() - 2) + truncStr);
+            }
+            THEN("No truncate %n as arg")
+            {
+                Log::debug("good string %s", "%n");
+                CHECK(logger->lastMessage == "good string %n");
+            }
+            Log::RemoveLogger(logger);
+        }
+    }
+    //Note: equally tests initAndAddConsoleLogger because
+    //the ConsoleLogger inherits from FileLogger with the only
+    //difference being that logs are directed to stdout
+    SUBCASE("Test the initAndAddFileLogger() function")
+    {
+        GIVEN("a debug file logger with an invalid componentID")
+        {
+            std::string componentID = "/foo/blah/?test";
+            Log::initAndAddFileLogger("", componentID.c_str(), Log::LogLevel::DEBUG);
+            THEN("Create a Gravity.log file")
+            {
+                std::ifstream myfile("Gravity.log");
+                CHECK(myfile.is_open());
+                myfile.close();
+                GIVEN("A debug log message")
+                {
+                    std::string message = "My unique message";
+                    //log message
+                    Log::debug(message.c_str());
+                    THEN("Write log message with invalid componentID")
+                    {
+                        //read message
+                        std::string line;
+                        if (myfile.is_open())
+                        {
+                            std::getline(myfile, line);
+                            auto pos = line.find_first_of("DEBUG");
+                            CHECK_MESSAGE(pos != std::string::npos, "contains DEBUG statement");
+                            pos = line.find_first_of(componentID);
+                            CHECK_MESSAGE(pos != std::string::npos, "contains componentID");
+                            pos = line.find_first_of(message);
+                            CHECK_MESSAGE(pos != std::string::npos, "contains message");
+                            CHECK_MESSAGE(!(std::getline(myfile, line)), "Only one line should have been written");
+                            myfile.close();
+                        }
+                        CHECK(1 == Log::NumberOfLoggers());
+                        Log::CloseLoggers();
+                        CHECK(0 == Log::NumberOfLoggers());
+                        std::remove("Gravity.log");
+                    }
+                }
+            }
+        }
+
+        GIVEN("an initialized file logger with log level Debug")
+        {
+            std::string componentID = "TestID";
+            //if file exists, delete it
+            std::string path = componentID + ".log";
+            Log::initAndAddFileLogger("", componentID.c_str(), Log::LogLevel::DEBUG);
+
+            GIVEN("a debug Log message")
+            {
+                std::string message = "My unique message";
+                //log message
+                Log::debug(message.c_str());
+                THEN("write debug message to the file")
+                {
+                    //read message
+                    std::string line;
+                    std::ifstream myfile(path);
+                    CHECK(myfile.is_open());
+                    if (myfile.is_open())
+                    {
+                        std::getline(myfile, line);
+                        auto pos = line.find_first_of("DEBUG");
+                        CHECK_MESSAGE(pos != std::string::npos, "contains DEBUG statement");
+                        pos = line.find_first_of(componentID);
+                        CHECK_MESSAGE(pos != std::string::npos, "contains componentID");
+                        pos = line.find_first_of(message);
+                        CHECK_MESSAGE(pos != std::string::npos, "contains message");
+                        CHECK_MESSAGE(!(std::getline(myfile, line)), "Only one line should have been written");
+                        myfile.close();
+                    }
+                }
+            }
+
+            GIVEN("a trace Log message")
+            {
+                std::string message = "My unique message";
+                //log message
+                Log::trace(message.c_str());
+                THEN("create an empty file without writing trace message")
+                {
+                    //read message
+                    std::string line;
+                    std::ifstream myfile(path);
+                    CHECK(myfile.is_open());
+                    if (myfile.is_open())
+                    {
+                        CHECK_MESSAGE(!(std::getline(myfile, line)), "Nothing should have been written");
+                        myfile.close();
+                    }
+                }
+            }
+
+            GIVEN("an empty debug Log message")
+            {
+                std::string message = "";
+                //log message
+                Log::debug(message.c_str());
+                THEN("write an empty debug message to the file")
+                {
+                    //read message
+                    std::string line;
+                    std::ifstream myfile(path);
+                    CHECK(myfile.is_open());
+                    if (myfile.is_open())
+                    {
+                        std::getline(myfile, line);
+                        auto pos = line.find_first_of("DEBUG");
+                        CHECK_MESSAGE(pos != std::string::npos, "contains DEBUG statement");
+                        pos = line.find_first_of(componentID);
+                        CHECK_MESSAGE(pos != std::string::npos, "contains componentID");
+                        pos = line.find_first_of(message);
+                        CHECK_MESSAGE(pos == std::string::npos, "contains message");
+                        CHECK_MESSAGE(!(std::getline(myfile, line)), "Only one line should have been written");
+                        myfile.close();
+                    }
+                }
             }
             CHECK(1 == Log::NumberOfLoggers());
             Log::CloseLoggers();
             CHECK(0 == Log::NumberOfLoggers());
-            std::remove("Gravity.log");
-          }
+            std::remove(path.c_str());
         }
-      }
-      
     }
 
-    GIVEN("an initialized file logger with log level Debug") {
-      std::string componentID = "TestID"; 
-      //if file exists, delete it
-      std::string path = componentID + ".log";
-      Log::initAndAddFileLogger("", componentID.c_str(), Log::LogLevel::DEBUG);
-
-      GIVEN("a debug Log message") {
-        std::string message = "My unique message";
-        //log message
-        Log::debug(message.c_str());
-        THEN("write debug message to the file") {
-          //read message
-          std::string line;
-          std::ifstream myfile(path); 
-          CHECK(myfile.is_open());
-          if(myfile.is_open())
-          {
-            std::getline(myfile, line);
-            auto pos = line.find_first_of("DEBUG");
-            CHECK_MESSAGE(pos != std::string::npos, "contains DEBUG statement");
-            pos = line.find_first_of(componentID);
-            CHECK_MESSAGE(pos != std::string::npos, "contains componentID");
-            pos = line.find_first_of(message);
-            CHECK_MESSAGE(pos != std::string::npos, "contains message");
-            CHECK_MESSAGE(!(std::getline(myfile,line)), "Only one line should have been written");
-            myfile.close();
-          }
+    SUBCASE("test the CloseLoggers() and RemoveLogger() functions")
+    {
+        GIVEN("initializing 2 loggers through the init functions")
+        {
+            Log::initAndAddFileLogger("", "filename", Log::LogLevel::DEBUG);
+            Log::initAndAddFileLogger("", "filename2", Log::LogLevel::DEBUG);
+            THEN("successfully close loggers with CloseLoggers()")
+            {
+                CHECK(2 == Log::NumberOfLoggers());
+                Log::CloseLoggers();
+                CHECK(0 == Log::NumberOfLoggers());
+            }
         }
-      }
 
-      GIVEN("a trace Log message") {
-        std::string message = "My unique message";
-        //log message
-        Log::trace(message.c_str());
-        THEN("create an empty file without writing trace message") {
-          //read message
-          std::string line;
-          std::ifstream myfile(path); 
-          CHECK(myfile.is_open());
-          if(myfile.is_open())
-          {
-            CHECK_MESSAGE(!(std::getline(myfile,line)), "Nothing should have been written");
-            myfile.close();
-          }
+        GIVEN("manually create and add loggers")
+        {
+            TestLogger* logger = new TestLogger();
+            Log::initAndAddLogger(logger, Log::DEBUG);  //ptr now owned by Log
+            TestLogger* logger2 = new TestLogger();
+            Log::initAndAddLogger(logger2, Log::DEBUG);  //ptr now owned by Log
+
+            THEN("successfully close loggers with RemoveLogger()")
+            {
+                CHECK(2 == Log::NumberOfLoggers());
+                Log::RemoveLogger(logger2);  //remove specific Loggger
+                Log::RemoveLogger(logger);   //remove specific Loggger
+                CHECK(0 == Log::NumberOfLoggers());
+            }
+
+            THEN("successfully close loggers with CloseLoggers()")
+            {
+                CHECK(2 == Log::NumberOfLoggers());
+                Log::CloseLoggers();
+                CHECK(0 == Log::NumberOfLoggers());
+            }
         }
-      }
 
+        GIVEN("add pointer to same logger more than once")
+        {
+            TestLogger* logger = new TestLogger();
+            TestLogger* logger2 = new TestLogger();
+            Log::initAndAddLogger(logger, Log::DEBUG);   //ptr now owned by Log
+            Log::initAndAddLogger(logger2, Log::DEBUG);  //ptr now owned by Log
+            Log::initAndAddLogger(logger, Log::DEBUG);   //duplicate ptr
 
-      GIVEN("an empty debug Log message") {
-        std::string message = "";
-        //log message
-        Log::debug(message.c_str());
-        THEN("write an empty debug message to the file") {
-          //read message
-          std::string line;
-          std::ifstream myfile(path); 
-          CHECK(myfile.is_open());
-          if(myfile.is_open())
-          {
-            std::getline(myfile, line);
-            auto pos = line.find_first_of("DEBUG");
-            CHECK_MESSAGE(pos != std::string::npos, "contains DEBUG statement");
-            pos = line.find_first_of(componentID);
-            CHECK_MESSAGE(pos != std::string::npos, "contains componentID");
-            pos = line.find_first_of(message);
-            CHECK_MESSAGE(pos == std::string::npos, "contains message");
-            CHECK_MESSAGE(!(std::getline(myfile,line)), "Only one line should have been written");
-            myfile.close();
-          }
+            THEN("do not store duplicate loggers and close loggers with CloseLoggers")
+            {
+                CHECK(2 == Log::NumberOfLoggers());
+                Log::CloseLoggers();
+                CHECK(0 == Log::NumberOfLoggers());
+            }
+
+            THEN("do not store duplicate loggers and close loggers with RemoveLoggers")
+            {
+                CHECK(2 == Log::NumberOfLoggers());
+                Log::RemoveLogger(logger2);  //remove specific Loggger
+                Log::RemoveLogger(logger);   //remove specific Loggger
+                CHECK(0 == Log::NumberOfLoggers());
+            }
         }
-      }
-      CHECK(1 == Log::NumberOfLoggers());
-      Log::CloseLoggers();
-      CHECK(0 == Log::NumberOfLoggers());
-      std::remove(path.c_str());
     }
-  }
-  
-  SUBCASE("test the CloseLoggers() and RemoveLogger() functions") {
-
-    GIVEN("initializing 2 loggers through the init functions") {
-      Log::initAndAddFileLogger("", "filename", Log::LogLevel::DEBUG);
-      Log::initAndAddFileLogger("", "filename2", Log::LogLevel::DEBUG);
-      THEN("successfully close loggers with CloseLoggers()") {
-        CHECK(2 == Log::NumberOfLoggers());
-        Log::CloseLoggers();
-        CHECK(0 == Log::NumberOfLoggers());
-      }
-    }
-
-    GIVEN("manually create and add loggers") {
-      TestLogger* logger = new TestLogger();
-      Log::initAndAddLogger(logger, Log::DEBUG); //ptr now owned by Log
-      TestLogger* logger2 = new TestLogger();
-      Log::initAndAddLogger(logger2, Log::DEBUG); //ptr now owned by Log
-
-      THEN("successfully close loggers with RemoveLogger()") {
-        CHECK(2 == Log::NumberOfLoggers());
-        Log::RemoveLogger(logger2); //remove specific Loggger
-        Log::RemoveLogger(logger); //remove specific Loggger
-        CHECK(0 == Log::NumberOfLoggers());
-      }
-
-      THEN("successfully close loggers with CloseLoggers()") {
-        CHECK(2 == Log::NumberOfLoggers());
-        Log::CloseLoggers();
-        CHECK(0 == Log::NumberOfLoggers());
-      }
-    }
-
-    GIVEN("add pointer to same logger more than once") {
-      TestLogger* logger = new TestLogger();
-      TestLogger* logger2 = new TestLogger();
-      Log::initAndAddLogger(logger, Log::DEBUG); //ptr now owned by Log
-      Log::initAndAddLogger(logger2, Log::DEBUG); //ptr now owned by Log
-      Log::initAndAddLogger(logger, Log::DEBUG); //duplicate ptr
-
-      THEN("do not store duplicate loggers and close loggers with CloseLoggers") {
-        CHECK(2 == Log::NumberOfLoggers());
-        Log::CloseLoggers();
-        CHECK(0 == Log::NumberOfLoggers());
-      }
-     
-      THEN("do not store duplicate loggers and close loggers with RemoveLoggers") {
-        CHECK(2 == Log::NumberOfLoggers());
-        Log::RemoveLogger(logger2); //remove specific Loggger
-        Log::RemoveLogger(logger); //remove specific Loggger
-        CHECK(0 == Log::NumberOfLoggers());
-      }
-
-    }
-  }
-} 
-
+}

--- a/test/api/cpp/tests/GravityNode_tests.cpp
+++ b/test/api/cpp/tests/GravityNode_tests.cpp
@@ -7,258 +7,285 @@
 
 using namespace gravity;
 
-TEST_CASE("Tests without the mocking framework") {
-
-  GIVEN("A GravityReturnCode") {
-    THEN("return that code in a string.") {
-      GravityNode gravityNode;
-      CHECK("SUCCESS" == gravityNode.getCodeString(GravityReturnCode::SUCCESS));
-    }
-  }
-
-  //
-  // Note that parsing method is different on different systems.
-  // Do we have to conduct tests on different machines to validate system?
-  // 
-
-  SUBCASE("Testing the Gravity.ini parsing functions")
-  {
-    //only initializing gravity node once - will make it quicker to run
-    static GravityNode gn;
-    static bool init = true;
-    if (init)
-      gn.init("Test");
-    init = false;  
-
-    GIVEN("a Gravity.ini file") {
-
-      THEN("Different spacing shouldn't affect keys and values") {
-        std::string string1 = gn.getStringParam("string1", "default");
-        std::string string2 = gn.getStringParam("string2", "default");
-        std::string string3 = gn.getStringParam("string3", "default");
-        std::string string4 = gn.getStringParam("string4", "default");
-        CHECK(string1 == "message1");
-        CHECK(string2 == "message2");
-        CHECK(string3 == "message3");
-        CHECK(string4 == "message4");
-
-        int pint1 = gn.getIntParam("pint1", 0);
-        int pint2 = gn.getIntParam("pint2", 0);
-        int pint3 = gn.getIntParam("pint3", 0);
-        int pint4 = gn.getIntParam("pint4", 0);
-        int pintp = gn.getIntParam("pintp", 0);
-        CHECK(pint1 == 1);
-        CHECK(pint2 == 2);
-        CHECK(pint3 == 3);
-        CHECK(pint4 == 4);
-        CHECK(pintp == 1);
-
-        int nint1 = gn.getIntParam("nint1", 0);
-        CHECK(nint1 == -9);
-
-        double pflt1 = gn.getFloatParam("pflt1", 0);
-        double pflt2 = gn.getFloatParam("pflt2", 0);
-        double pflt3 = gn.getFloatParam("pflt3", 0);
-        double pflt4 = gn.getFloatParam("pflt4", 0);
-        double pfltp = gn.getFloatParam("pfltp", 0);
-        CHECK(pflt1 == 1.6);
-        CHECK(pflt2 == 2.6);
-        CHECK(pflt3 == 3.6);
-        CHECK(pflt4 == 4.6);
-        CHECK(pfltp == 9.7);
-
-        double nflt1 = gn.getFloatParam("nflt1", 0);
-        CHECK(nflt1 == -9.6);
-        
-
-        bool bool1 = gn.getBoolParam("bool1", false);
-        bool bool2 = gn.getBoolParam("bool2", false);
-        bool bool3 = gn.getBoolParam("bool3", false);
-        bool bool4 = gn.getBoolParam("bool4", false);
-        CHECK(bool1 == true);
-        CHECK(bool2 == true);
-        CHECK(bool3 == true);
-        CHECK(bool4 == true);
-      }
-
-      THEN("calling keys is not case-sensitive") {
-        std::string STRING1 = gn.getStringParam("STRING1", "default");
-        CHECK(STRING1 == "message1");
-        int PINT1 = gn.getIntParam("PINT1", 0);
-        CHECK(PINT1 == 1);
-      }
-
-      THEN("the same key but with different case should not overwrite value") {
-        std::string string6 = gn.getStringParam("string6", "default");
-        std::string String6 = gn.getStringParam("String6", "default");
-        CHECK_MESSAGE(string6 == "message6", "value was overwritten");
-        CHECK_MESSAGE(String6 == "message6", "value was overwritten");
-
-        int pint6 = gn.getIntParam("pint6", 0);
-        int Pint6 = gn.getIntParam("Pint6", 0);
-        CHECK(pint6 == 6);
-        CHECK(Pint6 == 6);
-
-        double pflt6 = gn.getFloatParam("pflt6", 0);
-        double Pflt6 = gn.getFloatParam("Pflt6", 0);
-        CHECK(pflt6 == 6.6);
-        CHECK(Pflt6 == 6.6);
-
-        bool bool6 = gn.getBoolParam("bool6", false);
-        bool Bool6 = gn.getBoolParam("Bool6", false);
-        CHECK(bool6 == true);
-        CHECK(Bool6 == true);
-      }
-      
-      THEN("comment on the same line will not affect parsing") {
-        std::string string5 = gn.getStringParam("string5", "default");
-        CHECK(string5 == "message5");
-        int pint5 = gn.getIntParam("pint5", 0);
-        CHECK(pint5 == 5);
-        double pflt5 = gn.getFloatParam("pflt5", 0);
-        CHECK(pflt5 == 5.6);
-        bool bool5 = gn.getBoolParam("bool5", false);
-        CHECK(bool5 == true);
-      }
-
-      THEN("a very large integer should return the default") {
-        int pintLarge = gn.getIntParam("pintLarge", 0);
-        CHECK(pintLarge == 0);
-      }
-
-      THEN("can read an int, flt, or bool as a string") {
-        std::string pint1 = gn.getStringParam("pint1", "default");
-        std::string pflt1 = gn.getStringParam("pflt1", "default");
-        std::string bool1 = gn.getStringParam("bool1", "default");
-        std::string nflt1 = gn.getStringParam("nflt1", "default");
-        CHECK(pint1 == "1");
-        CHECK(pflt1 == "1.6");
-        CHECK(bool1 == "true");
-        CHECK(nflt1 == "-9.6");
-      }
-
-      THEN("return default for an invalid int") {
-        int readAsInt = gn.getIntParam("string1", 0);
-        CHECK(readAsInt == 0);
-      }
-
-      THEN("using getIntParam on a float will truncate the float") {
-        double pflt5 = gn.getIntParam("pflt5", 0);
-        CHECK(pflt5 == 5.0);
-      }
-      
-      THEN("boolean key is not case-sensitive and yes/y/t also indicate true") {
-        bool bool7 = gn.getBoolParam("bool7", false);
-        bool bool8 = gn.getBoolParam("bool8", false);
-        bool bool9 = gn.getBoolParam("bool9", false);
-        CHECK(bool7 == true);
-        CHECK(bool8 == true);
-        CHECK(bool9 == true);
-      }
-      
-    }
-    std::remove("Test.log");
-  }
-
-  SUBCASE("Testing uninitalization GravideNode")
-  {
-    class TestStub : public GravitySubscriber, public GravityRequestor, public GravityServiceProvider,
-                     public GravityHeartbeatListener, public GravitySubscriptionMonitor
+TEST_CASE("Tests without the mocking framework")
+{
+    GIVEN("A GravityReturnCode")
     {
-    public:
-      GRAVITY_API virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts) {}
-      GRAVITY_API virtual void requestFilled(std::string serviceID, std::string requestID, const GravityDataProduct& response) {}
-      virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID, const GravityDataProduct& dataProduct)
-      {
-          return std::shared_ptr<GravityDataProduct>(NULL);
-      }
-      GRAVITY_API virtual void ReceivedHeartbeat(std::string componentID, int64_t& interval_in_microseconds) {}
-      GRAVITY_API virtual void MissedHeartbeat(std::string componentID, int64_t microsecond_to_last_heartbeat, int64_t& interval_in_microseconds) {}
-      GRAVITY_API virtual void subscriptionTimeout(std::string dataProductID, int milliSecondsSinceLast, std::string filter, std::string domain) {}
-      virtual ~TestStub() {}
-    };
-
-    static GravityNode gn;
-
-    GIVEN("an uninitialized GravityNode") {
-
-      THEN("getParam methods should return default value") {
-        std::string string1 = gn.getStringParam("string1", "default");
-        CHECK(string1 == "default");
-        int int1 = gn.getIntParam("int1", -123);
-        CHECK(int1 == -123);
-        float float1 = gn.getFloatParam("float1", 1.234);
-        CHECK(float1 == 1.234f);
-        bool bool1 = gn.getBoolParam("bool1", true);
-        CHECK(bool1);
-      }
-
-      THEN("methods should return NOT_INITIALIZED") {
-        GravityReturnCode ret;
-
-        ret = gn.subscribe("", TestStub());
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-        ret = gn.subscribe("", TestStub(), "");
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-        ret = gn.subscribe("", TestStub(), "", "");
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-        ret = gn.subscribe("", TestStub(), "", "", false);
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-        ret = gn.unsubscribe("", TestStub());
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-
-        ret = gn.publish(GravityDataProduct());
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-
-        ret = gn.request("", GravityDataProduct(), TestStub());
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-
-        ret = gn.startHeartbeat(100);
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-        ret = gn.stopHeartbeat();
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-
-        ret = gn.registerDataProduct("", GravityTransportType::TCP);
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-        ret = gn.registerDataProduct("", GravityTransportType::TCP, true);
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-        ret = gn.unregisterDataProduct("");
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-
-        ret = gn.registerService("", GravityTransportType::TCP, TestStub());
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-        ret = gn.unregisterService("");
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-
-        ret = gn.registerHeartbeatListener("", 100, TestStub());
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-        ret = gn.unregisterHeartbeatListener("", "");
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-
-        ret = gn.registerRelay("", TestStub(), true, GravityTransportType::TCP);
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-        ret = gn.registerRelay("", TestStub(), true, GravityTransportType::TCP, true);
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-        ret = gn.unregisterRelay("", TestStub());
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-
-        ret = gn.setSubscriptionTimeoutMonitor("", TestStub(), 100);
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-        ret = gn.clearSubscriptionTimeoutMonitor("", TestStub());
-        CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
-      }
-
-      THEN("other methods should return as expected") {
-        std::shared_ptr<GravityDataProduct> retSP = gn.request("", GravityDataProduct());
-        CHECK(!retSP);
-
-        CHECK(gn.getComponentID() == "");
-        CHECK(gn.getIP() == "");
-        CHECK(gn.getDomain() == "");
-
-        std::shared_ptr<FutureResponse> ret = gn.createFutureResponse();
-        CHECK(!ret);
-      }
+        THEN("return that code in a string.")
+        {
+            GravityNode gravityNode;
+            CHECK("SUCCESS" == gravityNode.getCodeString(GravityReturnCode::SUCCESS));
+        }
     }
-  }
+
+    //
+    // Note that parsing method is different on different systems.
+    // Do we have to conduct tests on different machines to validate system?
+    //
+
+    SUBCASE("Testing the Gravity.ini parsing functions")
+    {
+        //only initializing gravity node once - will make it quicker to run
+        static GravityNode gn;
+        static bool init = true;
+        if (init) gn.init("Test");
+        init = false;
+
+        GIVEN("a Gravity.ini file")
+        {
+            THEN("Different spacing shouldn't affect keys and values")
+            {
+                std::string string1 = gn.getStringParam("string1", "default");
+                std::string string2 = gn.getStringParam("string2", "default");
+                std::string string3 = gn.getStringParam("string3", "default");
+                std::string string4 = gn.getStringParam("string4", "default");
+                CHECK(string1 == "message1");
+                CHECK(string2 == "message2");
+                CHECK(string3 == "message3");
+                CHECK(string4 == "message4");
+
+                int pint1 = gn.getIntParam("pint1", 0);
+                int pint2 = gn.getIntParam("pint2", 0);
+                int pint3 = gn.getIntParam("pint3", 0);
+                int pint4 = gn.getIntParam("pint4", 0);
+                int pintp = gn.getIntParam("pintp", 0);
+                CHECK(pint1 == 1);
+                CHECK(pint2 == 2);
+                CHECK(pint3 == 3);
+                CHECK(pint4 == 4);
+                CHECK(pintp == 1);
+
+                int nint1 = gn.getIntParam("nint1", 0);
+                CHECK(nint1 == -9);
+
+                double pflt1 = gn.getFloatParam("pflt1", 0);
+                double pflt2 = gn.getFloatParam("pflt2", 0);
+                double pflt3 = gn.getFloatParam("pflt3", 0);
+                double pflt4 = gn.getFloatParam("pflt4", 0);
+                double pfltp = gn.getFloatParam("pfltp", 0);
+                CHECK(pflt1 == 1.6);
+                CHECK(pflt2 == 2.6);
+                CHECK(pflt3 == 3.6);
+                CHECK(pflt4 == 4.6);
+                CHECK(pfltp == 9.7);
+
+                double nflt1 = gn.getFloatParam("nflt1", 0);
+                CHECK(nflt1 == -9.6);
+
+                bool bool1 = gn.getBoolParam("bool1", false);
+                bool bool2 = gn.getBoolParam("bool2", false);
+                bool bool3 = gn.getBoolParam("bool3", false);
+                bool bool4 = gn.getBoolParam("bool4", false);
+                CHECK(bool1 == true);
+                CHECK(bool2 == true);
+                CHECK(bool3 == true);
+                CHECK(bool4 == true);
+            }
+
+            THEN("calling keys is not case-sensitive")
+            {
+                std::string STRING1 = gn.getStringParam("STRING1", "default");
+                CHECK(STRING1 == "message1");
+                int PINT1 = gn.getIntParam("PINT1", 0);
+                CHECK(PINT1 == 1);
+            }
+
+            THEN("the same key but with different case should not overwrite value")
+            {
+                std::string string6 = gn.getStringParam("string6", "default");
+                std::string String6 = gn.getStringParam("String6", "default");
+                CHECK_MESSAGE(string6 == "message6", "value was overwritten");
+                CHECK_MESSAGE(String6 == "message6", "value was overwritten");
+
+                int pint6 = gn.getIntParam("pint6", 0);
+                int Pint6 = gn.getIntParam("Pint6", 0);
+                CHECK(pint6 == 6);
+                CHECK(Pint6 == 6);
+
+                double pflt6 = gn.getFloatParam("pflt6", 0);
+                double Pflt6 = gn.getFloatParam("Pflt6", 0);
+                CHECK(pflt6 == 6.6);
+                CHECK(Pflt6 == 6.6);
+
+                bool bool6 = gn.getBoolParam("bool6", false);
+                bool Bool6 = gn.getBoolParam("Bool6", false);
+                CHECK(bool6 == true);
+                CHECK(Bool6 == true);
+            }
+
+            THEN("comment on the same line will not affect parsing")
+            {
+                std::string string5 = gn.getStringParam("string5", "default");
+                CHECK(string5 == "message5");
+                int pint5 = gn.getIntParam("pint5", 0);
+                CHECK(pint5 == 5);
+                double pflt5 = gn.getFloatParam("pflt5", 0);
+                CHECK(pflt5 == 5.6);
+                bool bool5 = gn.getBoolParam("bool5", false);
+                CHECK(bool5 == true);
+            }
+
+            THEN("a very large integer should return the default")
+            {
+                int pintLarge = gn.getIntParam("pintLarge", 0);
+                CHECK(pintLarge == 0);
+            }
+
+            THEN("can read an int, flt, or bool as a string")
+            {
+                std::string pint1 = gn.getStringParam("pint1", "default");
+                std::string pflt1 = gn.getStringParam("pflt1", "default");
+                std::string bool1 = gn.getStringParam("bool1", "default");
+                std::string nflt1 = gn.getStringParam("nflt1", "default");
+                CHECK(pint1 == "1");
+                CHECK(pflt1 == "1.6");
+                CHECK(bool1 == "true");
+                CHECK(nflt1 == "-9.6");
+            }
+
+            THEN("return default for an invalid int")
+            {
+                int readAsInt = gn.getIntParam("string1", 0);
+                CHECK(readAsInt == 0);
+            }
+
+            THEN("using getIntParam on a float will truncate the float")
+            {
+                double pflt5 = gn.getIntParam("pflt5", 0);
+                CHECK(pflt5 == 5.0);
+            }
+
+            THEN("boolean key is not case-sensitive and yes/y/t also indicate true")
+            {
+                bool bool7 = gn.getBoolParam("bool7", false);
+                bool bool8 = gn.getBoolParam("bool8", false);
+                bool bool9 = gn.getBoolParam("bool9", false);
+                CHECK(bool7 == true);
+                CHECK(bool8 == true);
+                CHECK(bool9 == true);
+            }
+        }
+        std::remove("Test.log");
+    }
+
+    SUBCASE("Testing uninitalization GravideNode")
+    {
+        class TestStub : public GravitySubscriber,
+                         public GravityRequestor,
+                         public GravityServiceProvider,
+                         public GravityHeartbeatListener,
+                         public GravitySubscriptionMonitor
+        {
+        public:
+            GRAVITY_API virtual void subscriptionFilled(
+                const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
+            {
+            }
+            GRAVITY_API virtual void requestFilled(std::string serviceID, std::string requestID,
+                                                   const GravityDataProduct& response)
+            {
+            }
+            virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID,
+                                                                const GravityDataProduct& dataProduct)
+            {
+                return std::shared_ptr<GravityDataProduct>(NULL);
+            }
+            GRAVITY_API virtual void ReceivedHeartbeat(std::string componentID, int64_t& interval_in_microseconds) {}
+            GRAVITY_API virtual void MissedHeartbeat(std::string componentID, int64_t microsecond_to_last_heartbeat,
+                                                     int64_t& interval_in_microseconds)
+            {
+            }
+            GRAVITY_API virtual void subscriptionTimeout(std::string dataProductID, int milliSecondsSinceLast,
+                                                         std::string filter, std::string domain)
+            {
+            }
+            virtual ~TestStub() {}
+        };
+
+        static GravityNode gn;
+
+        GIVEN("an uninitialized GravityNode")
+        {
+            THEN("getParam methods should return default value")
+            {
+                std::string string1 = gn.getStringParam("string1", "default");
+                CHECK(string1 == "default");
+                int int1 = gn.getIntParam("int1", -123);
+                CHECK(int1 == -123);
+                float float1 = gn.getFloatParam("float1", 1.234);
+                CHECK(float1 == 1.234f);
+                bool bool1 = gn.getBoolParam("bool1", true);
+                CHECK(bool1);
+            }
+
+            THEN("methods should return NOT_INITIALIZED")
+            {
+                GravityReturnCode ret;
+
+                ret = gn.subscribe("", TestStub());
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+                ret = gn.subscribe("", TestStub(), "");
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+                ret = gn.subscribe("", TestStub(), "", "");
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+                ret = gn.subscribe("", TestStub(), "", "", false);
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+                ret = gn.unsubscribe("", TestStub());
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+
+                ret = gn.publish(GravityDataProduct());
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+
+                ret = gn.request("", GravityDataProduct(), TestStub());
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+
+                ret = gn.startHeartbeat(100);
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+                ret = gn.stopHeartbeat();
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+
+                ret = gn.registerDataProduct("", GravityTransportType::TCP);
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+                ret = gn.registerDataProduct("", GravityTransportType::TCP, true);
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+                ret = gn.unregisterDataProduct("");
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+
+                ret = gn.registerService("", GravityTransportType::TCP, TestStub());
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+                ret = gn.unregisterService("");
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+
+                ret = gn.registerHeartbeatListener("", 100, TestStub());
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+                ret = gn.unregisterHeartbeatListener("", "");
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+
+                ret = gn.registerRelay("", TestStub(), true, GravityTransportType::TCP);
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+                ret = gn.registerRelay("", TestStub(), true, GravityTransportType::TCP, true);
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+                ret = gn.unregisterRelay("", TestStub());
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+
+                ret = gn.setSubscriptionTimeoutMonitor("", TestStub(), 100);
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+                ret = gn.clearSubscriptionTimeoutMonitor("", TestStub());
+                CHECK(ret == GravityReturnCodes::NOT_INITIALIZED);
+            }
+
+            THEN("other methods should return as expected")
+            {
+                std::shared_ptr<GravityDataProduct> retSP = gn.request("", GravityDataProduct());
+                CHECK(!retSP);
+
+                CHECK(gn.getComponentID() == "");
+                CHECK(gn.getIP() == "");
+                CHECK(gn.getDomain() == "");
+
+                std::shared_ptr<FutureResponse> ret = gn.createFutureResponse();
+                CHECK(!ret);
+            }
+        }
+    }
 }

--- a/test/api/cpp/tests/Utility_tests.cpp
+++ b/test/api/cpp/tests/Utility_tests.cpp
@@ -9,213 +9,230 @@
 
 using namespace gravity;
 
-TEST_CASE("String helper tests") {
-  
-  GIVEN("an empty string") {
-    std::string empty = "";
-    THEN("return an empty string") {
-      CHECK(empty==StringToLowerCase(empty));
-      CHECK(empty==StringCopyToLowerCase(empty));
-      CHECK(empty==trim(empty));
-    }
-    THEN("return default value") {
-      int i = 423;
-      CHECK(i == StringToInt(empty,i));
-      double dbl = 24.23;
-      CHECK(doctest::Approx(dbl) == StringToDouble(empty,dbl));
-    }
-  }
-
-  SUBCASE("test *ToLowerCase() functions") {
-
-    GIVEN("A single uppercase letter.") {
-      char c[] = {'A'};
-      std::string s = "A";
-      std::string expected = "a";
-      THEN("return lower case character") {
-        CHECK(expected == StringToLowerCase(s));
-        CHECK(expected == StringCopyToLowerCase(s));
-        CHECK(expected[0] == StringToLowerCase(c, 1)[0]);
-      }
-      THEN("StringToLower additionally makes in-place modification") {
-        StringToLowerCase(c, 1);
-        CHECK(expected[0] == c[0]);
-      }
-    } 
-
-    GIVEN("A single lowercase letter.") {
-      char c[] = {'a'};
-      std::string s = "a";
-      std::string expected = "a";
-      THEN("return lower case character") {
-        CHECK(expected == StringToLowerCase(s));
-        CHECK(expected == StringCopyToLowerCase(s));
-        CHECK(expected[0] == StringToLowerCase(c, 1)[0]);
-      }
-      THEN("StringToLower makes additionally in-place modification") {
-        StringToLowerCase(c, 1);
-        CHECK(expected[0] == c[0]);
-      }
+TEST_CASE("String helper tests")
+{
+    GIVEN("an empty string")
+    {
+        std::string empty = "";
+        THEN("return an empty string")
+        {
+            CHECK(empty == StringToLowerCase(empty));
+            CHECK(empty == StringCopyToLowerCase(empty));
+            CHECK(empty == trim(empty));
+        }
+        THEN("return default value")
+        {
+            int i = 423;
+            CHECK(i == StringToInt(empty, i));
+            double dbl = 24.23;
+            CHECK(doctest::Approx(dbl) == StringToDouble(empty, dbl));
+        }
     }
 
-    GIVEN("A mixed case word.") {
-      char c[] = "hEllO WorlD";
-      std::string s = "hEllO WorlD"; 
-      int sz = s.size();
-      std::string expected = "hello world";
-      THEN("return the same sequence") {
-        CHECK(expected == StringToLowerCase(s));
-        CHECK(expected == StringCopyToLowerCase(s));
-        check_equality(expected, StringToLowerCase(c, sz), sz);
-      }
-      THEN("StringToLower makes additional in-place modifications") {
-        StringToLowerCase(c, sz);
-        check_equality(expected, c, sz);
-      }
+    SUBCASE("test *ToLowerCase() functions")
+    {
+        GIVEN("A single uppercase letter.")
+        {
+            char c[] = {'A'};
+            std::string s = "A";
+            std::string expected = "a";
+            THEN("return lower case character")
+            {
+                CHECK(expected == StringToLowerCase(s));
+                CHECK(expected == StringCopyToLowerCase(s));
+                CHECK(expected[0] == StringToLowerCase(c, 1)[0]);
+            }
+            THEN("StringToLower additionally makes in-place modification")
+            {
+                StringToLowerCase(c, 1);
+                CHECK(expected[0] == c[0]);
+            }
+        }
+
+        GIVEN("A single lowercase letter.")
+        {
+            char c[] = {'a'};
+            std::string s = "a";
+            std::string expected = "a";
+            THEN("return lower case character")
+            {
+                CHECK(expected == StringToLowerCase(s));
+                CHECK(expected == StringCopyToLowerCase(s));
+                CHECK(expected[0] == StringToLowerCase(c, 1)[0]);
+            }
+            THEN("StringToLower makes additionally in-place modification")
+            {
+                StringToLowerCase(c, 1);
+                CHECK(expected[0] == c[0]);
+            }
+        }
+
+        GIVEN("A mixed case word.")
+        {
+            char c[] = "hEllO WorlD";
+            std::string s = "hEllO WorlD";
+            int sz = s.size();
+            std::string expected = "hello world";
+            THEN("return the same sequence")
+            {
+                CHECK(expected == StringToLowerCase(s));
+                CHECK(expected == StringCopyToLowerCase(s));
+                check_equality(expected, StringToLowerCase(c, sz), sz);
+            }
+            THEN("StringToLower makes additional in-place modifications")
+            {
+                StringToLowerCase(c, sz);
+                check_equality(expected, c, sz);
+            }
+        }
+
+        GIVEN("A sequence of alpha and non-alpha characters.")
+        {
+            char c[] = "2R#(_. g";
+            std::string s = "2R#(_. g";
+            int sz = s.size();
+            std::string expected = "2r#(_. g";
+            THEN("return the same sequence")
+            {
+                CHECK(expected == StringToLowerCase(s));
+                CHECK(expected == StringCopyToLowerCase(s));
+                check_equality(expected, StringToLowerCase(c, sz), sz);
+            }
+            THEN("StringToLower makes no additional in-place modifications")
+            {
+                StringToLowerCase(c, sz);
+                check_equality(expected, c, sz);
+            }
+        }
     }
 
-    GIVEN("A sequence of alpha and non-alpha characters.") {
-      char c[] = "2R#(_. g";
-      std::string s = "2R#(_. g"; 
-      int sz = s.size();
-      std::string expected = "2r#(_. g";
-      THEN("return the same sequence") {
-        CHECK(expected == StringToLowerCase(s));
-        CHECK(expected == StringCopyToLowerCase(s));
-        check_equality(expected, StringToLowerCase(c, sz), sz);
-      }
-      THEN("StringToLower makes no additional in-place modifications") {
-        StringToLowerCase(c, sz);
-        check_equality(expected, c, sz);
-      }
+    SUBCASE("test StringToDouble() and StringToInt() functions")
+    {
+        int default_int = 123;
+        double default_double = 45.67;
+
+        GIVEN("An invalid string")
+        {
+            std::string s = "hello";
+            THEN("return default value")
+            {
+                CHECK(default_int == StringToInt(s, default_int));
+                CHECK(doctest::Approx(default_double) == StringToDouble(s, default_double));
+            }
+        }
+
+        GIVEN("A double")
+        {
+            std::string s = "3.82";
+            double expected_dbl = 3.82;
+            int expected_int = 3;
+            THEN("return truncated double") { CHECK(expected_int == StringToInt(s, default_int)); }
+            THEN("return double") { CHECK(doctest::Approx(expected_dbl) == StringToDouble(s, default_double)); }
+        }
+
+        GIVEN("A negative double")
+        {
+            std::string s = "-3.82";
+            double expected_dbl = -3.82;
+            int expected_int = -3;
+            THEN("return truncated double") { CHECK(expected_int == StringToInt(s, default_int)); }
+            THEN("return double") { CHECK(doctest::Approx(expected_dbl) == StringToDouble(s, default_double)); }
+        }
+
+        GIVEN("The maximum value for an integer.")
+        {
+            std::string s = std::to_string(INT_MAX);
+            THEN("return this integer") { CHECK(INT_MAX == StringToInt(s, default_int)); }
+        }
+
+        GIVEN("An out of limits integer.")
+        {
+            std::string s = std::to_string(INT_MAX) + '0';  //guaranteed out-of-bounds
+            THEN("return the default integer") { CHECK(default_int == StringToInt(s, default_int)); }
+        }
+
+        GIVEN("The maximum value for a double.")
+        {
+            std::string s = std::to_string(DBL_MAX);
+            THEN("return this double") { CHECK(DBL_MAX == StringToDouble(s, default_double)); }
+        }
+
+        GIVEN("An out of limits double.")
+        {
+            std::string s = '1' + std::to_string(DBL_MAX);  //guaranteed out-of-bounds
+            THEN("return the default double") { CHECK(default_double == StringToDouble(s, default_double)); }
+        }
     }
 
-  }
+    SUBCASE("test trim() function")
+    {
+        GIVEN("an empty string")
+        {
+            std::string str = "";
+            THEN("return an empty string")
+            {
+                CHECK(trim(str) == "");
+                CHECK(str == "");
+            }
+        }
 
+        GIVEN("A string with default deliminators")
+        {
+            std::string str = "deliminators: \f\n\r\t\v";
+            THEN("modify and return a string with deliminators removed")
+            {
+                CHECK(trim(str) == "deliminators:");
+                CHECK(str == "deliminators:");
+            }
+        }
 
-  SUBCASE("test StringToDouble() and StringToInt() functions") {
-    int default_int = 123;
-    double default_double = 45.67;
-
-    GIVEN("An invalid string") {
-      std::string s = "hello";
-      THEN("return default value") {
-        CHECK(default_int == StringToInt(s, default_int));
-        CHECK(doctest::Approx(default_double) == StringToDouble(s, default_double));
-      }
+        GIVEN("A string")
+        {
+            std::string str = "my string";
+            THEN("modify and return a string with my deliminators removed")
+            {
+                CHECK(trim(str, "mg") == "y strin");
+                CHECK(str == "y strin");
+            }
+        }
     }
 
-    GIVEN("A double") {
-      std::string s = "3.82";
-      double expected_dbl = 3.82;
-      int expected_int = 3;
-      THEN("return truncated double") {
-        CHECK(expected_int == StringToInt(s, default_int));
-      }
-      THEN("return double") {
-        CHECK(doctest::Approx(expected_dbl) == StringToDouble(s, default_double));
-      }
+    SUBCASE("test replaceAll() function")
+    {
+        GIVEN("an empty string")
+        {
+            std::string str = "";
+            std::string oldValue = "\n";
+            std::string newValue = "\t";
+            THEN("string remains empty")
+            {
+                replaceAll(str, oldValue, newValue);
+                CHECK(str == "");
+            }
+        }
+
+        GIVEN("an empty string for the old value to replace")
+        {
+            std::string str = "my unique string.";
+            std::string oldValue = "";
+            std::string newValue = "a";
+            THEN("do not modify string")
+            {
+                replaceAll(str, oldValue, newValue);
+                CHECK(str == "my unique string.");
+            }
+        }
+
+        GIVEN("an empty string for the new value to replace")
+        {
+            std::string str = "my unique string named str.";
+            std::string oldValue = "str";
+            std::string newValue = "";
+            THEN("modify string with removed values")
+            {
+                replaceAll(str, oldValue, newValue);
+                CHECK(str == "my unique ing named .");
+            }
+        }
     }
-
-    GIVEN("A negative double") {
-      std::string s = "-3.82";
-      double expected_dbl = -3.82;
-      int expected_int = -3;
-      THEN("return truncated double") {
-        CHECK(expected_int == StringToInt(s, default_int));
-      }
-      THEN("return double") {
-        CHECK(doctest::Approx(expected_dbl) == StringToDouble(s, default_double));
-      }
-    }
-
-    GIVEN("The maximum value for an integer.") {      
-      std::string s = std::to_string(INT_MAX);
-      THEN("return this integer") {
-        CHECK(INT_MAX == StringToInt(s, default_int));
-      }
-    }
-
-    GIVEN("An out of limits integer.") {      
-      std::string s = std::to_string(INT_MAX) + '0'; //guaranteed out-of-bounds
-      THEN("return the default integer") {
-        CHECK(default_int == StringToInt(s, default_int));
-      }
-    }
-
-    GIVEN("The maximum value for a double.") {      
-      std::string s = std::to_string(DBL_MAX);
-      THEN("return this double") {
-        CHECK(DBL_MAX == StringToDouble(s, default_double));
-      }
-    }
-
-    GIVEN("An out of limits double.") {      
-      std::string s = '1' + std::to_string(DBL_MAX); //guaranteed out-of-bounds
-      THEN("return the default double") {
-        CHECK(default_double == StringToDouble(s, default_double));
-      }
-    }
-  }
-
-  SUBCASE("test trim() function") {
-    GIVEN("an empty string") {
-      std::string str = "";
-      THEN("return an empty string") {
-        CHECK(trim(str) == "");
-        CHECK(str == "");
-      }
-    }
-
-    GIVEN("A string with default deliminators") {
-      std::string str = "deliminators: \f\n\r\t\v";
-      THEN("modify and return a string with deliminators removed") {
-        CHECK(trim(str) == "deliminators:");
-        CHECK(str == "deliminators:");
-      }
-    }
-
-    GIVEN("A string") {
-      std::string str = "my string";
-      THEN("modify and return a string with my deliminators removed") {
-        CHECK(trim(str, "mg") == "y strin");
-        CHECK(str == "y strin");
-      }
-    }
-  }
-
-  SUBCASE("test replaceAll() function") {
-
-    GIVEN("an empty string") {
-      std::string str = "";
-      std::string oldValue = "\n";
-      std::string newValue = "\t";
-      THEN("string remains empty") {
-        replaceAll(str, oldValue, newValue);
-        CHECK(str == "");
-      } 
-    }
-
-    GIVEN("an empty string for the old value to replace") {
-      std::string str = "my unique string.";
-      std::string oldValue = "";
-      std::string newValue = "a";
-      THEN("do not modify string") {
-        replaceAll(str, oldValue, newValue);
-        CHECK(str == "my unique string.");
-      } 
-    }
-
-    GIVEN("an empty string for the new value to replace") {
-      std::string str = "my unique string named str.";
-      std::string oldValue = "str";
-      std::string newValue = "";
-      THEN("modify string with removed values") {
-        replaceAll(str, oldValue, newValue);
-        CHECK(str == "my unique ing named .");
-      } 
-    }
-
-  }
-
 }

--- a/test/api/cpp/utils/utils.h
+++ b/test/api/cpp/utils/utils.h
@@ -6,9 +6,11 @@
  * Container must have an operator[] overload that results in the same type as T
  */
 template <typename Container, typename T>
-void check_equality(const Container& expected, const T* result, uint32_t size) {
-  for(auto i = 0u; i < size; ++i) {
-    CAPTURE(i);
-    CHECK(expected[i] == result[i]);
-  }  
+void check_equality(const Container& expected, const T* result, uint32_t size)
+{
+    for (auto i = 0u; i < size; ++i)
+    {
+        CAPTURE(i);
+        CHECK(expected[i] == result[i]);
+    }
 }

--- a/test/components/cpp/ConfigServerTest/ConfigServerTest.cpp
+++ b/test/components/cpp/ConfigServerTest/ConfigServerTest.cpp
@@ -31,17 +31,18 @@
 using namespace std;
 using namespace gravity;
 
-int main() {
-	GravityNode gn;
-	gn.init("ConfigTest");
+int main()
+{
+    GravityNode gn;
+    gn.init("ConfigTest");
 
-	cout << "LocalLogLevel=" << gn.getStringParam("LocalLogLevel") << endl;
-	cout << "NetLogLevel=" << gn.getStringParam("NetLogLevel") << endl;
+    cout << "LocalLogLevel=" << gn.getStringParam("LocalLogLevel") << endl;
+    cout << "NetLogLevel=" << gn.getStringParam("NetLogLevel") << endl;
 
-	cout << "Override=" << gn.getStringParam("Override")  << endl;
-	cout << "NonOverride=" << gn.getStringParam("NonOverride")  << endl;
+    cout << "Override=" << gn.getStringParam("Override") << endl;
+    cout << "NonOverride=" << gn.getStringParam("NonOverride") << endl;
 
-	cout << "Param1=" << gn.getStringParam("Param1") << endl;
+    cout << "Param1=" << gn.getStringParam("Param1") << endl;
 
-	return 0;
+    return 0;
 }

--- a/test/components/cpp/HeartbeatTest/HeartbeatDummy.cpp
+++ b/test/components/cpp/HeartbeatTest/HeartbeatDummy.cpp
@@ -30,17 +30,18 @@
 using namespace std;
 using namespace gravity;
 
-int main() {
-	GravityNode gn;
-	gn.init("hbdummydpid");
+int main()
+{
+    GravityNode gn;
+    gn.init("hbdummydpid");
 
-	cout << "Start" << endl;
+    cout << "Start" << endl;
 
-	gn.startHeartbeat(490000); //About 1/2 second.
+    gn.startHeartbeat(490000);  //About 1/2 second.
 
-	cout << "Started" << endl;
+    cout << "Started" << endl;
 
-	gn.waitForExit();
+    gn.waitForExit();
 
-	return 0;
+    return 0;
 }

--- a/test/components/cpp/HeartbeatTest/HeartbeatDummyListener.cpp
+++ b/test/components/cpp/HeartbeatTest/HeartbeatDummyListener.cpp
@@ -37,23 +37,28 @@
 using namespace std;
 using namespace gravity;
 
-class MyHeartbeatListener : public GravityHeartbeatListener {
-	virtual void MissedHeartbeat(std::string dataProductID, int microsecond_to_last_heartbeat, std::string status);
+class MyHeartbeatListener : public GravityHeartbeatListener
+{
+    virtual void MissedHeartbeat(std::string dataProductID, int microsecond_to_last_heartbeat, std::string status);
 };
 
-void MyHeartbeatListener::MissedHeartbeat(std::string dataProductID, int microsecond_to_last_heartbeat, std::string status)
+void MyHeartbeatListener::MissedHeartbeat(std::string dataProductID, int microsecond_to_last_heartbeat,
+                                          std::string status)
 {
-	cout << "Dataproduct: " << dataProductID << " missed heartbeat.  Last Heard: " << microsecond_to_last_heartbeat / 1000 << "ms.  Status: " << status << endl;
+    cout << "Dataproduct: " << dataProductID
+         << " missed heartbeat.  Last Heard: " << microsecond_to_last_heartbeat / 1000 << "ms.  Status: " << status
+         << endl;
 }
 
-int main() {
-	GravityNode gn;
-	gn.init("HBListener");
+int main()
+{
+    GravityNode gn;
+    gn.init("HBListener");
 
-	MyHeartbeatListener listener;
-	gn.registerHeartbeatListener("hbdummydpid", 490000, listener);
+    MyHeartbeatListener listener;
+    gn.registerHeartbeatListener("hbdummydpid", 490000, listener);
 
-	gn.waitForExit();
+    gn.waitForExit();
 
-	return 0;
+    return 0;
 }

--- a/test/components/cpp/Logger/testLogger.cpp
+++ b/test/components/cpp/Logger/testLogger.cpp
@@ -24,31 +24,30 @@ using namespace std;
 
 int main()
 {
-  using namespace gravity;
-  GravityNode gn;
-  gn.init("TestLogger");
+    using namespace gravity;
+    GravityNode gn;
+    gn.init("TestLogger");
 
-  cout << "test" << endl;
+    cout << "test" << endl;
 
-  //Log::setLocalLevel(Log::TRACE);
-  //Log::init(gn, "test.log", 43211);
+    //Log::setLocalLevel(Log::TRACE);
+    //Log::init(gn, "test.log", 43211);
 
-  getchar();
+    getchar();
 
-  cout << "finished init" << endl;
+    cout << "finished init" << endl;
 
-  Log::trace("Trace");
+    Log::trace("Trace");
 
-  Log::debug("1+1=%d", (1+1));
+    Log::debug("1+1=%d", (1 + 1));
 
-  //  OtherFunc();
+    //  OtherFunc();
 
-  Log::message("Hi %s", "there");
+    Log::message("Hi %s", "there");
 
-  Log::warning("Warn!!!");
+    Log::warning("Warn!!!");
 
-  Log::critical("1!=2");
+    Log::critical("1!=2");
 
-  Log::fatal("AAAAAaaaaaaahhhhhh....");
-
+    Log::fatal("AAAAAaaaaaaahhhhhh....");
 }

--- a/test/components/cpp/ServiceDirectory/GravityNodeTest.cpp
+++ b/test/components/cpp/ServiceDirectory/GravityNodeTest.cpp
@@ -22,9 +22,10 @@
 
 #include <mutex>
 
-namespace {
-  std::mutex mtx;
-} //end anonymous namespace
+namespace
+{
+std::mutex mtx;
+}  //end anonymous namespace
 
 using namespace gravity;
 using namespace std;
@@ -32,11 +33,12 @@ using namespace std;
 class Subscriber : public GravitySubscriber
 {
     int count;
+
 public:
     Subscriber() : count(0) {}
     ~Subscriber() {}
     int getCount() { return count; }
-    void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts) { count++; }
+    void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts) { count++; }
 };
 
 class GravitySyncTest : public GravitySubscriber
@@ -46,15 +48,12 @@ class GravitySyncTest : public GravitySubscriber
     int gdpcount1, gdpcount2;
 
 public:
-
     GravitySyncTest();
-    void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
     void testSync();
 };
 
-GravitySyncTest::GravitySyncTest() : gdp("SyncTestGDP")
-{
-}
+GravitySyncTest::GravitySyncTest() : gdp("SyncTestGDP") {}
 
 void GravitySyncTest::testSync()
 {
@@ -73,8 +72,7 @@ void GravitySyncTest::testSync()
         gdp.setData(&i, sizeof(int));
         gravityNode.publish(gdp);
         // mix up the timing a little
-        if (i % 3 == 0)
-            sleep(1);
+        if (i % 3 == 0) sleep(1);
     }
 
     // give it a second to finish sending subscription data
@@ -87,9 +85,10 @@ void GravitySyncTest::testSync()
     gravityNode.unsubscribe("SyncTestGDP2", *this);
 }
 
-void GravitySyncTest::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void GravitySyncTest::subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-    for(vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin(); i != dataProducts.end(); i++)
+    for (vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin(); i != dataProducts.end();
+         i++)
     {
         std::shared_ptr<GravityDataProduct> dataProduct = *i;
         int receivedCount;
@@ -129,25 +128,26 @@ void GravityNodeTest::setUp()
 
 void GravityNodeTest::testServiceWithDomain(void)
 {
-	GravityNode node;
-	GravityReturnCode ret = node.init("TestDomainServiceNode");
-	GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
+    GravityNode node;
+    GravityReturnCode ret = node.init("TestDomainServiceNode");
+    GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
 
-	// Get the domain from the Service Directory
-	string domain;
-	GravityDataProduct request("GetDomain");
-	std::shared_ptr<GravityDataProduct> response = node.request(gravity::constants::DIRECTORY_SERVICE_DPID, request, 1000);
-	GRAVITY_TEST(response);
-	char* p = (char*)calloc(response->getDataSize(), sizeof(char));
-	response->getData(p, response->getDataSize());
-	domain.assign(p, response->getDataSize());	
-	free(p);	
-	GRAVITY_TEST_EQUALS(strcmp(domain.c_str(), "GravityTest"), 0);
+    // Get the domain from the Service Directory
+    string domain;
+    GravityDataProduct request("GetDomain");
+    std::shared_ptr<GravityDataProduct> response =
+        node.request(gravity::constants::DIRECTORY_SERVICE_DPID, request, 1000);
+    GRAVITY_TEST(response);
+    char* p = (char*)calloc(response->getDataSize(), sizeof(char));
+    response->getData(p, response->getDataSize());
+    domain.assign(p, response->getDataSize());
+    free(p);
+    GRAVITY_TEST_EQUALS(strcmp(domain.c_str(), "GravityTest"), 0);
 
-	GravityDataProduct gdp("REQUEST");
-	gdp.setData("REQ_DATA", 9);
+    GravityDataProduct gdp("REQUEST");
+    gdp.setData("REQ_DATA", 9);
 
-	clearServiceFlags();
+    clearServiceFlags();
 
     // Register a service
     ret = node.registerService("SERVICE_TEST", GravityTransportTypes::TCP, *this);
@@ -159,89 +159,90 @@ void GravityNodeTest::testServiceWithDomain(void)
     GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
     sleep(2);
 
-	// Check for request
-	GRAVITY_TEST(gotRequest());
+    // Check for request
+    GRAVITY_TEST(gotRequest());
 
-	// Check for response
-	GRAVITY_TEST(gotResponse());	
+    // Check for response
+    GRAVITY_TEST(gotResponse());
 
-	// Submit sync request  with domain specified
-	std::shared_ptr<GravityDataProduct> retGDP = node.request("SERVICE_TEST", gdp, -1, domain);
-	GRAVITY_TEST_EQUALS(retGDP->getDataProductID(), "RESPONSE");
+    // Submit sync request  with domain specified
+    std::shared_ptr<GravityDataProduct> retGDP = node.request("SERVICE_TEST", gdp, -1, domain);
+    GRAVITY_TEST_EQUALS(retGDP->getDataProductID(), "RESPONSE");
 
-	// Clear service info
-	clearServiceFlags();
+    // Clear service info
+    clearServiceFlags();
 
-	// Submit async request to the service with bad domain specified
-    ret = node.request("SERVICE_TEST", gdp, *this, "REQUEST_ID", -1, domain+"_");
+    // Submit async request to the service with bad domain specified
+    ret = node.request("SERVICE_TEST", gdp, *this, "REQUEST_ID", -1, domain + "_");
     GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::NO_SUCH_SERVICE);
     sleep(2);
 
-	// Check for request (should not be received)
-	GRAVITY_TEST(!gotRequest());
+    // Check for request (should not be received)
+    GRAVITY_TEST(!gotRequest());
 
-	// Check for response (should not be received)
-	GRAVITY_TEST(!gotResponse());
+    // Check for response (should not be received)
+    GRAVITY_TEST(!gotResponse());
 
-	// Clear service info
-	clearServiceFlags();
+    // Clear service info
+    clearServiceFlags();
 
-	// Unregister service
-	ret = node.unregisterService("SERVICE_TEST");
-	GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
+    // Unregister service
+    ret = node.unregisterService("SERVICE_TEST");
+    GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
 }
 
 void GravityNodeTest::testSubscribeDomain(void)
 {
-	GravityNode node;
+    GravityNode node;
     GravityReturnCode ret = node.init("TestNode");
     GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
 
-	// Get the domain from the Service Directory
-	string domain;
-	GravityDataProduct request("GetDomain");
-	std::shared_ptr<GravityDataProduct> response = node.request(gravity::constants::DIRECTORY_SERVICE_DPID, request, 1000);
-	GRAVITY_TEST(response);
-	char* p = (char*)calloc(response->getDataSize(), sizeof(char));
-	response->getData(p, response->getDataSize());
-	domain.assign(p, response->getDataSize());	
-	free(p);	
-	GRAVITY_TEST_EQUALS(strcmp(domain.c_str(), "GravityTest"), 0);
+    // Get the domain from the Service Directory
+    string domain;
+    GravityDataProduct request("GetDomain");
+    std::shared_ptr<GravityDataProduct> response =
+        node.request(gravity::constants::DIRECTORY_SERVICE_DPID, request, 1000);
+    GRAVITY_TEST(response);
+    char* p = (char*)calloc(response->getDataSize(), sizeof(char));
+    response->getData(p, response->getDataSize());
+    domain.assign(p, response->getDataSize());
+    free(p);
+    GRAVITY_TEST_EQUALS(strcmp(domain.c_str(), "GravityTest"), 0);
 
-	ret = node.registerDataProduct("TEST", GravityTransportTypes::TCP);
+    ret = node.registerDataProduct("TEST", GravityTransportTypes::TCP);
     GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
 
-	Subscriber badSubscriber;
-	ret = node.subscribe("TEST", badSubscriber, "", domain+"_");
+    Subscriber badSubscriber;
+    ret = node.subscribe("TEST", badSubscriber, "", domain + "_");
     GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
 
-	Subscriber goodSubscriber1;
-	ret = node.subscribe("TEST", goodSubscriber1, "", domain);
+    Subscriber goodSubscriber1;
+    ret = node.subscribe("TEST", goodSubscriber1, "", domain);
     GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
 
-	Subscriber goodSubscriber2;
-	ret = node.subscribe("TEST", goodSubscriber2);
+    Subscriber goodSubscriber2;
+    ret = node.subscribe("TEST", goodSubscriber2);
     GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
 
-	// Give the consumer threads time to start up
+    // Give the consumer threads time to start up
     sleep(50);
 
-	ret = node.registerDataProduct("TEST", GravityTransportTypes::TCP);
-	GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
+    ret = node.registerDataProduct("TEST", GravityTransportTypes::TCP);
+    GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
 
     // Create and publish a message
     GravityDataProduct gdp("TEST");
     ret = node.publish(gdp);
 
-	// Give the consumers a little time
+    // Give the consumers a little time
     sleep(50);
 
-	// Test that the domains functioned properly
+    // Test that the domains functioned properly
     GRAVITY_TEST_EQUALS(badSubscriber.getCount(), 0);
-	GRAVITY_TEST_EQUALS(goodSubscriber1.getCount(), 1);
-	GRAVITY_TEST_EQUALS(goodSubscriber2.getCount(), 1);
+    GRAVITY_TEST_EQUALS(goodSubscriber1.getCount(), 1);
+    GRAVITY_TEST_EQUALS(goodSubscriber2.getCount(), 1);
 
-    node.unsubscribe("TEST", badSubscriber, "", domain+"_");
+    node.unsubscribe("TEST", badSubscriber, "", domain + "_");
     node.unsubscribe("TEST", goodSubscriber1, "", domain);
     node.unsubscribe("TEST", goodSubscriber2);
 }
@@ -293,9 +294,9 @@ void GravityNodeTest::testRegisterData(void)
 
 void GravityNodeTest::testSubscriptionManager(void)
 {
-	GravityNode node;
-	GravityReturnCode ret = node.init("TestNode2");
-	GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
+    GravityNode node;
+    GravityReturnCode ret = node.init("TestNode2");
+    GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
 
     Subscriber preSubscriber;
     ret = node.subscribe("TEST", preSubscriber, "FILT");
@@ -303,8 +304,8 @@ void GravityNodeTest::testSubscriptionManager(void)
     // Give the consumer thread time to start up
     sleep(20);
 
-	ret = node.registerDataProduct("TEST", GravityTransportTypes::TCP);
-	GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
+    ret = node.registerDataProduct("TEST", GravityTransportTypes::TCP);
+    GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
 
     // Create and publish a message
     GravityDataProduct gdp("TEST");
@@ -317,7 +318,7 @@ void GravityNodeTest::testSubscriptionManager(void)
     GRAVITY_TEST_EQUALS(preSubscriber.getCount(), 1);
 
     Subscriber postSubscriber;
-	ret = node.subscribe("TEST", postSubscriber, "FILT");
+    ret = node.subscribe("TEST", postSubscriber, "FILT");
 
     // Give the consumer thread time to start up
     sleep(20);
@@ -336,20 +337,20 @@ void GravityNodeTest::testSubscriptionManager(void)
     // Clear out subscription filled flag
     clearSubFlag();
 
-	ret = node.subscribe("TEST", *this, "FILT");
-	GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
+    ret = node.subscribe("TEST", *this, "FILT");
+    GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
 
-	// Give it a couple secs
-	sleep(20);
+    // Give it a couple secs
+    sleep(20);
 
-	// Check for subscription filled
-	GRAVITY_TEST(subFilled());
+    // Check for subscription filled
+    GRAVITY_TEST(subFilled());
 
-	// Check that postSubscriber wasn't called again
+    // Check that postSubscriber wasn't called again
     GRAVITY_TEST_EQUALS(postSubscriber.getCount(), 2);
 
-	// Clear flag
-	clearSubFlag();
+    // Clear flag
+    clearSubFlag();
 
     // Resend message
     ret = node.publish(gdp, "FIL");
@@ -363,16 +364,16 @@ void GravityNodeTest::testSubscriptionManager(void)
     // Clear flag
     clearSubFlag();
 
-	// Unsubscribe & wait a couple secs
-	ret = node.unsubscribe("TEST", *this, "FILT");
-	sleep(2);
+    // Unsubscribe & wait a couple secs
+    ret = node.unsubscribe("TEST", *this, "FILT");
+    sleep(2);
 
-	// Resend message
-	ret = node.publish(gdp, "FILT");
-	sleep(2);
+    // Resend message
+    ret = node.publish(gdp, "FILT");
+    sleep(2);
 
-	// Check to ensure that nothing was sent
-	GRAVITY_TEST(!subFilled());
+    // Check to ensure that nothing was sent
+    GRAVITY_TEST(!subFilled());
 
     node.unsubscribe("TEST", preSubscriber, "FILT");
     node.unsubscribe("TEST", postSubscriber, "FILT");
@@ -380,20 +381,20 @@ void GravityNodeTest::testSubscriptionManager(void)
 
 void GravityNodeTest::testServiceManager(void)
 {
-	GravityNode node;
-	GravityReturnCode ret = node.init("TestNode3");
-	//sleep(2);
-	GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
+    GravityNode node;
+    GravityReturnCode ret = node.init("TestNode3");
+    //sleep(2);
+    GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
 
-	GravityDataProduct gdp("REQUEST");
-	gdp.setData("REQ_DATA", 9);
+    GravityDataProduct gdp("REQUEST");
+    gdp.setData("REQ_DATA", 9);
 
-	clearServiceFlags();
+    clearServiceFlags();
 
-	// Submit request to the service before it's available
-	ret = node.request("SERVICE_TEST", gdp, *this, "REQUEST_ID");
-	GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::NO_SUCH_SERVICE);
-	sleep(2);
+    // Submit request to the service before it's available
+    ret = node.request("SERVICE_TEST", gdp, *this, "REQUEST_ID");
+    GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::NO_SUCH_SERVICE);
+    sleep(2);
 
     // Register a service
     ret = node.registerService("SERVICE_TEST", GravityTransportTypes::TCP, *this);
@@ -406,16 +407,16 @@ void GravityNodeTest::testServiceManager(void)
     sleep(2);
 
     std::shared_ptr<GravityDataProduct> retGDP = node.request("SERVICE_TEST", gdp);
-	GRAVITY_TEST_EQUALS(retGDP->getDataProductID(), "RESPONSE");
+    GRAVITY_TEST_EQUALS(retGDP->getDataProductID(), "RESPONSE");
 
-	ret = node.unregisterService("SERVICE_TEST");
-	GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
+    ret = node.unregisterService("SERVICE_TEST");
+    GRAVITY_TEST_EQUALS(ret, GravityReturnCodes::SUCCESS);
 
-	// Check for request
-	GRAVITY_TEST(gotRequest());
+    // Check for request
+    GRAVITY_TEST(gotRequest());
 
-	// Check for response
-	GRAVITY_TEST(gotResponse());
+    // Check for response
+    GRAVITY_TEST(gotResponse());
 }
 
 void GravityNodeTest::testRegisterService(void)
@@ -452,20 +453,20 @@ void GravityNodeTest::testRegisterService(void)
 
 void GravityNodeTest::testDataProduct(void)
 {
-	GravityDataProduct gdp("GDP_ID");
-	gdp.setData("TEST_DATA", 10);
+    GravityDataProduct gdp("GDP_ID");
+    gdp.setData("TEST_DATA", 10);
 
-	char* data = (char*)malloc(gdp.getSize());
-	gdp.serializeToArray(data);
+    char* data = (char*)malloc(gdp.getSize());
+    gdp.serializeToArray(data);
 
-	GravityDataProduct gdp2(data, gdp.getSize());
-	GRAVITY_TEST(strcmp(gdp2.getDataProductID().c_str(), "GDP_ID")==0);
-	char* data2 = (char*)malloc(gdp.getDataSize());
-	gdp2.getData(data2, gdp2.getDataSize());
-	GRAVITY_TEST(strcmp(data2, "TEST_DATA")==0);
+    GravityDataProduct gdp2(data, gdp.getSize());
+    GRAVITY_TEST(strcmp(gdp2.getDataProductID().c_str(), "GDP_ID") == 0);
+    char* data2 = (char*)malloc(gdp.getDataSize());
+    gdp2.getData(data2, gdp2.getDataSize());
+    GRAVITY_TEST(strcmp(data2, "TEST_DATA") == 0);
 
-	free(data);
-	free(data2);
+    free(data);
+    free(data2);
 }
 
 void GravityNodeTest::testComponentID(void)
@@ -476,7 +477,7 @@ void GravityNodeTest::testComponentID(void)
     GRAVITY_TEST_EQUALS(gn.getComponentID(), "TestCompId");
 }
 
-void GravityNodeTest::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void GravityNodeTest::subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
     std::lock_guard<std::mutex> guard(mtx);
     subFilledFlag = true;
@@ -484,65 +485,64 @@ void GravityNodeTest::subscriptionFilled(const std::vector< std::shared_ptr<Grav
 
 bool GravityNodeTest::subFilled()
 {
-	bool ret;
-  std::lock_guard<std::mutex> guard(mtx);
-	ret = subFilledFlag;
-	return ret;
+    bool ret;
+    std::lock_guard<std::mutex> guard(mtx);
+    ret = subFilledFlag;
+    return ret;
 }
 
 void GravityNodeTest::clearSubFlag()
 {
     std::lock_guard<std::mutex> guard(mtx);
-   	subFilledFlag = false;
+    subFilledFlag = false;
 }
 
 void GravityNodeTest::clearServiceFlags()
 {
-  std::lock_guard<std::mutex> guard(mtx);
-	gotResponseFlag = false;
-	gotRequestFlag = false;
+    std::lock_guard<std::mutex> guard(mtx);
+    gotResponseFlag = false;
+    gotRequestFlag = false;
 }
 
 bool GravityNodeTest::gotRequest()
 {
-	bool ret = false;
-  std::lock_guard<std::mutex> guard(mtx);
-   	ret = gotRequestFlag;
-   	return ret;
+    bool ret = false;
+    std::lock_guard<std::mutex> guard(mtx);
+    ret = gotRequestFlag;
+    return ret;
 }
 
 bool GravityNodeTest::gotResponse()
 {
-  	bool ret = false;
+    bool ret = false;
     std::lock_guard<std::mutex> guard(mtx);
-   	ret = gotResponseFlag;
-   	return ret;
+    ret = gotResponseFlag;
+    return ret;
 }
 
-std::shared_ptr<GravityDataProduct> GravityNodeTest::request(const std::string serviceID, const GravityDataProduct& dataProduct)
+std::shared_ptr<GravityDataProduct> GravityNodeTest::request(const std::string serviceID,
+                                                             const GravityDataProduct& dataProduct)
 {
     std::shared_ptr<GravityDataProduct> ret(new GravityDataProduct("RESPONSE"));
-	ret->setData("RESP_DATA", 10);
+    ret->setData("RESP_DATA", 10);
 
-  std::lock_guard<std::mutex> guard(mtx);
-	char* data = (char*)malloc(dataProduct.getDataSize());
-	dataProduct.getData(data, dataProduct.getDataSize());
-	gotRequestFlag = (strcmp(dataProduct.getDataProductID().c_str(), "REQUEST")==0 &&
-	    						strcmp(data, "REQ_DATA")==0);
+    std::lock_guard<std::mutex> guard(mtx);
+    char* data = (char*)malloc(dataProduct.getDataSize());
+    dataProduct.getData(data, dataProduct.getDataSize());
+    gotRequestFlag = (strcmp(dataProduct.getDataProductID().c_str(), "REQUEST") == 0 && strcmp(data, "REQ_DATA") == 0);
 
-	return ret;
+    return ret;
 }
 
 void GravityNodeTest::requestFilled(string serviceID, string requestID, const GravityDataProduct& response)
 {
-  std::lock_guard<std::mutex> guard(mtx);
-	char* data = (char*)malloc(response.getDataSize());
-	response.getData(data, response.getDataSize());
-	gotResponseFlag = (strcmp(response.getDataProductID().c_str(), "RESPONSE")==0 &&
-						strcmp(data, "RESP_DATA")==0);
+    std::lock_guard<std::mutex> guard(mtx);
+    char* data = (char*)malloc(response.getDataSize());
+    response.getData(data, response.getDataSize());
+    gotResponseFlag = (strcmp(response.getDataProductID().c_str(), "RESPONSE") == 0 && strcmp(data, "RESP_DATA") == 0);
 }
 
-int main( int argc, char *argv[] )
+int main(int argc, char* argv[])
 {
     GravityNodeTest gnTest;
     printf("\nAbout to run test setup...\n\n");

--- a/test/components/cpp/ServiceDirectory/GravityNodeTest.h
+++ b/test/components/cpp/ServiceDirectory/GravityNodeTest.h
@@ -23,7 +23,7 @@
  *      Author: Chris Brundick
  */
 
- /*
+/*
   * Gravity APIs Tested here:
   * registerDataProduct
   * unregisterDataProduct
@@ -53,7 +53,7 @@
 #include "GravityDataProduct.h"
 #include "Utility.h"
 
-class GravityNodeTest: public gravity::GravitySubscriber, gravity::GravityServiceProvider, gravity::GravityRequestor
+class GravityNodeTest : public gravity::GravitySubscriber, gravity::GravityServiceProvider, gravity::GravityRequestor
 {
 public:
     void setUp();
@@ -62,12 +62,13 @@ public:
     void testServiceManager(void);
     void testRegisterService(void);
     void testDataProduct(void);
-	void testSubscribeDomain(void);
-	void testServiceWithDomain(void);
-	void testComponentID(void);
-    void subscriptionFilled(const std::vector< std::shared_ptr<gravity::GravityDataProduct> >& dataProducts);
+    void testSubscribeDomain(void);
+    void testServiceWithDomain(void);
+    void testComponentID(void);
+    void subscriptionFilled(const std::vector<std::shared_ptr<gravity::GravityDataProduct> >& dataProducts);
     void requestFilled(std::string serviceID, std::string requestID, const gravity::GravityDataProduct& response);
-    std::shared_ptr<gravity::GravityDataProduct> request(const std::string serviceID, const gravity::GravityDataProduct& dataProduct);
+    std::shared_ptr<gravity::GravityDataProduct> request(const std::string serviceID,
+                                                         const gravity::GravityDataProduct& dataProduct);
 
 private:
     bool gotResponse();

--- a/test/components/cpp/ServiceDirectoryReregister/Provider.cpp
+++ b/test/components/cpp/ServiceDirectoryReregister/Provider.cpp
@@ -28,32 +28,34 @@ class Provider : public GravityServiceProvider
 {
 public:
     int counter;
-	virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID, const GravityDataProduct& dataProduct);
+    virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID,
+                                                        const GravityDataProduct& dataProduct);
 };
 
-
-std::shared_ptr<GravityDataProduct> Provider::request(const std::string serviceID, const GravityDataProduct& dataProduct)
+std::shared_ptr<GravityDataProduct> Provider::request(const std::string serviceID,
+                                                      const GravityDataProduct& dataProduct)
 {
-	//Just to be safe.  In theory this can never happen unless this class is registered with more than one serviceID types.
-	if(dataProduct.getDataProductID() != "Counter") {
-		Log::critical("Request is not for counter!");
-		return std::shared_ptr<GravityDataProduct>(new GravityDataProduct("BadRequest"));
-	}
+    //Just to be safe.  In theory this can never happen unless this class is registered with more than one serviceID types.
+    if (dataProduct.getDataProductID() != "Counter")
+    {
+        Log::critical("Request is not for counter!");
+        return std::shared_ptr<GravityDataProduct>(new GravityDataProduct("BadRequest"));
+    }
 
-	Log::warning("Request received");
+    Log::warning("Request received");
 
-	std::shared_ptr<GravityDataProduct> resultDP(new GravityDataProduct("Result"));
-	resultDP->setData(&counter, sizeof(int));
-	counter++;
+    std::shared_ptr<GravityDataProduct> resultDP(new GravityDataProduct("Result"));
+    resultDP->setData(&counter, sizeof(int));
+    counter++;
 
-	return resultDP;
+    return resultDP;
 }
 
 int main()
 {
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	GravityReturnCode ret = gn.init("Provider");
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    GravityReturnCode ret = gn.init("Provider");
     int numTries = 3;
     while (ret != GravityReturnCodes::SUCCESS && numTries-- > 0)
     {
@@ -66,20 +68,20 @@ int main()
         exit(1);
     }
 
-	Provider msp;
-	msp.counter = 0;
-	gn.registerService(
-						//This identifies the Service to the service directory so that others can
-						// make a request to it.
-						"Counter",
-						//Assign a transport type to the socket (almost always tcp, unless you are only
-						//using the gravity data product between two processes on the same computer).
-						GravityTransportTypes::TCP,
-						//Give an instance of the service class to be called when a request is made.
-						msp);
+    Provider msp;
+    msp.counter = 0;
+    gn.registerService(
+        //This identifies the Service to the service directory so that others can
+        // make a request to it.
+        "Counter",
+        //Assign a transport type to the socket (almost always tcp, unless you are only
+        //using the gravity data product between two processes on the same computer).
+        GravityTransportTypes::TCP,
+        //Give an instance of the service class to be called when a request is made.
+        msp);
 
-	//Wait for us to exit (Ctrl-C or being killed).
-	gn.waitForExit();
+    //Wait for us to exit (Ctrl-C or being killed).
+    gn.waitForExit();
 
-	gn.unregisterService("Counter");
+    gn.unregisterService("Counter");
 }

--- a/test/components/cpp/ServiceDirectoryReregister/Publisher.cpp
+++ b/test/components/cpp/ServiceDirectoryReregister/Publisher.cpp
@@ -24,57 +24,56 @@
 
 int main()
 {
-	using namespace gravity;
+    using namespace gravity;
 
-	GravityNode gn;
-	const std::string dataProductID = "DataProduct";
+    GravityNode gn;
+    const std::string dataProductID = "DataProduct";
 
-	//Initialize gravity, giving this node a componentID.
-	GravityReturnCode ret = gn.init("Publisher");
+    //Initialize gravity, giving this node a componentID.
+    GravityReturnCode ret = gn.init("Publisher");
     int numTries = 3;
     while (ret != GravityReturnCodes::SUCCESS && numTries-- > 0)
     {
         Log::warning("Error during init, retrying...");
         ret = gn.init("Publisher");
     }
-	if (ret != GravityReturnCodes::SUCCESS)
-	{
-		Log::fatal("Could not initialize GravityNode, return code was %d", ret);
-		exit(1);
-	}
+    if (ret != GravityReturnCodes::SUCCESS)
+    {
+        Log::fatal("Could not initialize GravityNode, return code was %d", ret);
+        exit(1);
+    }
 
-	//Register a data product
-	ret = gn.registerDataProduct(
-							//This identifies the Data Product to the service directory so that others can
-							// subscribe to it.  (See BasicDataProductSubscriber.cpp).
-							dataProductID,
-							//Assign a transport type to the socket (almost always tcp, unless you are only
-							//using the gravity data product between two processes on the same computer).
-							GravityTransportTypes::TCP);
-	if (ret != GravityReturnCodes::SUCCESS)
-	{
-		Log::fatal("Could not register data product with id %s, return code was %d", dataProductID.c_str(), ret);
-		exit(1);
-	}
+    //Register a data product
+    ret = gn.registerDataProduct(
+        //This identifies the Data Product to the service directory so that others can
+        // subscribe to it.  (See BasicDataProductSubscriber.cpp).
+        dataProductID,
+        //Assign a transport type to the socket (almost always tcp, unless you are only
+        //using the gravity data product between two processes on the same computer).
+        GravityTransportTypes::TCP);
+    if (ret != GravityReturnCodes::SUCCESS)
+    {
+        Log::fatal("Could not register data product with id %s, return code was %d", dataProductID.c_str(), ret);
+        exit(1);
+    }
 
-	int counter = 1;
-	while(1)
-	{
-		//Create a data product to send across the network of type "DataProduct"
-		GravityDataProduct gdp(dataProductID);
-		//This is going to be a raw data product (ie not using protobufs).
-		gdp.setData(&counter, sizeof(int));
-		counter++;
+    int counter = 1;
+    while (1)
+    {
+        //Create a data product to send across the network of type "DataProduct"
+        GravityDataProduct gdp(dataProductID);
+        //This is going to be a raw data product (ie not using protobufs).
+        gdp.setData(&counter, sizeof(int));
+        counter++;
 
-		//Publish the  data product.
-		ret = gn.publish(gdp);
-		if (ret != GravityReturnCodes::SUCCESS)
-		{
-			Log::critical("Could not publish data product with id %s, return code was %d", dataProductID.c_str(), ret);
-		}
+        //Publish the  data product.
+        ret = gn.publish(gdp);
+        if (ret != GravityReturnCodes::SUCCESS)
+        {
+            Log::critical("Could not publish data product with id %s, return code was %d", dataProductID.c_str(), ret);
+        }
 
-		//Sleep for 1 second.
-		gravity::sleep(1000);
-	}
-
+        //Sleep for 1 second.
+        gravity::sleep(1000);
+    }
 }

--- a/test/components/cpp/ServiceDirectoryReregister/Requestor.cpp
+++ b/test/components/cpp/ServiceDirectoryReregister/Requestor.cpp
@@ -27,9 +27,9 @@ using namespace gravity;
 
 int main()
 {
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	GravityReturnCode ret = gn.init("Requestor");
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    GravityReturnCode ret = gn.init("Requestor");
     int numTries = 3;
     while (ret != GravityReturnCodes::SUCCESS && numTries-- > 0)
     {
@@ -42,17 +42,16 @@ int main()
         exit(1);
     }
 
-
-	GravityDataProduct request("Counter");
+    GravityDataProduct request("Counter");
 
     int counter = 0;
     int tries = 0;
-	while(counter < 20 && tries++ < 30)
-	{
-	    std::shared_ptr<GravityDataProduct> countReq = gn.request("Counter", //Service Name
-                                                             request, //Request
-                                                             3000); //Timeout in milliseconds
-        if(countReq == NULL)
+    while (counter < 20 && tries++ < 30)
+    {
+        std::shared_ptr<GravityDataProduct> countReq = gn.request("Counter",  //Service Name
+                                                                  request,    //Request
+                                                                  3000);      //Timeout in milliseconds
+        if (countReq == NULL)
         {
             Log::critical("Request Returned NULL!");
         }
@@ -63,10 +62,10 @@ int main()
         }
 
         gravity::sleep(1000);
-	}
+    }
 
     // make sure we finished
     GRAVITY_TEST(tries < 30);
 
-	return 0;
+    return 0;
 }

--- a/test/components/cpp/ServiceDirectoryReregister/Subscriber.cpp
+++ b/test/components/cpp/ServiceDirectoryReregister/Subscriber.cpp
@@ -29,65 +29,64 @@ using namespace gravity;
 class SimpleGravitySubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
-	bool done;
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
+    bool done;
 };
 
 int main()
 {
-	GravityNode gn;
-	const std::string dataProductID = "DataProduct";
+    GravityNode gn;
+    const std::string dataProductID = "DataProduct";
 
-	//Initialize gravity, giving this node a componentID.
-	GravityReturnCode ret = gn.init("Subscriber");
-	int numTries = 3;
-	while (ret != GravityReturnCodes::SUCCESS && numTries-- > 0)
-	{
-	    Log::warning("Error during init, retrying...");
-	    ret = gn.init("Subscriber");
-	}
-	if (ret != GravityReturnCodes::SUCCESS)
-	{
-		Log::fatal("Could not initialize GravityNode, return code is %d", ret);
-		exit(1);
-	}
+    //Initialize gravity, giving this node a componentID.
+    GravityReturnCode ret = gn.init("Subscriber");
+    int numTries = 3;
+    while (ret != GravityReturnCodes::SUCCESS && numTries-- > 0)
+    {
+        Log::warning("Error during init, retrying...");
+        ret = gn.init("Subscriber");
+    }
+    if (ret != GravityReturnCodes::SUCCESS)
+    {
+        Log::fatal("Could not initialize GravityNode, return code is %d", ret);
+        exit(1);
+    }
 
-	//Subscribe to the counter.
-	SimpleGravitySubscriber hwSubscriber;
+    //Subscribe to the counter.
+    SimpleGravitySubscriber hwSubscriber;
     hwSubscriber.done = false;
-	ret = gn.subscribe(dataProductID, hwSubscriber);
-	if (ret != GravityReturnCodes::SUCCESS)
-	{
-		Log::critical("Could not subscribe to data product with id %s, return code was %d", dataProductID.c_str(), ret);
-		exit(1);
-	}
+    ret = gn.subscribe(dataProductID, hwSubscriber);
+    if (ret != GravityReturnCodes::SUCCESS)
+    {
+        Log::critical("Could not subscribe to data product with id %s, return code was %d", dataProductID.c_str(), ret);
+        exit(1);
+    }
 
     int tries = 0;
-	while(!hwSubscriber.done && tries++ < 30)
-	{
-	    Log::trace("done = %d, tries = %d", hwSubscriber.done, tries);
-	    gravity::sleep(1000);
-	}
+    while (!hwSubscriber.done && tries++ < 30)
+    {
+        Log::trace("done = %d, tries = %d", hwSubscriber.done, tries);
+        gravity::sleep(1000);
+    }
 
-	// make sure we finished
-	GRAVITY_TEST(tries < 30);
+    // make sure we finished
+    GRAVITY_TEST(tries < 30);
 
-	gn.unsubscribe(dataProductID, hwSubscriber);
+    gn.unsubscribe(dataProductID, hwSubscriber);
 }
 
-void SimpleGravitySubscriber::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravitySubscriber::subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
-			i != dataProducts.end(); i++)
-	{
-		//Get a raw message
-		int counter;
-		(*i)->getData(&counter, sizeof(int));
+    for (std::vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+         i != dataProducts.end(); i++)
+    {
+        //Get a raw message
+        int counter;
+        (*i)->getData(&counter, sizeof(int));
 
-		//Output the message
-		Log::warning("Got message: %d", counter);
+        //Output the message
+        Log::warning("Got message: %d", counter);
 
-		if (counter > 20)
-		    done = true;
-	}
+        if (counter > 20) done = true;
+    }
 }

--- a/test/examples/1-BasicDataProduct/BasicDataProductPublisher.cpp
+++ b/test/examples/1-BasicDataProduct/BasicDataProductPublisher.cpp
@@ -24,53 +24,52 @@
 
 int main()
 {
-	using namespace gravity;
+    using namespace gravity;
 
-	GravityNode gn;
-	const std::string dataProductID = "HelloWorldDataProduct";
+    GravityNode gn;
+    const std::string dataProductID = "HelloWorldDataProduct";
 
-	//Initialize gravity, giving this node a componentID.
-	GravityReturnCode ret = gn.init("SimpleGravityComponentID");
-	if (ret != GravityReturnCodes::SUCCESS)
-	{
-		spdlog::critical("Could not initialize GravityNode, return code was {}", ret);
-		exit(1);
-	}
+    //Initialize gravity, giving this node a componentID.
+    GravityReturnCode ret = gn.init("SimpleGravityComponentID");
+    if (ret != GravityReturnCodes::SUCCESS)
+    {
+        spdlog::critical("Could not initialize GravityNode, return code was {}", ret);
+        exit(1);
+    }
 
-	//Register a data product
-	ret = gn.registerDataProduct(
-							//This identifies the Data Product to the service directory so that others can
-							// subscribe to it.  (See BasicDataProductSubscriber.cpp).
-							dataProductID,
-							//Assign a transport type to the socket (almost always tcp, unless you are only
-							//using the gravity data product between two processes on the same computer).
-							GravityTransportTypes::TCP);
-	if (ret != GravityReturnCodes::SUCCESS)
-	{
-		spdlog::critical("Could not register data product with id {}, return code was {}", dataProductID, ret);
-		exit(1);
-	}
+    //Register a data product
+    ret = gn.registerDataProduct(
+        //This identifies the Data Product to the service directory so that others can
+        // subscribe to it.  (See BasicDataProductSubscriber.cpp).
+        dataProductID,
+        //Assign a transport type to the socket (almost always tcp, unless you are only
+        //using the gravity data product between two processes on the same computer).
+        GravityTransportTypes::TCP);
+    if (ret != GravityReturnCodes::SUCCESS)
+    {
+        spdlog::critical("Could not register data product with id {}, return code was {}", dataProductID, ret);
+        exit(1);
+    }
 
-	bool quit = false; //TODO: set this when you want the program to quit if you need to clean up before exiting.
-	int count = 1;
-	while(!quit)
-	{
-		//Create a data product to send across the network of type "HelloWorldDataProduct"
-		GravityDataProduct helloWorldDataProduct(dataProductID);
-		//This is going to be a raw data product (ie not using protobufs).
-		char data[24];
-		sprintf(data, "Hello World #%d", count++);
-		helloWorldDataProduct.setData((void*)data, strlen(data));
+    bool quit = false;  //TODO: set this when you want the program to quit if you need to clean up before exiting.
+    int count = 1;
+    while (!quit)
+    {
+        //Create a data product to send across the network of type "HelloWorldDataProduct"
+        GravityDataProduct helloWorldDataProduct(dataProductID);
+        //This is going to be a raw data product (ie not using protobufs).
+        char data[24];
+        sprintf(data, "Hello World #%d", count++);
+        helloWorldDataProduct.setData((void*)data, strlen(data));
 
-		//Publish the  data product.
-		ret = gn.publish(helloWorldDataProduct);
-		if (ret != GravityReturnCodes::SUCCESS)
-		{
-			spdlog::error("Could not publish data product with id {}, return code was {}", dataProductID, ret);
-		}
+        //Publish the  data product.
+        ret = gn.publish(helloWorldDataProduct);
+        if (ret != GravityReturnCodes::SUCCESS)
+        {
+            spdlog::error("Could not publish data product with id {}, return code was {}", dataProductID, ret);
+        }
 
-		//Sleep for 1 second.
-		gravity::sleep(1000);
-	}
-
+        //Sleep for 1 second.
+        gravity::sleep(1000);
+    }
 }

--- a/test/examples/1-BasicDataProduct/BasicDataProductSubscriber.cpp
+++ b/test/examples/1-BasicDataProduct/BasicDataProductSubscriber.cpp
@@ -28,53 +28,53 @@ using namespace gravity;
 class SimpleGravitySubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 int main()
 {
-	GravityNode gn;
-	const std::string dataProductID = "HelloWorldDataProduct";
+    GravityNode gn;
+    const std::string dataProductID = "HelloWorldDataProduct";
 
-	//Initialize gravity, giving this node a componentID.
-	GravityReturnCode ret = gn.init("SimpleGravityComponentID2");
-	if (ret != GravityReturnCodes::SUCCESS)
-	{
-		spdlog::critical("Could not initialize GravityNode, return code is {}", ret);
-		exit(1);
-	}
+    //Initialize gravity, giving this node a componentID.
+    GravityReturnCode ret = gn.init("SimpleGravityComponentID2");
+    if (ret != GravityReturnCodes::SUCCESS)
+    {
+        spdlog::critical("Could not initialize GravityNode, return code is {}", ret);
+        exit(1);
+    }
 
-	//Subscribe a SimpleGravityHelloWorldSubscriber to the counter.
-	SimpleGravitySubscriber hwSubscriber;
-	ret = gn.subscribe(dataProductID, hwSubscriber);
-	if (ret != GravityReturnCodes::SUCCESS)
-	{
-		spdlog::error("Could not subscribe to data product with id {}, return code was {}", dataProductID, ret);
-		exit(1);
-	}
+    //Subscribe a SimpleGravityHelloWorldSubscriber to the counter.
+    SimpleGravitySubscriber hwSubscriber;
+    ret = gn.subscribe(dataProductID, hwSubscriber);
+    if (ret != GravityReturnCodes::SUCCESS)
+    {
+        spdlog::error("Could not subscribe to data product with id {}, return code was {}", dataProductID, ret);
+        exit(1);
+    }
 
-	//Wait for us to exit (Ctrl-C or being killed).
-	gn.waitForExit();
+    //Wait for us to exit (Ctrl-C or being killed).
+    gn.waitForExit();
 
-	//Currently this will never be hit because we will have been killed (unfortunately).
-	//But this shouldn't make a difference because the OS should close the socket and free all resources.
-	gn.unsubscribe("HelloWorldDataProduct", hwSubscriber);
+    //Currently this will never be hit because we will have been killed (unfortunately).
+    //But this shouldn't make a difference because the OS should close the socket and free all resources.
+    gn.unsubscribe("HelloWorldDataProduct", hwSubscriber);
 }
 
-void SimpleGravitySubscriber::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravitySubscriber::subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
-			i != dataProducts.end(); i++)
-	{
-		//Get a raw message
-		int size = (*i)->getDataSize();
-		char* message = new char[size+1];
-		(*i)->getData(message, size);
-		message[size] = 0; // null terminate
+    for (std::vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+         i != dataProducts.end(); i++)
+    {
+        //Get a raw message
+        int size = (*i)->getDataSize();
+        char* message = new char[size + 1];
+        (*i)->getData(message, size);
+        message[size] = 0;  // null terminate
 
-		//Output the message
-		spdlog::warn("Got message: {}", message);
-		//Don't forget to free the memory we allocated.
-		delete[] message;
-	}
+        //Output the message
+        spdlog::warn("Got message: {}", message);
+        //Don't forget to free the memory we allocated.
+        delete[] message;
+    }
 }

--- a/test/examples/10-Archiving/ArchiveTest.cpp
+++ b/test/examples/10-Archiving/ArchiveTest.cpp
@@ -26,66 +26,66 @@
 
 int main()
 {
-	using namespace gravity;
+    using namespace gravity;
     using namespace std;
 
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	GravityReturnCode grc = gn.init("ArchiveTest");
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    GravityReturnCode grc = gn.init("ArchiveTest");
 
-	// It's possible that the GravityNode fails to initialize when using Domains because
-	// it hasn't heard from the ServiceDirectory.  Looping as we've done here ensures that
-	// the component has connected to the ServiceDirectory before it continues to other tasks.
-	while (grc != GravityReturnCodes::SUCCESS)
-	{
-	    spdlog::warn("Unable to connect to ServiceDirectory, will try again in 1 second...");
-	    gravity::sleep(1000);
-	    grc = gn.init("ArchiveTest");
-	}
+    // It's possible that the GravityNode fails to initialize when using Domains because
+    // it hasn't heard from the ServiceDirectory.  Looping as we've done here ensures that
+    // the component has connected to the ServiceDirectory before it continues to other tasks.
+    while (grc != GravityReturnCodes::SUCCESS)
+    {
+        spdlog::warn("Unable to connect to ServiceDirectory, will try again in 1 second...");
+        gravity::sleep(1000);
+        grc = gn.init("ArchiveTest");
+    }
 
-	gn.registerDataProduct(
-                            //This identifies the Data Product to the service directory so that others can
-							// subscribe to it.  (See BasicDataProductSubscriber.cpp).
-							"BasicCounterDataProduct",
-							//Assign a transport type to the socket (almost always tcp, unless you are only
-							//using the gravity data product between two processes on the same computer).
-							GravityTransportTypes::TCP);
+    gn.registerDataProduct(
+        //This identifies the Data Product to the service directory so that others can
+        // subscribe to it.  (See BasicDataProductSubscriber.cpp).
+        "BasicCounterDataProduct",
+        //Assign a transport type to the socket (almost always tcp, unless you are only
+        //using the gravity data product between two processes on the same computer).
+        GravityTransportTypes::TCP);
 
-	bool quit = false; //TODO: set this when you want the program to quit if you need to clean up before exiting.
-	int count = 1;
-	bool suspend = true;
-	while(!quit)
-	{
-		//Create a data product to send across the network of type "BasicCounterDataProduct".
-		GravityDataProduct counterDataProduct("BasicCounterDataProduct"); //In order to publish, the DataProductID must match one of the registered types.
+    bool quit = false;  //TODO: set this when you want the program to quit if you need to clean up before exiting.
+    int count = 1;
+    bool suspend = true;
+    while (!quit)
+    {
+        //Create a data product to send across the network of type "BasicCounterDataProduct".
+        GravityDataProduct counterDataProduct(
+            "BasicCounterDataProduct");  //In order to publish, the DataProductID must match one of the registered types.
 
-		//Initialize our message
-		BasicCounterDataProductPB counterDataPB;
-		counterDataPB.set_count(count);
+        //Initialize our message
+        BasicCounterDataProductPB counterDataPB;
+        counterDataPB.set_count(count);
 
-		//Put message into data product
-		counterDataProduct.setData(counterDataPB);
+        //Put message into data product
+        counterDataProduct.setData(counterDataPB);
 
-		//Publish the data product.
-		gn.publish(counterDataProduct);
-		spdlog::info("published count = {}", count);
+        //Publish the data product.
+        gn.publish(counterDataProduct);
+        spdlog::info("published count = {}", count);
 
-		//Increment count
-		count++;
-		if(count > 50)
-			count = 1;
+        //Increment count
+        count++;
+        if (count > 50) count = 1;
 
-		if (count % 5 == 0)
-		{
-		    GravityDataProduct gdp("FileArchiverControlRequest");
-		    FileArchiverControlRequestPB request;
-		    request.set_suspend(suspend);
-		    suspend = !suspend;
-		    gdp.setData(request);
-		    gn.request("FileArchiverControlRequest", gdp);
-		}
+        if (count % 5 == 0)
+        {
+            GravityDataProduct gdp("FileArchiverControlRequest");
+            FileArchiverControlRequestPB request;
+            request.set_suspend(suspend);
+            suspend = !suspend;
+            gdp.setData(request);
+            gn.request("FileArchiverControlRequest", gdp);
+        }
 
-		//Sleep for 1 second.
-		gravity::sleep(1000);
-	}
+        //Sleep for 1 second.
+        gravity::sleep(1000);
+    }
 }

--- a/test/examples/10-Archiving/ReplayTest.cpp
+++ b/test/examples/10-Archiving/ReplayTest.cpp
@@ -31,48 +31,49 @@ using namespace std;
 class SimpleGravityCounterSubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 int main()
 {
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	GravityReturnCode grc = gn.init("ReplayTest");
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    GravityReturnCode grc = gn.init("ReplayTest");
 
     // It's possible that the GravityNode fails to initialize when using Domains because
     // it hasn't heard from the ServiceDirectory.  Looping as we've done here ensures that
     // the component has connected to the ServiceDirectory before it continues to other tasks.
-	while (grc != GravityReturnCodes::SUCCESS)
+    while (grc != GravityReturnCodes::SUCCESS)
     {
         spdlog::warn("Unable to connect to ServiceDirectory, will try again in 1 second...");
         gravity::sleep(1000);
         grc = gn.init("ReplayTest");
     }
 
-	//Declare an object of type SimpleGravityCounterSubscriber (this also initilizes the total count to 0).
-	SimpleGravityCounterSubscriber counterSubscriber;
-	//Subscribe a SimpleGravityCounterSubscriber to the counter data product.
-	gn.subscribe("BasicCounterDataProduct", counterSubscriber);
+    //Declare an object of type SimpleGravityCounterSubscriber (this also initilizes the total count to 0).
+    SimpleGravityCounterSubscriber counterSubscriber;
+    //Subscribe a SimpleGravityCounterSubscriber to the counter data product.
+    gn.subscribe("BasicCounterDataProduct", counterSubscriber);
 
-	//Wait for us to exit (Ctrl-C or being killed).
-	gn.waitForExit();
+    //Wait for us to exit (Ctrl-C or being killed).
+    gn.waitForExit();
 
-	//Currently this will never be hit because we will have been killed (unfortunately).
-	//But this shouldn't make a difference because the OS should close the socket and free all resources.
-	gn.unsubscribe("BasicCounterDataProduct", counterSubscriber);
+    //Currently this will never be hit because we will have been killed (unfortunately).
+    //But this shouldn't make a difference because the OS should close the socket and free all resources.
+    gn.unsubscribe("BasicCounterDataProduct", counterSubscriber);
 }
 
-void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravityCounterSubscriber::subscriptionFilled(
+    const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
-			i != dataProducts.end(); i++)
-	{
-		//Get the protobuf object from the message
-		BasicCounterDataProductPB counterDataPB;
-		(*i)->populateMessage(counterDataPB);
+    for (std::vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+         i != dataProducts.end(); i++)
+    {
+        //Get the protobuf object from the message
+        BasicCounterDataProductPB counterDataPB;
+        (*i)->populateMessage(counterDataPB);
 
-		//Process the message
-		spdlog::warn("Current Count: {}", counterDataPB.count());
-	}
+        //Process the message
+        spdlog::warn("Current Count: {}", counterDataPB.count());
+    }
 }

--- a/test/examples/13-Relay/ProtobufDataProductPublisher.cpp
+++ b/test/examples/13-Relay/ProtobufDataProductPublisher.cpp
@@ -25,44 +25,44 @@
 
 int main()
 {
-	using namespace gravity;
-	using namespace std;
+    using namespace gravity;
+    using namespace std;
 
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	gn.init("Publisher");
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    gn.init("Publisher");
 
-	gn.registerDataProduct(
-							//This identifies the Data Product to the service directory so that others can
-							// subscribe to it.  (See BasicDataProductSubscriber.cpp).
-							"BasicCounterDataProduct",
-							//Assign a transport type to the socket (almost always tcp, unless you are only
-							//using the gravity data product between two processes on the same computer).
-							GravityTransportTypes::TCP);
+    gn.registerDataProduct(
+        //This identifies the Data Product to the service directory so that others can
+        // subscribe to it.  (See BasicDataProductSubscriber.cpp).
+        "BasicCounterDataProduct",
+        //Assign a transport type to the socket (almost always tcp, unless you are only
+        //using the gravity data product between two processes on the same computer).
+        GravityTransportTypes::TCP);
 
-	bool quit = false; //TODO: set this when you want the program to quit if you need to clean up before exiting.
-	int count = 1;
-	while(!quit)
-	{
-		//Create a data product to send across the network of type "BasicCounterDataProduct".
-		GravityDataProduct counterDataProduct("BasicCounterDataProduct"); //In order to publish, the DataProductID must match one of the registered types.
+    bool quit = false;  //TODO: set this when you want the program to quit if you need to clean up before exiting.
+    int count = 1;
+    while (!quit)
+    {
+        //Create a data product to send across the network of type "BasicCounterDataProduct".
+        GravityDataProduct counterDataProduct(
+            "BasicCounterDataProduct");  //In order to publish, the DataProductID must match one of the registered types.
 
-		//Initialize our message
-		BasicCounterDataProductPB counterDataPB;
-		counterDataPB.set_count(count);
+        //Initialize our message
+        BasicCounterDataProductPB counterDataPB;
+        counterDataPB.set_count(count);
 
-		//Put message into data product
-		counterDataProduct.setData(counterDataPB);
+        //Put message into data product
+        counterDataProduct.setData(counterDataPB);
 
-		//Publish the data product.
-		gn.publish(counterDataProduct);
+        //Publish the data product.
+        gn.publish(counterDataProduct);
 
-		//Increment count
-		count++;
-		if(count > 50)
-			count = 1;
+        //Increment count
+        count++;
+        if (count > 50) count = 1;
 
-		//Sleep for 1 second.
-		gravity::sleep(1000);
-	}
+        //Sleep for 1 second.
+        gravity::sleep(1000);
+    }
 }

--- a/test/examples/13-Relay/ProtobufDataProductSubscriber.cpp
+++ b/test/examples/13-Relay/ProtobufDataProductSubscriber.cpp
@@ -31,38 +31,40 @@ using namespace std;
 class SimpleGravityCounterSubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 int main()
 {
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	gn.init("Subscriber");
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    gn.init("Subscriber");
 
-	//Declare an object of type SimpleGravityCounterSubscriber (this also initilizes the total count to 0).
-	SimpleGravityCounterSubscriber counterSubscriber;
-	//Subscribe a SimpleGravityCounterSubscriber to the counter data product.
-	gn.subscribe("BasicCounterDataProduct", counterSubscriber);
+    //Declare an object of type SimpleGravityCounterSubscriber (this also initilizes the total count to 0).
+    SimpleGravityCounterSubscriber counterSubscriber;
+    //Subscribe a SimpleGravityCounterSubscriber to the counter data product.
+    gn.subscribe("BasicCounterDataProduct", counterSubscriber);
 
-	//Wait for us to exit (Ctrl-C or being killed).
-	gn.waitForExit();
+    //Wait for us to exit (Ctrl-C or being killed).
+    gn.waitForExit();
 
-	//Currently this will never be hit because we will have been killed (unfortunately).
-	//But this shouldn't make a difference because the OS should close the socket and free all resources.
-	gn.unsubscribe("BasicCounterDataProduct", counterSubscriber);
+    //Currently this will never be hit because we will have been killed (unfortunately).
+    //But this shouldn't make a difference because the OS should close the socket and free all resources.
+    gn.unsubscribe("BasicCounterDataProduct", counterSubscriber);
 }
 
-void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravityCounterSubscriber::subscriptionFilled(
+    const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
-			i != dataProducts.end(); i++)
-	{
-		//Get the protobuf object from the message
-		BasicCounterDataProductPB counterDataPB;
-		(*i)->populateMessage(counterDataPB);
+    for (std::vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+         i != dataProducts.end(); i++)
+    {
+        //Get the protobuf object from the message
+        BasicCounterDataProductPB counterDataPB;
+        (*i)->populateMessage(counterDataPB);
 
-		//Process the message
-		spdlog::warn("Current Count: {}, message was relayed = {}", counterDataPB.count(), (*i)->isRelayedDataproduct() ? "true" : "false");
-	}
+        //Process the message
+        spdlog::warn("Current Count: {}, message was relayed = {}", counterDataPB.count(),
+                     (*i)->isRelayedDataproduct() ? "true" : "false");
+    }
 }

--- a/test/examples/2-ProtobufDataProduct/ProtobufDataProductPublisher.cpp
+++ b/test/examples/2-ProtobufDataProduct/ProtobufDataProductPublisher.cpp
@@ -25,44 +25,44 @@
 
 int main()
 {
-	using namespace gravity;
-	using namespace std;
+    using namespace gravity;
+    using namespace std;
 
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	gn.init("ProtobufGravityComponentID");
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    gn.init("ProtobufGravityComponentID");
 
-	gn.registerDataProduct(
-							//This identifies the Data Product to the service directory so that others can
-							// subscribe to it.  (See BasicDataProductSubscriber.cpp).
-							"BasicCounterDataProduct",
-							//Assign a transport type to the socket (almost always tcp, unless you are only
-							//using the gravity data product between two processes on the same computer).
-							GravityTransportTypes::TCP);
+    gn.registerDataProduct(
+        //This identifies the Data Product to the service directory so that others can
+        // subscribe to it.  (See BasicDataProductSubscriber.cpp).
+        "BasicCounterDataProduct",
+        //Assign a transport type to the socket (almost always tcp, unless you are only
+        //using the gravity data product between two processes on the same computer).
+        GravityTransportTypes::TCP);
 
-	bool quit = false; //TODO: set this when you want the program to quit if you need to clean up before exiting.
-	int count = 1;
-	while(!quit)
-	{
-		//Create a data product to send across the network of type "BasicCounterDataProduct".
-		GravityDataProduct counterDataProduct("BasicCounterDataProduct"); //In order to publish, the DataProductID must match one of the registered types.
+    bool quit = false;  //TODO: set this when you want the program to quit if you need to clean up before exiting.
+    int count = 1;
+    while (!quit)
+    {
+        //Create a data product to send across the network of type "BasicCounterDataProduct".
+        GravityDataProduct counterDataProduct(
+            "BasicCounterDataProduct");  //In order to publish, the DataProductID must match one of the registered types.
 
-		//Initialize our message
-		BasicCounterDataProductPB counterDataPB;
-		counterDataPB.set_count(count);
+        //Initialize our message
+        BasicCounterDataProductPB counterDataPB;
+        counterDataPB.set_count(count);
 
-		//Put message into data product
-		counterDataProduct.setData(counterDataPB);
+        //Put message into data product
+        counterDataProduct.setData(counterDataPB);
 
-		//Publish the data product.
-		gn.publish(counterDataProduct);
+        //Publish the data product.
+        gn.publish(counterDataProduct);
 
-		//Increment count
-		count++;
-		if(count > 50)
-			count = 1;
+        //Increment count
+        count++;
+        if (count > 50) count = 1;
 
-		//Sleep for 1 second.
-		gravity::sleep(1000);
-	}
+        //Sleep for 1 second.
+        gravity::sleep(1000);
+    }
 }

--- a/test/examples/2-ProtobufDataProduct/ProtobufDataProductSubscriber.cpp
+++ b/test/examples/2-ProtobufDataProduct/ProtobufDataProductSubscriber.cpp
@@ -31,38 +31,39 @@ using namespace std;
 class SimpleGravityCounterSubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 int main()
 {
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	gn.init("SimpleGravityComponentID2");
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    gn.init("SimpleGravityComponentID2");
 
-	//Declare an object of type SimpleGravityCounterSubscriber (this also initilizes the total count to 0).
-	SimpleGravityCounterSubscriber counterSubscriber;
-	//Subscribe a SimpleGravityCounterSubscriber to the counter data product.
-	gn.subscribe("BasicCounterDataProduct", counterSubscriber);
+    //Declare an object of type SimpleGravityCounterSubscriber (this also initilizes the total count to 0).
+    SimpleGravityCounterSubscriber counterSubscriber;
+    //Subscribe a SimpleGravityCounterSubscriber to the counter data product.
+    gn.subscribe("BasicCounterDataProduct", counterSubscriber);
 
-	//Wait for us to exit (Ctrl-C or being killed).
-	gn.waitForExit();
+    //Wait for us to exit (Ctrl-C or being killed).
+    gn.waitForExit();
 
-	//Currently this will never be hit because we will have been killed (unfortunately).
-	//But this shouldn't make a difference because the OS should close the socket and free all resources.
-	gn.unsubscribe("BasicCounterDataProduct", counterSubscriber);
+    //Currently this will never be hit because we will have been killed (unfortunately).
+    //But this shouldn't make a difference because the OS should close the socket and free all resources.
+    gn.unsubscribe("BasicCounterDataProduct", counterSubscriber);
 }
 
-void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravityCounterSubscriber::subscriptionFilled(
+    const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
-			i != dataProducts.end(); i++)
-	{
-		//Get the protobuf object from the message
-		BasicCounterDataProductPB counterDataPB;
-		(*i)->populateMessage(counterDataPB);
+    for (std::vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+         i != dataProducts.end(); i++)
+    {
+        //Get the protobuf object from the message
+        BasicCounterDataProductPB counterDataPB;
+        (*i)->populateMessage(counterDataPB);
 
-		//Process the message
-		spdlog::warn("Current Count: {}", counterDataPB.count());
-	}
+        //Process the message
+        spdlog::warn("Current Count: {}", counterDataPB.count());
+    }
 }

--- a/test/examples/3-MultipleDataProduct/MultipleDataProductPublisher.cpp
+++ b/test/examples/3-MultipleDataProduct/MultipleDataProductPublisher.cpp
@@ -27,57 +27,55 @@ using namespace gravity;
 
 int main()
 {
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    gn.init("SimpleGravityComponentID");
 
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	gn.init("SimpleGravityComponentID");
+    gn.registerDataProduct(
+        //This identifies the Data Product to the service directory so that others can
+        // subscribe to it.  (See BasicDataProductSubscriber.cpp).
+        "BasicCounterDataProduct",
+        //Assign a transport type to the socket (almost always tcp, unless you are only
+        //using the gravity data product between two processes on the same computer).
+        GravityTransportTypes::TCP);
 
-	gn.registerDataProduct(
-							//This identifies the Data Product to the service directory so that others can
-							// subscribe to it.  (See BasicDataProductSubscriber.cpp).
-							"BasicCounterDataProduct",
-							//Assign a transport type to the socket (almost always tcp, unless you are only
-							//using the gravity data product between two processes on the same computer).
-							GravityTransportTypes::TCP);
+    //Register a second data product (for kicks).
+    gn.registerDataProduct("HelloWorldDataProduct", GravityTransportTypes::TCP);
 
-	//Register a second data product (for kicks).
-	gn.registerDataProduct("HelloWorldDataProduct", GravityTransportTypes::TCP);
+    bool quit = false;  //TODO: set this when you want the program to quit if you need to clean up before exiting.
+    int count = 1;
+    while (!quit)
+    {
+        //Create a data product to send across the network of type "BasicCounterDataProduct".
+        GravityDataProduct counterDataProduct(
+            "BasicCounterDataProduct");  //In order to publish, the DataProductID must match one of the registered types.
 
-	bool quit = false; //TODO: set this when you want the program to quit if you need to clean up before exiting.
-	int count = 1;
-	while(!quit)
-	{
-		//Create a data product to send across the network of type "BasicCounterDataProduct".
-		GravityDataProduct counterDataProduct("BasicCounterDataProduct"); //In order to publish, the DataProductID must match one of the registered types.
+        //Initialize our message
+        BasicCounterDataProductPB counterDataPB;
+        counterDataPB.set_count(count);
 
-		//Initialize our message
-		BasicCounterDataProductPB counterDataPB;
-		counterDataPB.set_count(count);
+        //Put message into data product
+        counterDataProduct.setData(counterDataPB);
 
-		//Put message into data product
-		counterDataProduct.setData(counterDataPB);
+        //Publish the data product.
+        gn.publish(counterDataProduct);
 
-		//Publish the data product.
-		gn.publish(counterDataProduct);
+        //Increment count
+        count++;
+        if (count > 50) count = 1;
 
-		//Increment count
-		count++;
-		if(count > 50)
-			count = 1;
+        //Create a second Data Product without using protobufs.
+        GravityDataProduct helloWorldDataProduct("HelloWorldDataProduct");
+        std::string data = "Hello World";
+        helloWorldDataProduct.setData(data.c_str(), data.length());
 
-		//Create a second Data Product without using protobufs.
-		GravityDataProduct helloWorldDataProduct("HelloWorldDataProduct");
-		std::string data = "Hello World";
-		helloWorldDataProduct.setData(data.c_str(), data.length());
+        //Publish the second data product.
+        gn.publish(helloWorldDataProduct);
 
-		//Publish the second data product.
-		gn.publish(helloWorldDataProduct);
+        //A little logging is always nice.  Use gravity.ini to control which logs get written.
+        spdlog::warn("Published message1 with count {} and message2 with data {}", count, data);
 
-		//A little logging is always nice.  Use gravity.ini to control which logs get written.
-		spdlog::warn("Published message1 with count {} and message2 with data {}", count, data);
-
-		//Sleep for 1 second.
-		gravity::sleep(1000);
-	}
-
+        //Sleep for 1 second.
+        gravity::sleep(1000);
+    }
 }

--- a/test/examples/3-MultipleDataProduct/MultipleDataProductSubscriber.cpp
+++ b/test/examples/3-MultipleDataProduct/MultipleDataProductSubscriber.cpp
@@ -30,105 +30,104 @@ using namespace std;
 class SimpleGravitySubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 //Declare another class for receiving Published messages.
 class SimpleGravityCounterSubscriber : public GravitySubscriber
 {
 public:
-	SimpleGravityCounterSubscriber();
-	virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    SimpleGravityCounterSubscriber();
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
+
 private:
-	int countTotals; //Declare a variable to keep track of the sum of all counts received.
+    int countTotals;  //Declare a variable to keep track of the sum of all counts received.
 };
 
 //Define the constructor to SimpleGravityCounterSubscriber (called when a SimpleGravityCounterSubscriber object is created).
-SimpleGravityCounterSubscriber::SimpleGravityCounterSubscriber()
-{
-	countTotals = 0;
-}
+SimpleGravityCounterSubscriber::SimpleGravityCounterSubscriber() { countTotals = 0; }
 
 //Declare another class for receiving Published messages.
 class SimpleGravityHelloWorldSubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
 };
-
 
 int main()
 {
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	gn.init("SimpleGravityComponentID2");
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    gn.init("SimpleGravityComponentID2");
 
-	//Declare an object of type SimpleGravityCounterSubscriber (this also initilizes the total count to 0).
-	SimpleGravityCounterSubscriber counterSubscriber;
-	//Subscribe a SimpleGravityCounterSubscriber to the counter data product.
-	gn.subscribe("BasicCounterDataProduct", counterSubscriber);
+    //Declare an object of type SimpleGravityCounterSubscriber (this also initilizes the total count to 0).
+    SimpleGravityCounterSubscriber counterSubscriber;
+    //Subscribe a SimpleGravityCounterSubscriber to the counter data product.
+    gn.subscribe("BasicCounterDataProduct", counterSubscriber);
 
-	//Subscribe a SimpleGravityHelloWorldSubscriber to the counter.
-	SimpleGravityHelloWorldSubscriber hwSubscriber;
-	gn.subscribe("HelloWorldDataProduct", hwSubscriber);
+    //Subscribe a SimpleGravityHelloWorldSubscriber to the counter.
+    SimpleGravityHelloWorldSubscriber hwSubscriber;
+    gn.subscribe("HelloWorldDataProduct", hwSubscriber);
 
-	//Subscribe this guy to both data products.
-	SimpleGravitySubscriber	allSubscriber;
-	gn.subscribe("BasicCounterDataProduct", allSubscriber);
-	gn.subscribe("HelloWorldDataProduct", allSubscriber);
+    //Subscribe this guy to both data products.
+    SimpleGravitySubscriber allSubscriber;
+    gn.subscribe("BasicCounterDataProduct", allSubscriber);
+    gn.subscribe("HelloWorldDataProduct", allSubscriber);
 
-	//Wait for us to exit (Ctrl-C or being killed).
-	gn.waitForExit();
+    //Wait for us to exit (Ctrl-C or being killed).
+    gn.waitForExit();
 }
 
-void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravityCounterSubscriber::subscriptionFilled(
+    const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
-			i != dataProducts.end(); i++)
-	{
-		//Get the protobuf object from the message
-		BasicCounterDataProductPB counterDataPB;
-		(*i)->populateMessage(counterDataPB);
+    for (std::vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+         i != dataProducts.end(); i++)
+    {
+        //Get the protobuf object from the message
+        BasicCounterDataProductPB counterDataPB;
+        (*i)->populateMessage(counterDataPB);
 
-		//Process the message
-		countTotals = countTotals + counterDataPB.count();
+        //Process the message
+        countTotals = countTotals + counterDataPB.count();
 
-		spdlog::warn("Subscriber 1: Sum of All Counts Received: {}", countTotals);
-	}
+        spdlog::warn("Subscriber 1: Sum of All Counts Received: {}", countTotals);
+    }
 }
 
-void SimpleGravityHelloWorldSubscriber::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravityHelloWorldSubscriber::subscriptionFilled(
+    const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
-			i != dataProducts.end(); i++)
-	{
-		//Get a raw message
-		int size = (*i)->getDataSize();
-		char* message = new char[size + 1];
-		(*i)->getData(message, size);
-		message[size] = 0; //Add NULL terminator
+    for (std::vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+         i != dataProducts.end(); i++)
+    {
+        //Get a raw message
+        int size = (*i)->getDataSize();
+        char* message = new char[size + 1];
+        (*i)->getData(message, size);
+        message[size] = 0;  //Add NULL terminator
 
-		//Output the message
-		spdlog::warn("Subscriber 2: Got message: {}", message);
-		//Don't forget to free the memory we allocated.
-		delete[] message;
-	}
+        //Output the message
+        spdlog::warn("Subscriber 2: Got message: {}", message);
+        //Don't forget to free the memory we allocated.
+        delete[] message;
+    }
 }
 
-void SimpleGravitySubscriber::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravitySubscriber::subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
-			i != dataProducts.end(); i++)
-	{
-		//Process Message
-		spdlog::warn("Subscriber 3: Got a {} data product", (*i)->getDataProductID());
+    for (std::vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+         i != dataProducts.end(); i++)
+    {
+        //Process Message
+        spdlog::warn("Subscriber 3: Got a {} data product", (*i)->getDataProductID());
 
-		//Take different actions based on the message type.
-		if((*i)->getDataProductID() == "BasicCounterDataProduct")
-		{
-			BasicCounterDataProductPB counterDataPB;
-			(*i)->populateMessage(counterDataPB);
-			spdlog::warn("Subscriber 3: Current Count: {}", counterDataPB.count());
-		}
-	}
+        //Take different actions based on the message type.
+        if ((*i)->getDataProductID() == "BasicCounterDataProduct")
+        {
+            BasicCounterDataProductPB counterDataPB;
+            (*i)->populateMessage(counterDataPB);
+            spdlog::warn("Subscriber 3: Current Count: {}", counterDataPB.count());
+        }
+    }
 }

--- a/test/examples/4-BasicService/BasicServiceProvider.cpp
+++ b/test/examples/4-BasicService/BasicServiceProvider.cpp
@@ -29,58 +29,60 @@ using namespace std;
 class MultiplicationServiceProvider : public GravityServiceProvider
 {
 public:
-	virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID, const GravityDataProduct& dataProduct);
+    virtual std::shared_ptr<GravityDataProduct> request(const std::string serviceID,
+                                                        const GravityDataProduct& dataProduct);
 };
 
-
-std::shared_ptr<GravityDataProduct> MultiplicationServiceProvider::request(const std::string serviceID, const GravityDataProduct& dataProduct)
+std::shared_ptr<GravityDataProduct> MultiplicationServiceProvider::request(const std::string serviceID,
+                                                                           const GravityDataProduct& dataProduct)
 {
-	//Just to be safe.  In theory this can never happen unless this class is registered with more than one serviceID types.
-	if(dataProduct.getDataProductID() != "Multiplication") {
-		spdlog::error("Request is not for multiplication!");
-		return std::shared_ptr<GravityDataProduct>(new GravityDataProduct("BadRequest"));
-	}
+    //Just to be safe.  In theory this can never happen unless this class is registered with more than one serviceID types.
+    if (dataProduct.getDataProductID() != "Multiplication")
+    {
+        spdlog::error("Request is not for multiplication!");
+        return std::shared_ptr<GravityDataProduct>(new GravityDataProduct("BadRequest"));
+    }
 
-	//Get the parameters for this request.
-	MultiplicationOperandsPB params;
-	dataProduct.populateMessage(params);
+    //Get the parameters for this request.
+    MultiplicationOperandsPB params;
+    dataProduct.populateMessage(params);
 
-	spdlog::warn("Request received: {} x {}", params.multiplicand_a(), params.multiplicand_b());
+    spdlog::warn("Request received: {} x {}", params.multiplicand_a(), params.multiplicand_b());
 
-	//Do the calculation
-	int result = params.multiplicand_a() * params.multiplicand_b();
+    //Do the calculation
+    int result = params.multiplicand_a() * params.multiplicand_b();
 
-	//Return the results to the requestor
-	MultiplicationResultPB resultPB;
-	resultPB.set_result(result);
+    //Return the results to the requestor
+    MultiplicationResultPB resultPB;
+    resultPB.set_result(result);
 
-	std::shared_ptr<GravityDataProduct> resultDP(new GravityDataProduct("MultiplicationResult"));
-	resultDP->setData(resultPB);
+    std::shared_ptr<GravityDataProduct> resultDP(new GravityDataProduct("MultiplicationResult"));
+    resultDP->setData(resultPB);
 
-	return resultDP;
+    return resultDP;
 }
 
 int main()
 {
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	gn.init("MultiplicationComponent");
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    gn.init("MultiplicationComponent");
 
-	MultiplicationServiceProvider msp;
-	gn.registerService(
-						//This identifies the Service to the service directory so that others can
-						// make a request to it.
-						"Multiplication",
-						//Assign a transport type to the socket (almost always tcp, unless you are only
-						//using the gravity data product between two processes on the same computer).
-						GravityTransportTypes::TCP,
-						//Give an instance of the multiplication service class to be called when a request is made for multiplication.
-						msp);
+    MultiplicationServiceProvider msp;
+    gn.registerService(
+        //This identifies the Service to the service directory so that others can
+        // make a request to it.
+        "Multiplication",
+        //Assign a transport type to the socket (almost always tcp, unless you are only
+        //using the gravity data product between two processes on the same computer).
+        GravityTransportTypes::TCP,
+        //Give an instance of the multiplication service class to be called when a request is made for multiplication.
+        msp);
 
-	//Wait for us to exit (Ctrl-C or being killed).
-	gn.waitForExit();
+    //Wait for us to exit (Ctrl-C or being killed).
+    gn.waitForExit();
 
-	//Currently this will never be hit because we will have been killed (unfortunately).
-	//This tells the service directory that the multiplication service is no longer available.
-	gn.unregisterService("Multiplication");
+    //Currently this will never be hit because we will have been killed (unfortunately).
+    //This tells the service directory that the multiplication service is no longer available.
+    gn.unregisterService("Multiplication");
 }

--- a/test/examples/4-BasicService/BasicServiceRequestor.cpp
+++ b/test/examples/4-BasicService/BasicServiceRequestor.cpp
@@ -32,88 +32,88 @@ bool gotAsyncMessage = false;
 class MultiplicationRequestor : public GravityRequestor
 {
 public:
-	virtual void requestFilled(std::string serviceID, std::string requestID, const GravityDataProduct& response);
+    virtual void requestFilled(std::string serviceID, std::string requestID, const GravityDataProduct& response);
 };
 
-void MultiplicationRequestor::requestFilled(std::string serviceID, std::string requestID, const GravityDataProduct& response)
+void MultiplicationRequestor::requestFilled(std::string serviceID, std::string requestID,
+                                            const GravityDataProduct& response)
 {
-	//Parse the message into a protobuf.
-	MultiplicationResultPB result;
-	response.populateMessage(result);
+    //Parse the message into a protobuf.
+    MultiplicationResultPB result;
+    response.populateMessage(result);
 
-	//Write the answer
-	spdlog::warn("Asynchronous response received: {} = {}", requestID, result.result());
+    //Write the answer
+    spdlog::warn("Asynchronous response received: {} = {}", requestID, result.result());
 
-	gotAsyncMessage = true;
+    gotAsyncMessage = true;
 }
 
 int main()
 {
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	GravityReturnCode ret = gn.init("MultiplicationRequestor");
-	while (ret != GravityReturnCodes::SUCCESS)
-	{
-	    spdlog::warn("Unable to init component, retrying...");
-	    ret = gn.init("MultiplicationRequestor");
-	}
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    GravityReturnCode ret = gn.init("MultiplicationRequestor");
+    while (ret != GravityReturnCodes::SUCCESS)
+    {
+        spdlog::warn("Unable to init component, retrying...");
+        ret = gn.init("MultiplicationRequestor");
+    }
 
-	/////////////////////////////
-	// Set up the first multiplication request
-	MultiplicationRequestor requestor;
+    /////////////////////////////
+    // Set up the first multiplication request
+    MultiplicationRequestor requestor;
 
-	GravityDataProduct multRequest1("Multiplication");
-	MultiplicationOperandsPB params1;
-	params1.set_multiplicand_a(8);
-	params1.set_multiplicand_b(2);
-	multRequest1.setData(params1);
+    GravityDataProduct multRequest1("Multiplication");
+    MultiplicationOperandsPB params1;
+    params1.set_multiplicand_a(8);
+    params1.set_multiplicand_b(2);
+    multRequest1.setData(params1);
 
-	// Make an Asynchronous request for multiplication
-	do
-	{
-        ret = gn.request("Multiplication", //Service Name
-                         multRequest1, //Request
-                         requestor, //Object containing callback that will get the result.
-                         "8 x 2"); //A string that identifies which request this is.
+    // Make an Asynchronous request for multiplication
+    do
+    {
+        ret = gn.request("Multiplication",  //Service Name
+                         multRequest1,      //Request
+                         requestor,         //Object containing callback that will get the result.
+                         "8 x 2");          //A string that identifies which request this is.
         // Service may not be registered yet
         if (ret != GravityReturnCodes::SUCCESS)
         {
             spdlog::warn("request to Multiplication service failed, retrying...");
             gravity::sleep(1000);
         }
-	}
-    while (ret != GravityReturnCodes::SUCCESS);
+    } while (ret != GravityReturnCodes::SUCCESS);
 
-	/////////////////////////////////////////
-	//Set up the second multiplication request
-	GravityDataProduct multRequest2("Multiplication");
-	MultiplicationOperandsPB params2;
-	params2.set_multiplicand_a(5);
-	params2.set_multiplicand_b(7);
-	multRequest2.setData(params2);
+    /////////////////////////////////////////
+    //Set up the second multiplication request
+    GravityDataProduct multRequest2("Multiplication");
+    MultiplicationOperandsPB params2;
+    params2.set_multiplicand_a(5);
+    params2.set_multiplicand_b(7);
+    multRequest2.setData(params2);
 
-	//Make a Synchronous request for multiplication
-	std::shared_ptr<GravityDataProduct> multSync = gn.request("Multiplication", //Service Name
-														multRequest2, //Request
-														1000); //Timeout in milliseconds
-	if(multSync == NULL)
-	{
-		spdlog::error("Request Returned NULL!");
-	}
-	else
-	{
-		MultiplicationResultPB result;
-		multSync->populateMessage(result);
+    //Make a Synchronous request for multiplication
+    std::shared_ptr<GravityDataProduct> multSync = gn.request("Multiplication",  //Service Name
+                                                              multRequest2,      //Request
+                                                              1000);             //Timeout in milliseconds
+    if (multSync == NULL)
+    {
+        spdlog::error("Request Returned NULL!");
+    }
+    else
+    {
+        MultiplicationResultPB result;
+        multSync->populateMessage(result);
 
-		spdlog::warn("Synchronous response received: 5 x 7 = {}", result.result());
-	}
+        spdlog::warn("Synchronous response received: 5 x 7 = {}", result.result());
+    }
 
-	/////////////////////////////////////////
-	//Wait for the Asynchronous message to come in.
-	while(!gotAsyncMessage)
-	{
-		gravity::sleep(1000);
-	}
+    /////////////////////////////////////////
+    //Wait for the Asynchronous message to come in.
+    while (!gotAsyncMessage)
+    {
+        gravity::sleep(1000);
+    }
 
-	return 0;
+    return 0;
 }

--- a/test/examples/5-MiscFunctionality/MiscComponent1.cpp
+++ b/test/examples/5-MiscFunctionality/MiscComponent1.cpp
@@ -25,36 +25,35 @@ using namespace gravity;
 
 int main()
 {
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    gn.init("MiscGravityComponentID1");
 
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	gn.init("MiscGravityComponentID1");
+    //Get a parameter from either the Gravity.ini config file, the MiscGravityComponentID.ini config file, or the config service.
+    int interval = gn.getIntParam("HeartbeatInterval", 500000);
 
-	//Get a parameter from either the Gravity.ini config file, the MiscGravityComponentID.ini config file, or the config service.
-	int interval = gn.getIntParam("HeartbeatInterval", 500000);
+    //Start a heartbeat that other components can listen to, telling them we're alive.
+    gn.startHeartbeat(interval);
 
-	//Start a heartbeat that other components can listen to, telling them we're alive.
-	gn.startHeartbeat(interval);
-
-	// IPC isn't supported in Windows.
+    // IPC isn't supported in Windows.
 #ifndef WIN32
-	//Register a data product that is very fast only for components on this same machine.
-	gn.registerDataProduct("IPCDataProduct", GravityTransportTypes::IPC);
+    //Register a data product that is very fast only for components on this same machine.
+    gn.registerDataProduct("IPCDataProduct", GravityTransportTypes::IPC);
 #endif
 
-	//Let this exit after a few seconds so the heartbeat listener in MiscComponent2 will be notified when it goes away.
-	int count = 5;
-	while(count-- > 0)
-	{
+    //Let this exit after a few seconds so the heartbeat listener in MiscComponent2 will be notified when it goes away.
+    int count = 5;
+    while (count-- > 0)
+    {
 #ifndef WIN32
-		//Publish the inter process communication data product.
-		GravityDataProduct ipcDataProduct("IPCDataProduct");
+        //Publish the inter process communication data product.
+        GravityDataProduct ipcDataProduct("IPCDataProduct");
 
-		std::string data = "hey!";
-		ipcDataProduct.setData(data.c_str(), data.length());
+        std::string data = "hey!";
+        ipcDataProduct.setData(data.c_str(), data.length());
 
-		gn.publish(ipcDataProduct);
+        gn.publish(ipcDataProduct);
 #endif
-		gravity::sleep(1000);
-	}
+        gravity::sleep(1000);
+    }
 }

--- a/test/examples/5-MiscFunctionality/MiscComponent2.cpp
+++ b/test/examples/5-MiscFunctionality/MiscComponent2.cpp
@@ -27,72 +27,73 @@ using namespace std;
 class MiscHBListener : public GravityHeartbeatListener
 {
 public:
-	virtual void MissedHeartbeat(std::string dataProductID, int64_t microsecond_to_last_heartbeat, int64_t& interval_in_microseconds);
-	virtual void ReceivedHeartbeat(std::string dataProductID, int64_t& interval_in_microseconds);
+    virtual void MissedHeartbeat(std::string dataProductID, int64_t microsecond_to_last_heartbeat,
+                                 int64_t& interval_in_microseconds);
+    virtual void ReceivedHeartbeat(std::string dataProductID, int64_t& interval_in_microseconds);
 };
 
-void MiscHBListener::MissedHeartbeat(std::string dataProductID, int64_t microsecond_to_last_heartbeat, int64_t& interval_in_microseconds)
+void MiscHBListener::MissedHeartbeat(std::string dataProductID, int64_t microsecond_to_last_heartbeat,
+                                     int64_t& interval_in_microseconds)
 {
-	spdlog::warn("Missed Heartbeat.  Last heartbeat {} microseconds ago.  ", microsecond_to_last_heartbeat);
+    spdlog::warn("Missed Heartbeat.  Last heartbeat {} microseconds ago.  ", microsecond_to_last_heartbeat);
 }
 
 void MiscHBListener::ReceivedHeartbeat(std::string dataProductID, int64_t& interval_in_microseconds)
 {
-	spdlog::warn("Received Heartbeat.");
-	// Now that we've received one, change the interval to 10 seconds.
-	interval_in_microseconds = 10 * 1000000;
+    spdlog::warn("Received Heartbeat.");
+    // Now that we've received one, change the interval to 10 seconds.
+    interval_in_microseconds = 10 * 1000000;
 }
 
 //Declare a class for receiving Published messages.
 class MiscGravitySubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
-void MiscGravitySubscriber::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void MiscGravitySubscriber::subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
-			i != dataProducts.end(); i++)
-	{
-		//Get a raw message
-		int size = (*i)->getDataSize();
-		char* message = new char[size+1];
-		(*i)->getData(message, size);
-		message[size] = 0; // null terminate
+    for (std::vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+         i != dataProducts.end(); i++)
+    {
+        //Get a raw message
+        int size = (*i)->getDataSize();
+        char* message = new char[size + 1];
+        (*i)->getData(message, size);
+        message[size] = 0;  // null terminate
 
-		//Output the message
-		spdlog::warn("Got message: {}", message);
-		//Don't forget to free the memory we allocated.
-		delete[] message;
-	}
+        //Output the message
+        spdlog::warn("Got message: {}", message);
+        //Don't forget to free the memory we allocated.
+        delete[] message;
+    }
 }
 
 int main()
 {
-	using namespace gravity;
+    using namespace gravity;
 
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	gn.init("MiscGravityComponentID2");
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    gn.init("MiscGravityComponentID2");
 
-	//Get a parameter from either the Gravity.ini config file, the MiscGravityComponentID.ini config file, or the config service.
-	int interval = gn.getIntParam("HeartbeatInterval", //Param Name
-									500000); //Default value.
+    //Get a parameter from either the Gravity.ini config file, the MiscGravityComponentID.ini config file, or the config service.
+    int interval = gn.getIntParam("HeartbeatInterval",  //Param Name
+                                  500000);              //Default value.
 
-	//Get another parameter from gravity.
-	bool listen_for_heartbeat = gn.getBoolParam("HeartbeatListener", true);
-	MiscHBListener hbl;
+    //Get another parameter from gravity.
+    bool listen_for_heartbeat = gn.getBoolParam("HeartbeatListener", true);
+    MiscHBListener hbl;
 
-	if(listen_for_heartbeat)
-		gn.registerHeartbeatListener("MiscGravityComponentID1", interval, hbl);
+    if (listen_for_heartbeat) gn.registerHeartbeatListener("MiscGravityComponentID1", interval, hbl);
 
-	// IPC isn't supported in Windows.
+        // IPC isn't supported in Windows.
 #ifndef WIN32
-	//Subscribe to the IPC data product.
-	MiscGravitySubscriber ipcSubscriber;
-	gn.subscribe("IPCDataProduct", ipcSubscriber);
+    //Subscribe to the IPC data product.
+    MiscGravitySubscriber ipcSubscriber;
+    gn.subscribe("IPCDataProduct", ipcSubscriber);
 #endif
 
-	gn.waitForExit();
+    gn.waitForExit();
 }

--- a/test/examples/8-ConfigFile/ConfigFileExample.cpp
+++ b/test/examples/8-ConfigFile/ConfigFileExample.cpp
@@ -24,31 +24,31 @@
 
 int main()
 {
-	using namespace gravity;
+    using namespace gravity;
 
-	GravityNode gn;
+    GravityNode gn;
 
-	//Initialize gravity, giving this node a componentID.
-	GravityReturnCode ret = gn.init("ConfigFileExample");
-	while (ret != GravityReturnCodes::SUCCESS)
-	{
-		spdlog::warn("Could not initialize GravityNode, return code was {} retrying...", ret);
-	    ret = gn.init("ConfigFileExample");
-	}
+    //Initialize gravity, giving this node a componentID.
+    GravityReturnCode ret = gn.init("ConfigFileExample");
+    while (ret != GravityReturnCodes::SUCCESS)
+    {
+        spdlog::warn("Could not initialize GravityNode, return code was {} retrying...", ret);
+        ret = gn.init("ConfigFileExample");
+    }
 
-	// Note that all config keys are case insensitive
-    spdlog::info("ServiceDirectoryURL = {}\n", gn.getStringParam( "ServiceDirectoryURL", "Not found" ));
-    spdlog::info("LocalLogLevel = {}\n", gn.getStringParam( "LocalLogLevel", "Not Found" ));
-    spdlog::info("bin_ms = {}\n", gn.getFloatParam( "bin_ms", 0. ) );
-    spdlog::info("bin_us = {}\n", gn.getFloatParam( "bin_us", 0. ) );
-    spdlog::info("win_ms = {}\n", gn.getIntParam( "win_ms", 0 ) );
-    spdlog::info("na_samples = {}\n", gn.getIntParam( "na_samples", 0 ) );
-    spdlog::info("nsamps = {}\n", gn.getIntParam( "nsamps", 0 ) );
-    spdlog::info("nsamps_minus = {}\n", gn.getIntParam( "nsamps_minus", 0 ) );
-    spdlog::info("operatorstr = {}\n", gn.getStringParam( "operatorstr", "Not found" ));
-    spdlog::info("default_value = {}\n", gn.getStringParam( "default_value", "Not found" ));
+    // Note that all config keys are case insensitive
+    spdlog::info("ServiceDirectoryURL = {}\n", gn.getStringParam("ServiceDirectoryURL", "Not found"));
+    spdlog::info("LocalLogLevel = {}\n", gn.getStringParam("LocalLogLevel", "Not Found"));
+    spdlog::info("bin_ms = {}\n", gn.getFloatParam("bin_ms", 0.));
+    spdlog::info("bin_us = {}\n", gn.getFloatParam("bin_us", 0.));
+    spdlog::info("win_ms = {}\n", gn.getIntParam("win_ms", 0));
+    spdlog::info("na_samples = {}\n", gn.getIntParam("na_samples", 0));
+    spdlog::info("nsamps = {}\n", gn.getIntParam("nsamps", 0));
+    spdlog::info("nsamps_minus = {}\n", gn.getIntParam("nsamps_minus", 0));
+    spdlog::info("operatorstr = {}\n", gn.getStringParam("operatorstr", "Not found"));
+    spdlog::info("default_value = {}\n", gn.getStringParam("default_value", "Not found"));
 
-    spdlog::info("config_server_value = {}\n", gn.getIntParam( "CONFIG_server_value", 0 ));
-    spdlog::info("config_server_overridden_value = {}\n", gn.getIntParam( "CONFIG_server_overridden_value", 0 ));
+    spdlog::info("config_server_value = {}\n", gn.getIntParam("CONFIG_server_value", 0));
+    spdlog::info("config_server_overridden_value = {}\n", gn.getIntParam("CONFIG_server_overridden_value", 0));
     return 0;
 }

--- a/test/examples/9-Domains/ProtobufDataProductPublisher.cpp
+++ b/test/examples/9-Domains/ProtobufDataProductPublisher.cpp
@@ -25,53 +25,53 @@
 
 int main()
 {
-	using namespace gravity;
+    using namespace gravity;
 
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	GravityReturnCode grc = gn.init("ProtobufGravityComponentID");
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    GravityReturnCode grc = gn.init("ProtobufGravityComponentID");
 
-	// It's possible that the GravityNode fails to initialize when using Domains because
-	// it hasn't heard from the ServiceDirectory.  Looping as we've done here ensures that
-	// the component has connected to the ServiceDirectory before it continues to other tasks.
-	while (grc != GravityReturnCodes::SUCCESS)
-	{
-	    spdlog::warn("Unable to connect to ServiceDirectory, will try again in 1 second...");
-	    gravity::sleep(1000);
-	    grc = gn.init("ProtobufGravityComponentID");
-	}
+    // It's possible that the GravityNode fails to initialize when using Domains because
+    // it hasn't heard from the ServiceDirectory.  Looping as we've done here ensures that
+    // the component has connected to the ServiceDirectory before it continues to other tasks.
+    while (grc != GravityReturnCodes::SUCCESS)
+    {
+        spdlog::warn("Unable to connect to ServiceDirectory, will try again in 1 second...");
+        gravity::sleep(1000);
+        grc = gn.init("ProtobufGravityComponentID");
+    }
 
-	gn.registerDataProduct(
-                            //This identifies the Data Product to the service directory so that others can
-							// subscribe to it.  (See BasicDataProductSubscriber.cpp).
-							"BasicCounterDataProduct",
-							//Assign a transport type to the socket (almost always tcp, unless you are only
-							//using the gravity data product between two processes on the same computer).
-							GravityTransportTypes::TCP);
+    gn.registerDataProduct(
+        //This identifies the Data Product to the service directory so that others can
+        // subscribe to it.  (See BasicDataProductSubscriber.cpp).
+        "BasicCounterDataProduct",
+        //Assign a transport type to the socket (almost always tcp, unless you are only
+        //using the gravity data product between two processes on the same computer).
+        GravityTransportTypes::TCP);
 
-	bool quit = false; //TODO: set this when you want the program to quit if you need to clean up before exiting.
-	int count = 1;
-	while(!quit)
-	{
-		//Create a data product to send across the network of type "BasicCounterDataProduct".
-		GravityDataProduct counterDataProduct("BasicCounterDataProduct"); //In order to publish, the DataProductID must match one of the registered types.
+    bool quit = false;  //TODO: set this when you want the program to quit if you need to clean up before exiting.
+    int count = 1;
+    while (!quit)
+    {
+        //Create a data product to send across the network of type "BasicCounterDataProduct".
+        GravityDataProduct counterDataProduct(
+            "BasicCounterDataProduct");  //In order to publish, the DataProductID must match one of the registered types.
 
-		//Initialize our message
-		BasicCounterDataProductPB counterDataPB;
-		counterDataPB.set_count(count);
+        //Initialize our message
+        BasicCounterDataProductPB counterDataPB;
+        counterDataPB.set_count(count);
 
-		//Put message into data product
-		counterDataProduct.setData(counterDataPB);
+        //Put message into data product
+        counterDataProduct.setData(counterDataPB);
 
-		//Publish the data product.
-		gn.publish(counterDataProduct);
+        //Publish the data product.
+        gn.publish(counterDataProduct);
 
-		//Increment count
-		count++;
-		if(count > 50)
-			count = 1;
+        //Increment count
+        count++;
+        if (count > 50) count = 1;
 
-		//Sleep for 1 second.
-		gravity::sleep(1000);
-	}
+        //Sleep for 1 second.
+        gravity::sleep(1000);
+    }
 }

--- a/test/examples/9-Domains/ProtobufDataProductSubscriber.cpp
+++ b/test/examples/9-Domains/ProtobufDataProductSubscriber.cpp
@@ -31,48 +31,49 @@ using namespace std;
 class SimpleGravityCounterSubscriber : public GravitySubscriber
 {
 public:
-	virtual void subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts);
+    virtual void subscriptionFilled(const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts);
 };
 
 int main()
 {
-	GravityNode gn;
-	//Initialize gravity, giving this node a componentID.
-	GravityReturnCode grc = gn.init("SimpleGravityComponentID2");
+    GravityNode gn;
+    //Initialize gravity, giving this node a componentID.
+    GravityReturnCode grc = gn.init("SimpleGravityComponentID2");
 
     // It's possible that the GravityNode fails to initialize when using Domains because
     // it hasn't heard from the ServiceDirectory.  Looping as we've done here ensures that
     // the component has connected to the ServiceDirectory before it continues to other tasks.
-	while (grc != GravityReturnCodes::SUCCESS)
+    while (grc != GravityReturnCodes::SUCCESS)
     {
         spdlog::warn("Unable to connect to ServiceDirectory, will try again in 1 second...");
         gravity::sleep(1000);
         grc = gn.init("SimpleGravityComponentID2");
     }
 
-	//Declare an object of type SimpleGravityCounterSubscriber (this also initilizes the total count to 0).
-	SimpleGravityCounterSubscriber counterSubscriber;
-	//Subscribe a SimpleGravityCounterSubscriber to the counter data product.
-	gn.subscribe("BasicCounterDataProduct", counterSubscriber);
+    //Declare an object of type SimpleGravityCounterSubscriber (this also initilizes the total count to 0).
+    SimpleGravityCounterSubscriber counterSubscriber;
+    //Subscribe a SimpleGravityCounterSubscriber to the counter data product.
+    gn.subscribe("BasicCounterDataProduct", counterSubscriber);
 
-	//Wait for us to exit (Ctrl-C or being killed).
-	gn.waitForExit();
+    //Wait for us to exit (Ctrl-C or being killed).
+    gn.waitForExit();
 
-	//Currently this will never be hit because we will have been killed (unfortunately).
-	//But this shouldn't make a difference because the OS should close the socket and free all resources.
-	gn.unsubscribe("BasicCounterDataProduct", counterSubscriber);
+    //Currently this will never be hit because we will have been killed (unfortunately).
+    //But this shouldn't make a difference because the OS should close the socket and free all resources.
+    gn.unsubscribe("BasicCounterDataProduct", counterSubscriber);
 }
 
-void SimpleGravityCounterSubscriber::subscriptionFilled(const std::vector< std::shared_ptr<GravityDataProduct> >& dataProducts)
+void SimpleGravityCounterSubscriber::subscriptionFilled(
+    const std::vector<std::shared_ptr<GravityDataProduct> >& dataProducts)
 {
-	for(std::vector< std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
-			i != dataProducts.end(); i++)
-	{
-		//Get the protobuf object from the message
-		BasicCounterDataProductPB counterDataPB;
-		(*i)->populateMessage(counterDataPB);
+    for (std::vector<std::shared_ptr<GravityDataProduct> >::const_iterator i = dataProducts.begin();
+         i != dataProducts.end(); i++)
+    {
+        //Get the protobuf object from the message
+        BasicCounterDataProductPB counterDataPB;
+        (*i)->populateMessage(counterDataPB);
 
-		//Process the message
-		spdlog::warn("Current Count: {}", counterDataPB.count());
-	}
+        //Process the message
+        spdlog::warn("Current Count: {}", counterDataPB.count());
+    }
 }


### PR DESCRIPTION
Used clang-format version 14.0.0 with the newly-committed .clang-format file to apply consistent formatting all files. The formatting rules were based on the Google rules but tweaked to more closely match the existing style. There are no changes in this PR other than formatting.